### PR TITLE
EPMDEDP-16701: fix: Show corret PipelineRuns in stage details

### DIFF
--- a/apps/client/src/k8s/api/groups/Tekton/PipelineRun/hooks/useWatchStagePipelineRuns/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/PipelineRun/hooks/useWatchStagePipelineRuns/index.ts
@@ -1,47 +1,39 @@
 import { PipelineRun, pipelineRunLabels, pipelineType } from "@my-project/shared";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { usePipelineRunWatchList } from "..";
 
-export const useWatchStagePipelineRuns = (stageMetadataName: string, cdPipelineName: string, namespace: string) => {
+// ISO-8601 UTC timestamps are lex-sortable; string compare avoids per-call Date allocations.
+const byCreationDesc = (a: PipelineRun, b: PipelineRun) =>
+  (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? "");
+
+export const useWatchStagePipelineRuns = (stageResourceName: string, cdPipelineName: string, namespace: string) => {
   const pipelineRunWatchList = usePipelineRunWatchList({
     namespace,
     labels: {
-      [pipelineRunLabels.stage]: stageMetadataName,
+      [pipelineRunLabels.cdStage]: stageResourceName,
       [pipelineRunLabels.cdPipeline]: cdPipelineName,
     },
   });
 
-  return useQuery({
-    queryKey: ["stagePipelineRuns", pipelineRunWatchList.resourceVersion],
-    queryFn: () => {
-      return pipelineRunWatchList.data.array.reduce<{
-        all: PipelineRun[];
-        deploy: PipelineRun[];
-        clean: PipelineRun[];
-      }>(
-        (acc, cur) => {
-          const curPipelineType = cur.metadata?.labels?.[pipelineRunLabels.pipelineType];
+  const data = useMemo(() => {
+    const deploy: PipelineRun[] = [];
+    const clean: PipelineRun[] = [];
 
-          if (!pipelineType) {
-            acc.all.push(cur);
-          }
+    for (const run of pipelineRunWatchList.data.array) {
+      const runPipelineType = run.metadata?.labels?.[pipelineRunLabels.pipelineType];
 
-          if (curPipelineType === pipelineType.deploy) {
-            acc.deploy.push(cur);
-          }
+      if (runPipelineType === pipelineType.deploy) {
+        deploy.push(run);
+      } else if (runPipelineType === pipelineType.clean) {
+        clean.push(run);
+      }
+    }
 
-          if (curPipelineType === pipelineType.clean) {
-            acc.clean.push(cur);
-          }
+    deploy.sort(byCreationDesc);
+    clean.sort(byCreationDesc);
 
-          return acc;
-        },
-        {
-          all: [],
-          deploy: [],
-          clean: [],
-        }
-      );
-    },
-  });
+    return { deploy, clean };
+  }, [pipelineRunWatchList.data.array]);
+
+  return { data };
 };

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/StagePipelineRuns/components/Pipelines/index.test.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/StagePipelineRuns/components/Pipelines/index.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { getStageResourceName, pipelineRunLabels } from "@my-project/shared";
+import { Pipelines } from "./index";
+
+const mockUseUnifiedPipelineRunList = vi.fn();
+
+vi.mock("@/modules/platform/tekton/hooks/useUnifiedPipelineRunList", () => ({
+  useUnifiedPipelineRunList: (opts: unknown) => mockUseUnifiedPipelineRunList(opts),
+}));
+
+vi.mock("@/modules/platform/tekton/components/PipelineRunList", () => ({
+  PipelineRunList: () => null,
+}));
+
+vi.mock("@/modules/platform/tekton/components/HistoryLoadingFooter", () => ({
+  HistoryLoadingFooter: () => null,
+}));
+
+vi.mock("@/modules/platform/tekton/pages/pipelinerun-details/route", () => ({
+  PATH_PIPELINERUN_DETAILS_FULL: "/c/$clusterName/pipelineruns/$namespace/$name",
+}));
+
+vi.mock("@/modules/platform/tekton/components/PipelineRunList/components/Filter/hooks/usePipelineRunFilter", () => ({
+  useDebouncedPipelineRunSearch: () => "",
+}));
+
+vi.mock("@/core/providers/Filter/provider", () => ({
+  FilterProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../../../../../../route", () => ({
+  routeStageDetails: {
+    useParams: () => ({
+      clusterName: "core",
+      namespace: "edp-delivery",
+      cdPipeline: "tekton",
+      stage: "dev",
+    }),
+  },
+}));
+
+describe("stage-details Pipelines tab", () => {
+  beforeEach(() => {
+    mockUseUnifiedPipelineRunList.mockReset();
+    mockUseUnifiedPipelineRunList.mockReturnValue({
+      mergedPipelineRuns: [],
+      isLoading: false,
+      isHistoryLoading: false,
+      historyQuery: { isLoading: false },
+    });
+  });
+
+  it("filters by app.edp.epam.com/cdstage (not /stage) so operator-created runs appear", () => {
+    render(<Pipelines />);
+
+    expect(mockUseUnifiedPipelineRunList).toHaveBeenCalledTimes(1);
+    const [opts] = mockUseUnifiedPipelineRunList.mock.calls[0] as [{ labels: Record<string, string> }];
+
+    expect(opts.labels).toEqual({
+      [pipelineRunLabels.cdPipeline]: "tekton",
+      [pipelineRunLabels.cdStage]: getStageResourceName("tekton", "dev"),
+    });
+  });
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/StagePipelineRuns/components/Pipelines/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/StagePipelineRuns/components/Pipelines/index.tsx
@@ -2,7 +2,7 @@ import { PipelineRunList } from "@/modules/platform/tekton/components/PipelineRu
 import { PATH_PIPELINERUN_DETAILS_FULL } from "@/modules/platform/tekton/pages/pipelinerun-details/route";
 import { useUnifiedPipelineRunList } from "@/modules/platform/tekton/hooks/useUnifiedPipelineRunList";
 import { HistoryLoadingFooter } from "@/modules/platform/tekton/components/HistoryLoadingFooter";
-import { pipelineRunLabels, pipelineType } from "@my-project/shared";
+import { getStageResourceName, pipelineRunLabels, pipelineType } from "@my-project/shared";
 import { routeStageDetails } from "../../../../../../route";
 import { FilterProvider } from "@/core/providers/Filter/provider";
 import {
@@ -29,13 +29,13 @@ export function Pipelines() {
 
 function PipelinesContent() {
   const params = routeStageDetails.useParams();
-  const stageLabel = `${params.cdPipeline}-${params.stage}`;
 
   const debouncedSearch = useDebouncedPipelineRunSearch();
 
   const { mergedPipelineRuns, isLoading, isHistoryLoading, historyQuery } = useUnifiedPipelineRunList({
     labels: {
-      [pipelineRunLabels.stage]: stageLabel,
+      [pipelineRunLabels.cdPipeline]: params.cdPipeline,
+      [pipelineRunLabels.cdStage]: getStageResourceName(params.cdPipeline, params.stage),
     },
     searchTerm: debouncedSearch,
   });

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/hooks/index.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/hooks/index.ts
@@ -9,6 +9,7 @@ import {
   CodebaseImageStream,
   codebaseLabels,
   codebaseType,
+  getStageResourceName,
   PipelineRun,
   Stage,
   TriggerTemplate,
@@ -39,7 +40,7 @@ export const useStageWatch = () => {
   const params = routeStageDetails.useParams();
 
   return useStageWatchItem({
-    name: `${params.cdPipeline}-${params.stage}`,
+    name: getStageResourceName(params.cdPipeline, params.stage),
     namespace: params.namespace,
   });
 };
@@ -55,7 +56,11 @@ export const useStageListWatch = () => {
 export const usePipelineRunsWatch = () => {
   const params = routeStageDetails.useParams();
 
-  return useWatchStagePipelineRuns(params.stage, params.cdPipeline, params.namespace);
+  return useWatchStagePipelineRuns(
+    getStageResourceName(params.cdPipeline, params.stage),
+    params.cdPipeline,
+    params.namespace
+  );
 };
 
 export const useApplicationsWatch = () => {
@@ -94,7 +99,7 @@ export const useVariablesConfigMapWatch = () => {
   const params = routeStageDetails.useParams();
 
   return useConfigMapWatchItem({
-    name: `${params.cdPipeline}-${params.stage}`,
+    name: getStageResourceName(params.cdPipeline, params.stage),
     namespace: params.namespace,
   });
 };

--- a/packages/shared/src/models/k8s/groups/KRCI/Stage/utils/getStageResourceName/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Stage/utils/getStageResourceName/index.ts
@@ -1,0 +1,2 @@
+// Shared across the Stage CR name, the PipelineRun `cdstage` label, and the per-stage ConfigMap name.
+export const getStageResourceName = (cdPipeline: string, stage: string) => `${cdPipeline}-${stage}`;

--- a/packages/shared/src/models/k8s/groups/KRCI/Stage/utils/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Stage/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./createStageDraft/index.js";
 export * from "./editStage/index.js";
+export * from "./getStageResourceName/index.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createDeployPipelineRunDraft/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createDeployPipelineRunDraft/index.test.ts
@@ -131,7 +131,7 @@ describe("testing createDeployPipelineRunDraft", () => {
         name: `deploy-test-pipe-very-long-long-long-long-long-long-name-s-${MOCKED_UUID}`,
         labels: {
           "app.edp.epam.com/cdpipeline": "test-pipe-very-long-long-long-long-long-long-name",
-          "app.edp.epam.com/cdstage": "test-namespace",
+          "app.edp.epam.com/cdstage": "test-pipe-very-long-long-long-long-long-long-name-sit",
           "app.edp.epam.com/codebase": "$(tt.params.CODEBASE)",
           "app.edp.epam.com/codebasebranch": "$(tt.params.CDPIPELINE)-$(tt.params.CDSTAGE)",
           "app.edp.epam.com/pipelinetype": "deploy",

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createDeployPipelineRunDraft/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createDeployPipelineRunDraft/index.ts
@@ -40,7 +40,7 @@ export const createDeployPipelineRunDraft = ({
   base.metadata.labels = base.metadata.labels || {};
   base.metadata.labels[pipelineRunLabels.cdPipeline] = cdPipeline.metadata.name;
   base.metadata.labels[pipelineRunLabels.stage] = stage.metadata.name;
-  base.metadata.labels[pipelineRunLabels.cdStage] = stage.metadata.namespace;
+  base.metadata.labels[pipelineRunLabels.cdStage] = stage.metadata.name;
   base.metadata.labels[pipelineRunLabels.pipelineType] = pipelineType.deploy;
 
   for (const param of base.spec.params || []) {


### PR DESCRIPTION
Three related issues were addressed so the stage-details Pipelines tab and Applications action buttons see all relevant PipelineRuns:

1. Wrong filter label in the stage-details views. Pipelines/index.tsx and useWatchStagePipelineRuns filtered by the legacy app.edp.epam.com/stage label, while operator-auto-triggered runs are labeled only with app.edp.epam.com/cdstage. The filter now uses cdstage with the Stage CR name (\${cdPipeline}-\${stage}), so both portal-created and operator-created runs are matched. useWatchStagePipelineRuns was additionally called with params.stage (the short name) against a label value of \${cdPipeline}-\${stage}, so it matched nothing at all and left deploy/clean action buttons in an incorrect enabled/disabled state.

2. Wrong cdstage label value in createDeployPipelineRunDraft. The draft wrote stage.metadata.namespace into the cdstage label instead of stage.metadata.name (the Stage CR name). The sibling createCleanPipelineRunDraft already used metadata.name, which is the operator's convention. The bug was dormant because the filter was also wrong; fixing only one would still hide portal-created deploy runs.

3. Latent bugs and inefficiency in useWatchStagePipelineRuns. The reduce contained an if (!pipelineType) check against the imported constant (always truthy), populating a dead 'all' bucket that no caller consumed. The watch list is iterated in Map insertion order, not by creationTimestamp, so consumers reading data.deploy[0] or data.clean[0] as 'latest run' could get a stale value. And the hook wrapped bucketing in useQuery keyed by resourceVersion, re-running on every watch event. Replaced with a straight useMemo, removed the dead bucket, and added an ISO-8601 lex-compare sort so [0] reliably returns the most recent run.

A new getStageResourceName(cdPipeline, stage) helper centralizes the \${cdPipeline}-\${stage} identifier shared by the Stage CR name, the PipelineRun cdstage label, and the per-stage ConfigMap name, so the format cannot drift again. A regression test on Pipelines/index.tsx guards the filter label and value.

