### PR TITLE
EPMDEDP-16688: feat: Resolve full PipelineRun data for historical rerun actions

### DIFF
--- a/apps/client/src/modules/platform/tekton/components/PipelineRunActionsMenu/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunActionsMenu/index.tsx
@@ -1,20 +1,82 @@
 import { ActionsMenuList } from "@/core/components/ActionsMenuList";
+import { showToast } from "@/core/components/Snackbar";
 import EditorYAML from "@/core/components/EditorYAML";
 import { useDialogOpener } from "@/core/providers/Dialog/hooks";
+import { useTRPCClient } from "@/core/providers/trpc";
 import { router } from "@/core/router";
 import { ListItemAction } from "@/core/types/global";
 import { createResourceAction } from "@/core/utils/createResourceAction";
 import { capitalizeFirstLetter } from "@/core/utils/format/capitalizeFirstLetter";
 import { usePipelineRunCRUD, usePipelineRunPermissions } from "@/k8s/api/groups/Tekton/PipelineRun";
 import { actionMenuType } from "@/k8s/constants/actionMenuTypes";
-import { createRerunPipelineRun, isHistoryPipelineRun, k8sOperation, PipelineRun } from "@my-project/shared";
+import {
+  createRerunPipelineRun,
+  isHistoryPipelineRun,
+  k8sOperation,
+  normalizeHistoryPipelineRun,
+  parseRecordName,
+  PipelineRun,
+} from "@my-project/shared";
 import { Redo2, Trash } from "lucide-react";
 import React from "react";
+import { buildPipelineRunNameFilter, SINGLE_RECORD_LOOKUP_PAGE_SIZE } from "../../utils/celFilters";
 import { CustomActionsInlineList } from "./components/CustomActionsInlineList";
 import { PipelineRunActionsMenuProps } from "./types";
 
+// History items from the list view lack spec/status details needed for rerun.
+async function resolveFullPipelineRun(
+  trpc: ReturnType<typeof useTRPCClient>,
+  pipelineRun: PipelineRun
+): Promise<PipelineRun> {
+  if (!isHistoryPipelineRun(pipelineRun)) {
+    return pipelineRun;
+  }
+
+  if (pipelineRun.spec?.pipelineSpec || pipelineRun.status?.childReferences) {
+    return pipelineRun;
+  }
+
+  const namespace = pipelineRun.metadata.namespace;
+
+  if (!namespace) {
+    throw new Error("PipelineRun is missing namespace");
+  }
+
+  const name = pipelineRun.metadata.name;
+
+  const searchResult = await trpc.tektonResults.listRecords.query({
+    namespace,
+    filter: buildPipelineRunNameFilter(name),
+    pageSize: SINGLE_RECORD_LOOKUP_PAGE_SIZE,
+    orderBy: "create_time desc",
+  });
+
+  const firstRecord = searchResult.records?.[0];
+  const recordInfo = firstRecord?.name ? parseRecordName(firstRecord.name) : null;
+
+  if (!recordInfo?.resultUid || !recordInfo?.recordUid) {
+    throw new Error("PipelineRun record not found in Tekton Results");
+  }
+
+  const fullData = await trpc.tektonResults.getPipelineRun.query({
+    namespace,
+    resultUid: recordInfo.resultUid,
+    recordUid: recordInfo.recordUid,
+  });
+
+  return normalizeHistoryPipelineRun(fullData.pipelineRun);
+}
+
+function handleResolveError(err: unknown) {
+  console.error("resolveFullPipelineRun failed:", err);
+  showToast("Failed to fetch PipelineRun data for rerun", "error", {
+    description: err instanceof Error ? err.message : String(err),
+  });
+}
+
 export const PipelineRunActionsMenu = ({ backRoute, variant, data: { pipelineRun } }: PipelineRunActionsMenuProps) => {
   const pipelineRunPermissions = usePipelineRunPermissions();
+  const trpc = useTRPCClient();
 
   const { triggerCreatePipelineRun, triggerDeletePipelineRun } = usePipelineRunCRUD();
 
@@ -46,13 +108,17 @@ export const PipelineRunActionsMenu = ({ backRoute, variant, data: { pipelineRun
           reason: pipelineRunPermissions.data.create.reason,
         },
         callback: (pipelineRun) => {
-          const newPipelineRun = createRerunPipelineRun(pipelineRun);
+          resolveFullPipelineRun(trpc, pipelineRun)
+            .then((fullPipelineRun) => {
+              const newPipelineRun = createRerunPipelineRun(fullPipelineRun);
 
-          triggerCreatePipelineRun({
-            data: {
-              pipelineRun: newPipelineRun,
-            },
-          });
+              triggerCreatePipelineRun({
+                data: {
+                  pipelineRun: newPipelineRun,
+                },
+              });
+            })
+            .catch(handleResolveError);
         },
       }),
       createResourceAction({
@@ -65,21 +131,25 @@ export const PipelineRunActionsMenu = ({ backRoute, variant, data: { pipelineRun
           reason: pipelineRunPermissions.data.create.reason,
         },
         callback: (pipelineRun: PipelineRun) => {
-          const newPipelineRun = createRerunPipelineRun(pipelineRun);
-          openEditorDialog({
-            content: newPipelineRun,
-            onSave: (_yaml, json) => {
-              if (!json) {
-                return;
-              }
+          resolveFullPipelineRun(trpc, pipelineRun)
+            .then((fullPipelineRun) => {
+              const newPipelineRun = createRerunPipelineRun(fullPipelineRun);
+              openEditorDialog({
+                content: newPipelineRun,
+                onSave: (_yaml, json) => {
+                  if (!json) {
+                    return;
+                  }
 
-              triggerCreatePipelineRun({
-                data: {
-                  pipelineRun: json as PipelineRun,
+                  triggerCreatePipelineRun({
+                    data: {
+                      pipelineRun: json as PipelineRun,
+                    },
+                  });
                 },
               });
-            },
-          });
+            })
+            .catch(handleResolveError);
         },
       }),
       isHistoryItem
@@ -100,6 +170,7 @@ export const PipelineRunActionsMenu = ({ backRoute, variant, data: { pipelineRun
     ].filter((action): action is ListItemAction => action !== undefined);
   }, [
     pipelineRun,
+    trpc,
     pipelineRunPermissions.data.create.allowed,
     pipelineRunPermissions.data.create.reason,
     pipelineRunPermissions.data.delete.allowed,

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Actions/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Actions/index.tsx
@@ -1,18 +1,12 @@
 import { Button } from "@/core/components/ui/button";
 import { DropdownMenu, DropdownMenuTrigger } from "@/core/components/ui/dropdown-menu";
 import React from "react";
-import { isHistoryPipelineRun, PipelineRun } from "@my-project/shared";
+import { PipelineRun } from "@my-project/shared";
 import { PipelineRunActionsMenu } from "../../../PipelineRunActionsMenu";
 import { EllipsisVertical } from "lucide-react";
 
 export const Actions = ({ pipelineRun }: { pipelineRun: PipelineRun }) => {
   const [open, setOpen] = React.useState(false);
-
-  const isHistoryItem = isHistoryPipelineRun(pipelineRun);
-
-  if (isHistoryItem) {
-    return null;
-  }
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/data.ts
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/data.ts
@@ -22,7 +22,7 @@ import {
 } from "@my-project/shared";
 import React from "react";
 import { RequestError } from "@/core/types/global";
-import { buildPipelineRunNameFilter } from "../../../utils/celFilters";
+import { buildPipelineRunNameFilter, SINGLE_RECORD_LOOKUP_PAGE_SIZE } from "../../../utils/celFilters";
 import { isK8sNotFoundError } from "../../../utils/isK8sNotFoundError";
 import { buildPipelineRunTasksByNameMap } from "./utils";
 import { routePipelineRunDetails } from "../route";
@@ -80,7 +80,7 @@ export function useUnifiedPipelineRunData({ namespace, name }: UnifiedPipelineRu
       trpc.tektonResults.listRecords.query({
         namespace,
         filter: buildPipelineRunNameFilter(name),
-        pageSize: 5,
+        pageSize: SINGLE_RECORD_LOOKUP_PAGE_SIZE,
         orderBy: "create_time desc",
       }),
     enabled: k8sNotFound,

--- a/apps/client/src/modules/platform/tekton/utils/celFilters.ts
+++ b/apps/client/src/modules/platform/tekton/utils/celFilters.ts
@@ -13,6 +13,9 @@ export function escapeCELString(value: string): string {
 
 const PIPELINE_RUN_DATA_TYPE = "data_type == 'tekton.dev/v1.PipelineRun'";
 
+/** Small page size for single-record lookups by name (buffer for potential collisions). */
+export const SINGLE_RECORD_LOOKUP_PAGE_SIZE = 6;
+
 export const buildPipelineRunNameFilter = (pipelineRunName: string): string => {
   return `data.metadata.name == '${escapeCELString(pipelineRunName)}' && ${PIPELINE_RUN_DATA_TYPE}`;
 };


### PR DESCRIPTION
History items from list view carry only lightweight summary data without spec.params or pipelineSpec. When rerunning, fetch full decoded PipelineRun from Tekton Results to ensure all task parameters are included.

Also:
- Extract SINGLE_RECORD_LOOKUP_PAGE_SIZE constant for consistency across single-record lookups (pageSize: 6 used in both actions menu and detail page hook)
- Remove history item filter from list actions—now shows rerun/edit actions for all items

