### PR TITLE
EPMDEDP-16650: chore: Update Node.js runtime and remove redundant bui…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.1.0-alpine
+FROM node:24-alpine
 
 ENV NODE_ENV=production
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "deploy:clean": "rimraf deploy",
     "deploy:prepare": "pnpm deploy --filter=client --prod deploy/client && pnpm deploy --filter=server --prod deploy/server",
     "deploy:post": "shx mkdir -p deploy/server/db && shx touch deploy/server/db/sessions.sqlite",
-    "prepare:artifacts": "pnpm deploy:clean && pnpm build && pnpm deploy:prepare && pnpm deploy:post"
+    "prepare:artifacts": "pnpm deploy:clean && pnpm deploy:prepare && pnpm deploy:post"
   },
   "packageManager": "pnpm@10.11.0",
   "workspaces": [


### PR DESCRIPTION
# Pull Request

## Description

Remove pnpm build from prepare:artifacts script — build is already performed in Tekton test step, eliminating double compilation in pipeline.
Update Dockerfile base image from pinned node:22.1.0-alpine to node:24-alpine

Fixes #EPMDEDP-16650
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing

**Test Configuration**:

- Node.js version:
- pnpm version:
- Browser (for frontend changes):
- Kubernetes version (if applicable):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have squashed my commits
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm format:check` and code is properly formatted
- [ ] I have run `pnpm test:coverage` and maintained adequate test coverage
