### PR TITLE
EPMDEDP-16713: feat: Add SonarQube pull-request support and REST proxy

### DIFF
--- a/apps/server/src/config/openapi.ts
+++ b/apps/server/src/config/openapi.ts
@@ -209,6 +209,157 @@ export function registerOpenApi(
   });
 
   // ---------------------------------------------------------------------------
+  // SonarQube — view proxies for `krci sonar`
+  // ---------------------------------------------------------------------------
+
+  // Parses a positive-integer query string. Returns `undefined` when absent,
+  // or a typed marker when the value is present but not a positive integer so
+  // the caller can emit a 400.
+  const parsePositiveIntQuery = (
+    raw: string | undefined
+  ): number | undefined | "invalid" => {
+    if (raw === undefined) return undefined;
+    if (!/^[1-9]\d*$/.test(raw)) return "invalid";
+    return Number(raw);
+  };
+
+  // GET /rest/v1/sonar/list (protected) — proxies sonarqube.getProjects
+  fastify.get<{
+    Querystring: {
+      page?: string;
+      pageSize?: string;
+      searchTerm?: string;
+    };
+  }>("/rest/v1/sonar/list", async (req, res) => {
+    try {
+      const { page, pageSize, searchTerm } = req.query;
+      const parsedPage = parsePositiveIntQuery(page);
+      const parsedPageSize = parsePositiveIntQuery(pageSize);
+      if (parsedPage === "invalid") {
+        return res.code(400).send({ error: "page must be a positive integer" });
+      }
+      if (parsedPageSize === "invalid") {
+        return res
+          .code(400)
+          .send({ error: "pageSize must be a positive integer" });
+      }
+
+      const caller = await buildCaller(req, res);
+      return await caller.sonarqube.getProjects({
+        page: parsedPage,
+        pageSize: parsedPageSize,
+        searchTerm: searchTerm || undefined,
+      });
+    } catch (error) {
+      return handleTRPCError(error, res);
+    }
+  });
+
+  // GET /rest/v1/sonar/get (protected) — proxies sonarqube.getProject
+  fastify.get<{
+    Querystring: {
+      projectKey: string;
+      pullRequest?: string;
+    };
+  }>("/rest/v1/sonar/get", async (req, res) => {
+    try {
+      const { projectKey, pullRequest } = req.query;
+      if (!projectKey) {
+        return res.code(400).send({ error: "projectKey is required" });
+      }
+
+      const caller = await buildCaller(req, res);
+      return await caller.sonarqube.getProject({
+        componentKey: projectKey,
+        pullRequest,
+      });
+    } catch (error) {
+      return handleTRPCError(error, res);
+    }
+  });
+
+  // GET /rest/v1/sonar/gate (protected) — proxies sonarqube.getQualityGateDetails
+  fastify.get<{
+    Querystring: {
+      projectKey: string;
+      pullRequest?: string;
+    };
+  }>("/rest/v1/sonar/gate", async (req, res) => {
+    try {
+      const { projectKey, pullRequest } = req.query;
+      if (!projectKey) {
+        return res.code(400).send({ error: "projectKey is required" });
+      }
+
+      const caller = await buildCaller(req, res);
+      return await caller.sonarqube.getQualityGateDetails({
+        projectKey,
+        pullRequest,
+      });
+    } catch (error) {
+      return handleTRPCError(error, res);
+    }
+  });
+
+  // GET /rest/v1/sonar/issues (protected) — proxies sonarqube.getProjectIssues
+  fastify.get<{
+    Querystring: {
+      projectKey: string;
+      pullRequest?: string;
+      types?: string;
+      severities?: string;
+      statuses?: string;
+      resolved?: "true" | "false";
+      s?: string;
+      asc?: "true" | "false";
+      p?: string;
+      ps?: string;
+    };
+  }>("/rest/v1/sonar/issues", async (req, res) => {
+    try {
+      const {
+        projectKey,
+        pullRequest,
+        types,
+        severities,
+        statuses,
+        resolved,
+        s,
+        asc,
+        p,
+        ps,
+      } = req.query;
+      if (!projectKey) {
+        return res.code(400).send({ error: "projectKey is required" });
+      }
+      const parsedP = parsePositiveIntQuery(p);
+      const parsedPs = parsePositiveIntQuery(ps);
+      if (parsedP === "invalid") {
+        return res.code(400).send({ error: "p must be a positive integer" });
+      }
+      if (parsedPs === "invalid") {
+        return res.code(400).send({ error: "ps must be a positive integer" });
+      }
+
+      const caller = await buildCaller(req, res);
+      return await caller.sonarqube.getProjectIssues({
+        componentKeys: projectKey,
+        pullRequest,
+        types,
+        severities,
+        statuses,
+        resolved,
+        s,
+        asc,
+        p: parsedP,
+        ps: parsedPs,
+      });
+    } catch (error) {
+      return handleTRPCError(error, res);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
   // OpenAPI spec (development only)
   // ---------------------------------------------------------------------------
 

--- a/packages/shared/src/models/sonarqube/schemas.ts
+++ b/packages/shared/src/models/sonarqube/schemas.ts
@@ -266,4 +266,5 @@ export const issuesQueryParamsSchema = z.object({
   ps: z.number().int().min(1).max(500).optional().default(25),
   s: z.string().optional(), // Sort field
   asc: z.enum(["true", "false"]).optional(),
+  pullRequest: z.string().optional(), // Forward to SonarQube /api/issues/search&pullRequest=<id>
 });

--- a/packages/trpc/src/clients/sonarqube/index.test.ts
+++ b/packages/trpc/src/clients/sonarqube/index.test.ts
@@ -39,3 +39,127 @@ describe("createSonarQubeClient", () => {
     expect(typeof client.getIssues).toBe("function");
   });
 });
+
+describe("SonarQubeClient pullRequest passthrough", () => {
+  const BASE = "https://sonar.example.com";
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ component: { key: "k", name: "k", measures: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  async function newClient() {
+    const { SonarQubeClient } = await import("./index.js");
+    return new SonarQubeClient({ apiBaseURL: BASE, token: "tkn", timeoutMs: 500 });
+  }
+
+  function capturedUrl(): string {
+    const firstCall = fetchMock.mock.calls[0];
+    return String(firstCall[0]);
+  }
+
+  it("getComponent appends pullRequest when supplied", async () => {
+    const client = await newClient();
+    await client.getComponent("my-proj", "123");
+    const url = capturedUrl();
+    expect(url).toContain("component=my-proj");
+    expect(url).toContain("pullRequest=123");
+  });
+
+  it("getComponent omits pullRequest when undefined", async () => {
+    const client = await newClient();
+    await client.getComponent("my-proj");
+    expect(capturedUrl()).not.toContain("pullRequest=");
+  });
+
+  it("getMeasures appends pullRequest when supplied", async () => {
+    const client = await newClient();
+    await client.getMeasures("my-proj", ["bugs"], "123");
+    const url = capturedUrl();
+    expect(url).toContain("component=my-proj");
+    expect(url).toContain("pullRequest=123");
+  });
+
+  it("getMeasures omits pullRequest when undefined", async () => {
+    const client = await newClient();
+    await client.getMeasures("my-proj", ["bugs"]);
+    expect(capturedUrl()).not.toContain("pullRequest=");
+  });
+
+  it("getQualityGateStatus appends pullRequest when supplied", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ projectStatus: { status: "OK", conditions: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const client = await newClient();
+    await client.getQualityGateStatus("my-proj", "123");
+    const url = capturedUrl();
+    expect(url).toContain("projectKey=my-proj");
+    expect(url).toContain("pullRequest=123");
+  });
+
+  it("getQualityGateStatus omits pullRequest when undefined", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ projectStatus: { status: "OK", conditions: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const client = await newClient();
+    await client.getQualityGateStatus("my-proj");
+    expect(capturedUrl()).not.toContain("pullRequest=");
+  });
+
+  it("getIssues appends pullRequest when supplied", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          total: 0,
+          p: 1,
+          ps: 25,
+          paging: { pageIndex: 1, pageSize: 25, total: 0 },
+          issues: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    const client = await newClient();
+    await client.getIssues({ componentKeys: "my-proj", resolved: "false", p: 1, ps: 25, pullRequest: "123" });
+    const url = capturedUrl();
+    expect(url).toContain("componentKeys=my-proj");
+    expect(url).toContain("pullRequest=123");
+  });
+
+  it("getIssues omits pullRequest when undefined", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          total: 0,
+          p: 1,
+          ps: 25,
+          paging: { pageIndex: 1, pageSize: 25, total: 0 },
+          issues: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    const client = await newClient();
+    await client.getIssues({ componentKeys: "my-proj", resolved: "false", p: 1, ps: 25 });
+    expect(capturedUrl()).not.toContain("pullRequest=");
+  });
+});

--- a/packages/trpc/src/clients/sonarqube/index.ts
+++ b/packages/trpc/src/clients/sonarqube/index.ts
@@ -220,11 +220,13 @@ export class SonarQubeClient {
    * Get a single component/project by exact key
    *
    * @param componentKey - The project/component key
+   * @param pullRequest - Optional pull request id; forwarded to Sonar as `pullRequest=<id>`
    * @returns Component data, or null if not found
    */
-  async getComponent(componentKey: string): Promise<ComponentShowResponse | null> {
+  async getComponent(componentKey: string, pullRequest?: string): Promise<ComponentShowResponse | null> {
     const endpoint = this.buildEndpoint("/api/components/show", {
       component: componentKey,
+      pullRequest,
     });
 
     try {
@@ -242,6 +244,7 @@ export class SonarQubeClient {
    *
    * @param componentKey - The project/component key
    * @param metricKeys - Array of metric keys to fetch
+   * @param pullRequest - Optional pull request id; forwarded to Sonar as `pullRequest=<id>`
    * @returns Component with measures
    *
    * @example
@@ -250,11 +253,13 @@ export class SonarQubeClient {
    */
   async getMeasures(
     componentKey: string,
-    metricKeys: readonly string[] = SONARQUBE_METRIC_KEYS
+    metricKeys: readonly string[] = SONARQUBE_METRIC_KEYS,
+    pullRequest?: string
   ): Promise<MeasuresComponentResponse> {
     const endpoint = this.buildEndpoint("/api/measures/component", {
       component: componentKey,
       metricKeys: metricKeys.join(","),
+      pullRequest,
     });
 
     return this.fetchJson<MeasuresComponentResponse>(endpoint);
@@ -290,15 +295,17 @@ export class SonarQubeClient {
    * Get quality gate status for a project
    *
    * @param projectKey - The project key
+   * @param pullRequest - Optional pull request id; forwarded to Sonar as `pullRequest=<id>`
    * @returns Quality gate status
    *
    * @example
    * const client = createSonarQubeClient();
    * const status = await client.getQualityGateStatus("my-project");
    */
-  async getQualityGateStatus(projectKey: string): Promise<QualityGateStatusResponse> {
+  async getQualityGateStatus(projectKey: string, pullRequest?: string): Promise<QualityGateStatusResponse> {
     const endpoint = this.buildEndpoint("/api/qualitygates/project_status", {
       projectKey,
+      pullRequest,
     });
 
     return this.fetchJson<QualityGateStatusResponse>(endpoint);
@@ -331,6 +338,7 @@ export class SonarQubeClient {
       ps: params.ps,
       s: params.s,
       asc: params.asc,
+      pullRequest: params.pullRequest,
     });
 
     return this.fetchJson<IssuesSearchResponse>(endpoint);

--- a/packages/trpc/src/routers/sonarqube/procedures/getProject/index.test.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProject/index.test.ts
@@ -42,21 +42,72 @@ describe("sonarqube.getProject", () => {
     expect(result!.key).toBe("my-service");
     expect(result!.qualityGateStatus).toBe("OK");
     expect(result!.measures).toEqual({ alert_status: "OK", bugs: "0" });
+    expect(mockGetComponent).toHaveBeenCalledWith("my-service", undefined);
+    expect(mockGetMeasures).toHaveBeenCalledWith("my-service", expect.any(Array), undefined);
   });
 
-  it("should return null when project not found", async () => {
+  it("should throw NOT_FOUND when project not found", async () => {
     mockGetComponent.mockResolvedValueOnce(null);
 
     const caller = createCaller(mockContext);
-    const result = await caller.sonarqube.getProject({ componentKey: "nonexistent" });
-
-    expect(result).toBeNull();
+    await expect(caller.sonarqube.getProject({ componentKey: "nonexistent" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "project nonexistent not found",
+    });
   });
 
-  it("should throw on client errors", async () => {
+  it("should throw NOT_FOUND with pull-request message when PR 404", async () => {
+    mockGetComponent.mockResolvedValueOnce(null);
+
+    const caller = createCaller(mockContext);
+    await expect(caller.sonarqube.getProject({ componentKey: "my-service", pullRequest: "123" })).rejects.toMatchObject(
+      {
+        code: "NOT_FOUND",
+        message: "pull request 123 not found",
+      }
+    );
+  });
+
+  it("should throw INTERNAL_SERVER_ERROR on upstream failure", async () => {
     mockGetComponent.mockRejectedValueOnce(new Error("500 Internal Server Error"));
 
     const caller = createCaller(mockContext);
-    await expect(caller.sonarqube.getProject({ componentKey: "error" })).rejects.toThrow("500");
+    await expect(caller.sonarqube.getProject({ componentKey: "error" })).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
+  });
+
+  it("should reject unknown fields via .strict()", async () => {
+    const caller = createCaller(mockContext);
+    // @ts-expect-error — deliberately passing an unknown field
+    await expect(caller.sonarqube.getProject({ componentKey: "ok", foo: "bar" })).rejects.toThrow();
+  });
+
+  it("should forward pullRequest when supplied", async () => {
+    mockGetComponent.mockResolvedValueOnce({
+      component: { key: "my-service", name: "My Service" },
+    });
+    mockGetMeasures.mockResolvedValueOnce({});
+    mockParseMeasures.mockReturnValueOnce({});
+
+    const caller = createCaller(mockContext);
+    await caller.sonarqube.getProject({ componentKey: "my-service", pullRequest: "123" });
+
+    expect(mockGetComponent).toHaveBeenCalledWith("my-service", "123");
+    expect(mockGetMeasures).toHaveBeenCalledWith("my-service", expect.any(Array), "123");
+  });
+
+  it("should omit pullRequest from upstream call when not supplied (UI regression)", async () => {
+    mockGetComponent.mockResolvedValueOnce({
+      component: { key: "my-service", name: "My Service" },
+    });
+    mockGetMeasures.mockResolvedValueOnce({});
+    mockParseMeasures.mockReturnValueOnce({});
+
+    const caller = createCaller(mockContext);
+    await caller.sonarqube.getProject({ componentKey: "my-service" });
+
+    expect(mockGetComponent.mock.calls[0][1]).toBeUndefined();
+    expect(mockGetMeasures.mock.calls[0][2]).toBeUndefined();
   });
 });

--- a/packages/trpc/src/routers/sonarqube/procedures/getProject/index.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProject/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createSonarQubeClient } from "../../../../clients/sonarqube/index.js";
 import {
@@ -10,24 +11,30 @@ import {
 
 /**
  * Get a single SonarQube project (via `/api/components/show`) with its measures.
- * Returns null when the component does not exist, so the UI can render an empty state.
+ * Throws NOT_FOUND when the component does not exist.
+ *
+ * When `pullRequest` is supplied, forwards `&pullRequest=<id>` to both
+ * `/api/components/show` and `/api/measures/component`.
  */
 export const getProjectProcedure = protectedProcedure
   .input(
-    z.object({
-      componentKey: z.string().describe("SonarQube component/project key"),
-    })
+    z
+      .object({
+        componentKey: z.string().describe("SonarQube component/project key"),
+        pullRequest: z.string().optional().describe("Optional SonarQube pull-request id"),
+      })
+      .strict()
   )
-  .output(projectWithMetricsSchema.nullable())
+  .output(projectWithMetricsSchema)
   .query(async ({ input }) => {
-    const { componentKey } = input;
+    const { componentKey, pullRequest } = input;
     const sonarqubeClient = createSonarQubeClient();
 
     try {
       // Fetch component and measures in parallel — measures failures are tolerated.
       const [componentResponse, measuresResponse] = await Promise.all([
-        sonarqubeClient.getComponent(componentKey),
-        sonarqubeClient.getMeasures(componentKey, SONARQUBE_METRIC_KEYS).catch((error) => {
+        sonarqubeClient.getComponent(componentKey, pullRequest),
+        sonarqubeClient.getMeasures(componentKey, SONARQUBE_METRIC_KEYS, pullRequest).catch((error) => {
           console.warn(`[SonarQube] Failed to fetch measures for ${componentKey}:`, error);
           return null;
         }),
@@ -35,7 +42,10 @@ export const getProjectProcedure = protectedProcedure
 
       if (!componentResponse) {
         console.warn(`[SonarQube] Component not found: ${componentKey}`);
-        return null;
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: pullRequest ? `pull request ${pullRequest} not found` : `project ${componentKey} not found`,
+        });
       }
 
       const measures = measuresResponse ? sonarqubeClient.parseMeasures(measuresResponse) : {};
@@ -52,8 +62,15 @@ export const getProjectProcedure = protectedProcedure
         qualityGateStatus,
       };
     } catch (error) {
+      if (error instanceof TRPCError) {
+        throw error;
+      }
       console.error(`[SonarQube] Failed to fetch project: ${componentKey}`, error);
-      throw error;
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `SonarQube upstream failure for ${componentKey}`,
+        cause: error,
+      });
     }
   });
 

--- a/packages/trpc/src/routers/sonarqube/procedures/getProjectIssues/index.test.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProjectIssues/index.test.ts
@@ -21,6 +21,14 @@ describe("sonarqube.getProjectIssues", () => {
     vi.clearAllMocks();
   });
 
+  const emptyResp = {
+    total: 0,
+    p: 1,
+    ps: 25,
+    paging: { pageIndex: 1, pageSize: 25, total: 0 },
+    issues: [],
+  };
+
   it("should return issues list", async () => {
     const mockResponse = {
       total: 1,
@@ -56,12 +64,79 @@ describe("sonarqube.getProjectIssues", () => {
     expect(mockGetIssues).toHaveBeenCalledWith(expect.objectContaining({ componentKeys: "my-service" }));
   });
 
-  it("should throw on API error", async () => {
-    mockGetIssues.mockRejectedValueOnce(new Error("API Error"));
+  it("should forward pullRequest and filters", async () => {
+    mockGetIssues.mockResolvedValueOnce(emptyResp);
 
     const caller = createCaller(mockContext);
-    await expect(caller.sonarqube.getProjectIssues({ componentKeys: "error", p: 1, ps: 25 })).rejects.toThrow(
-      "API Error"
+    await caller.sonarqube.getProjectIssues({
+      componentKeys: "my-service",
+      pullRequest: "123",
+      types: "BUG,VULNERABILITY",
+      severities: "BLOCKER,CRITICAL",
+      statuses: "OPEN",
+      resolved: "true",
+      s: "SEVERITY",
+      asc: "true",
+      p: 2,
+      ps: 50,
+    });
+
+    expect(mockGetIssues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        componentKeys: "my-service",
+        pullRequest: "123",
+        types: "BUG,VULNERABILITY",
+        severities: "BLOCKER,CRITICAL",
+        statuses: "OPEN",
+        resolved: "true",
+        s: "SEVERITY",
+        asc: "true",
+        p: 2,
+        ps: 50,
+      })
     );
+  });
+
+  it("should default resolved=false when not provided (UI regression)", async () => {
+    mockGetIssues.mockResolvedValueOnce(emptyResp);
+
+    const caller = createCaller(mockContext);
+    await caller.sonarqube.getProjectIssues({ componentKeys: "my-service", p: 1, ps: 25 });
+
+    const forwarded = mockGetIssues.mock.calls[0][0];
+    expect(forwarded.resolved).toBe("false");
+    expect(forwarded.pullRequest).toBeUndefined();
+  });
+
+  it("should reject unknown fields via .strict()", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.sonarqube.getProjectIssues({
+        componentKeys: "my-service",
+        p: 1,
+        ps: 25,
+        // @ts-expect-error — deliberately passing an unknown field
+        foo: "bar",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("should throw NOT_FOUND on Sonar 404", async () => {
+    mockGetIssues.mockRejectedValueOnce(new Error("SonarQube API request failed: 404 Not Found"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.sonarqube.getProjectIssues({ componentKeys: "nope", p: 1, ps: 25 })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "project nope not found",
+    });
+  });
+
+  it("should throw INTERNAL_SERVER_ERROR on Sonar 5xx", async () => {
+    mockGetIssues.mockRejectedValueOnce(new Error("SonarQube API request failed: 500 Internal Server Error"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.sonarqube.getProjectIssues({ componentKeys: "err", p: 1, ps: 25 })).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
   });
 });

--- a/packages/trpc/src/routers/sonarqube/procedures/getProjectIssues/index.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProjectIssues/index.ts
@@ -1,12 +1,16 @@
+import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createSonarQubeClient } from "../../../../clients/sonarqube/index.js";
 import { issuesQueryParamsSchema, issuesSearchResponseSchema } from "@my-project/shared";
 
 /**
  * Paginated issue search for a SonarQube project (via `/api/issues/search`).
+ *
+ * `pullRequest?` is plumbed through `issuesQueryParamsSchema` so it reaches
+ * Sonar as `&pullRequest=<id>` when supplied.
  */
 export const getProjectIssuesProcedure = protectedProcedure
-  .input(issuesQueryParamsSchema)
+  .input(issuesQueryParamsSchema.strict())
   .output(issuesSearchResponseSchema)
   .query(async ({ input }) => {
     const sonarqubeClient = createSonarQubeClient();
@@ -16,7 +20,23 @@ export const getProjectIssuesProcedure = protectedProcedure
       console.info(`[SonarQube] Found ${issuesResponse.total} issues for ${input.componentKeys}`);
       return issuesResponse;
     } catch (error) {
+      if (error instanceof TRPCError) {
+        throw error;
+      }
       console.error(`[SonarQube] Failed to fetch issues for ${input.componentKeys}:`, error);
-      throw error;
+      if (error instanceof Error && /:\s*404\b/.test(error.message)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: input.pullRequest
+            ? `pull request ${input.pullRequest} not found`
+            : `project ${input.componentKeys} not found`,
+          cause: error,
+        });
+      }
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `SonarQube upstream failure for ${input.componentKeys}`,
+        cause: error,
+      });
     }
   });

--- a/packages/trpc/src/routers/sonarqube/procedures/getProjects/index.test.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProjects/index.test.ts
@@ -76,4 +76,37 @@ describe("sonarqube.getProjects", () => {
     expect(result.projects).toHaveLength(1);
     expect(result.projects[0].measures).toBeUndefined();
   });
+
+  it("short-circuits when page*pageSize exceeds SonarQube's 10000-row offset limit", async () => {
+    const caller = createCaller(mockContext);
+    const result = await caller.sonarqube.getProjects({ page: 999, pageSize: 50 });
+
+    expect(result.projects).toHaveLength(0);
+    expect(result.paging).toEqual({ pageIndex: 999, pageSize: 50, total: 0 });
+    expect(mockGetProjects).not.toHaveBeenCalled();
+  });
+
+  it("returns empty page when SonarQube responds with 400 (belt-and-braces for limit drift)", async () => {
+    mockGetProjects.mockRejectedValueOnce(
+      new Error(
+        'SonarQube API request failed: 400 Bad Request\nResponse: {"errors":[{"msg":"Can return only the first 10000 results"}]}'
+      )
+    );
+
+    const caller = createCaller(mockContext);
+    // page*pageSize below our proactive 10k guard; exercises the catch branch.
+    const result = await caller.sonarqube.getProjects({ page: 10, pageSize: 50 });
+
+    expect(result.projects).toHaveLength(0);
+    expect(result.paging).toEqual({ pageIndex: 10, pageSize: 50, total: 0 });
+  });
+
+  it("maps non-400 upstream failure to INTERNAL_SERVER_ERROR", async () => {
+    mockGetProjects.mockRejectedValueOnce(new Error("SonarQube API request failed: 503 Service Unavailable"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.sonarqube.getProjects({ page: 1, pageSize: 50 })).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
+  });
 });

--- a/packages/trpc/src/routers/sonarqube/procedures/getProjects/index.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProjects/index.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createSonarQubeClient } from "../../../../clients/sonarqube/index.js";
 import {
@@ -6,6 +7,12 @@ import {
   SonarQubeProject,
   SONARQUBE_METRIC_KEYS,
 } from "@my-project/shared";
+
+// SonarQube `/api/components/search` refuses requests where `p * ps > 10_000`
+// with HTTP 400 ("Can return only the first 10000 results"). We short-circuit
+// to an empty page so the CLI experience stays consistent with "beyond last
+// page → empty result".
+const SONARQUBE_SEARCH_MAX_OFFSET = 10_000;
 
 /**
  * Get all SonarQube projects with their metrics and quality gate status
@@ -16,51 +23,82 @@ import {
  * 3. Extracts quality gate status from alert_status metric (no additional API call)
  * 4. Returns combined data for display in the SAST overview
  */
-export const getProjects = protectedProcedure.input(sonarqubeProjectsQueryParamsSchema).query(async ({ input }) => {
-  const client = createSonarQubeClient();
+export const getProjectsProcedure = protectedProcedure
+  .input(sonarqubeProjectsQueryParamsSchema)
+  .query(async ({ input }) => {
+    const client = createSonarQubeClient();
 
-  // Step 1: Fetch projects list (1 API call)
-  const projectsResponse = await client.getProjects(input);
+    const page = input.page;
+    const pageSize = input.pageSize;
 
-  // Handle empty projects list
-  if (projectsResponse.components.length === 0) {
+    // Proactively short-circuit requests that would exceed SonarQube's hard offset
+    // limit. Without this, the upstream returns 400 and we bubble a 500.
+    if (page * pageSize > SONARQUBE_SEARCH_MAX_OFFSET) {
+      return {
+        projects: [],
+        paging: { pageIndex: page, pageSize, total: 0 },
+      };
+    }
+
+    // Step 1: Fetch projects list (1 API call)
+    let projectsResponse;
+    try {
+      projectsResponse = await client.getProjects(input);
+    } catch (error) {
+      // Defensive: if SonarQube's offset limit changes, still handle 400 as "empty".
+      if (error instanceof Error && /:\s*400\b/.test(error.message)) {
+        return {
+          projects: [],
+          paging: { pageIndex: page, pageSize, total: 0 },
+        };
+      }
+
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "SonarQube upstream failure while listing projects",
+        cause: error,
+      });
+    }
+
+    // Handle empty projects list
+    if (projectsResponse.components.length === 0) {
+      return {
+        projects: [],
+        paging: projectsResponse.paging,
+      };
+    }
+
+    // Step 2: Extract project keys for batch fetch
+    const projectKeys = projectsResponse.components.map((project: SonarQubeProject) => project.key);
+
+    // Step 3: Batch fetch measures for ALL projects (1 API call)
+    let measuresByComponent: Record<string, Record<string, string>> = {};
+
+    try {
+      const batchMeasuresResponse = await client.getBatchMeasures(projectKeys, SONARQUBE_METRIC_KEYS);
+      measuresByComponent = client.parseBatchMeasures(batchMeasuresResponse);
+    } catch (error) {
+      console.warn("[SonarQube] Failed to fetch batch measures:", error);
+      // Continue with empty measures - projects will show without metrics
+    }
+
+    // Step 4: Combine project data with measures
+    const projectsWithMetrics: ProjectWithMetrics[] = projectsResponse.components.map((project: SonarQubeProject) => {
+      const measures = measuresByComponent[project.key];
+
+      // Extract quality gate status from alert_status metric
+      // alert_status is equivalent to the quality gate status (OK/WARN/ERROR/NONE)
+      const qualityGateStatus = measures?.alert_status as "OK" | "WARN" | "ERROR" | "NONE" | undefined;
+
+      return {
+        ...project,
+        measures: measures || undefined,
+        qualityGateStatus,
+      };
+    });
+
     return {
-      projects: [],
+      projects: projectsWithMetrics,
       paging: projectsResponse.paging,
     };
-  }
-
-  // Step 2: Extract project keys for batch fetch
-  const projectKeys = projectsResponse.components.map((project: SonarQubeProject) => project.key);
-
-  // Step 3: Batch fetch measures for ALL projects (1 API call)
-  let measuresByComponent: Record<string, Record<string, string>> = {};
-
-  try {
-    const batchMeasuresResponse = await client.getBatchMeasures(projectKeys, SONARQUBE_METRIC_KEYS);
-    measuresByComponent = client.parseBatchMeasures(batchMeasuresResponse);
-  } catch (error) {
-    console.warn("[SonarQube] Failed to fetch batch measures:", error);
-    // Continue with empty measures - projects will show without metrics
-  }
-
-  // Step 4: Combine project data with measures
-  const projectsWithMetrics: ProjectWithMetrics[] = projectsResponse.components.map((project: SonarQubeProject) => {
-    const measures = measuresByComponent[project.key];
-
-    // Extract quality gate status from alert_status metric
-    // alert_status is equivalent to the quality gate status (OK/WARN/ERROR/NONE)
-    const qualityGateStatus = measures?.alert_status as "OK" | "WARN" | "ERROR" | "NONE" | undefined;
-
-    return {
-      ...project,
-      measures: measures || undefined,
-      qualityGateStatus,
-    };
   });
-
-  return {
-    projects: projectsWithMetrics,
-    paging: projectsResponse.paging,
-  };
-});

--- a/packages/trpc/src/routers/sonarqube/procedures/getQualityGateDetails/index.test.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getQualityGateDetails/index.test.ts
@@ -36,14 +36,74 @@ describe("sonarqube.getQualityGateDetails", () => {
 
     expect(result.projectStatus.status).toBe("OK");
     expect(result.projectStatus.conditions).toHaveLength(1);
+    expect(mockGetQualityGateStatus).toHaveBeenCalledWith("my-service", undefined);
   });
 
-  it("should throw on API error", async () => {
-    mockGetQualityGateStatus.mockRejectedValueOnce(new Error("Service Unavailable"));
+  it("should return status=NONE verbatim on never-analyzed project", async () => {
+    mockGetQualityGateStatus.mockResolvedValueOnce({
+      projectStatus: { status: "NONE", conditions: [] },
+    });
+    const caller = createCaller(mockContext);
+    const result = await caller.sonarqube.getQualityGateDetails({ projectKey: "legacy" });
+    expect(result.projectStatus.status).toBe("NONE");
+  });
+
+  it("should forward pullRequest when supplied", async () => {
+    mockGetQualityGateStatus.mockResolvedValueOnce({
+      projectStatus: { status: "OK", conditions: [] },
+    });
 
     const caller = createCaller(mockContext);
-    await expect(caller.sonarqube.getQualityGateDetails({ projectKey: "error" })).rejects.toThrow(
-      "Service Unavailable"
-    );
+    await caller.sonarqube.getQualityGateDetails({ projectKey: "my-service", pullRequest: "123" });
+
+    expect(mockGetQualityGateStatus).toHaveBeenCalledWith("my-service", "123");
+  });
+
+  it("should omit pullRequest from upstream call when not supplied (UI regression)", async () => {
+    mockGetQualityGateStatus.mockResolvedValueOnce({
+      projectStatus: { status: "OK", conditions: [] },
+    });
+
+    const caller = createCaller(mockContext);
+    await caller.sonarqube.getQualityGateDetails({ projectKey: "my-service" });
+
+    expect(mockGetQualityGateStatus.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it("should reject unknown fields via .strict()", async () => {
+    const caller = createCaller(mockContext);
+    // @ts-expect-error — deliberately passing an unknown field
+    await expect(caller.sonarqube.getQualityGateDetails({ projectKey: "ok", foo: "bar" })).rejects.toThrow();
+  });
+
+  it("should throw NOT_FOUND on Sonar 404 (project)", async () => {
+    mockGetQualityGateStatus.mockRejectedValueOnce(new Error("SonarQube API request failed: 404 Not Found"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.sonarqube.getQualityGateDetails({ projectKey: "nope" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "project nope not found",
+    });
+  });
+
+  it("should throw NOT_FOUND with pull-request message on Sonar 404 (PR)", async () => {
+    mockGetQualityGateStatus.mockRejectedValueOnce(new Error("SonarQube API request failed: 404 Not Found"));
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.sonarqube.getQualityGateDetails({ projectKey: "my-service", pullRequest: "999" })
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "pull request 999 not found",
+    });
+  });
+
+  it("should throw INTERNAL_SERVER_ERROR on Sonar 5xx", async () => {
+    mockGetQualityGateStatus.mockRejectedValueOnce(new Error("SonarQube API request failed: 503 Service Unavailable"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.sonarqube.getQualityGateDetails({ projectKey: "err" })).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
   });
 });

--- a/packages/trpc/src/routers/sonarqube/procedures/getQualityGateDetails/index.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getQualityGateDetails/index.ts
@@ -1,28 +1,51 @@
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createSonarQubeClient } from "../../../../clients/sonarqube/index.js";
 import { qualityGateStatusResponseSchema } from "@my-project/shared";
 
 /**
  * Fetches the quality gate status (overall + per-condition) for a project.
+ *
+ * When `pullRequest` is supplied, forwards `&pullRequest=<id>` to
+ * `/api/qualitygates/project_status`.
  */
 export const getQualityGateDetailsProcedure = protectedProcedure
   .input(
-    z.object({
-      projectKey: z.string().describe("SonarQube project key"),
-    })
+    z
+      .object({
+        projectKey: z.string().describe("SonarQube project key"),
+        pullRequest: z.string().optional().describe("Optional SonarQube pull-request id"),
+      })
+      .strict()
   )
   .output(qualityGateStatusResponseSchema)
   .query(async ({ input }) => {
-    const { projectKey } = input;
+    const { projectKey, pullRequest } = input;
     const sonarqubeClient = createSonarQubeClient();
 
     try {
-      const qgResponse = await sonarqubeClient.getQualityGateStatus(projectKey);
+      const qgResponse = await sonarqubeClient.getQualityGateStatus(projectKey, pullRequest);
       console.info(`[SonarQube] Quality gate status for ${projectKey}: ${qgResponse.projectStatus.status}`);
       return qgResponse;
     } catch (error) {
+      if (error instanceof TRPCError) {
+        throw error;
+      }
       console.error(`[SonarQube] Failed to fetch quality gate for ${projectKey}:`, error);
-      throw error;
+
+      if (error instanceof Error && /:\s*404\b/.test(error.message)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: pullRequest ? `pull request ${pullRequest} not found` : `project ${projectKey} not found`,
+          cause: error,
+        });
+      }
+
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `SonarQube upstream failure for ${projectKey}`,
+        cause: error,
+      });
     }
   });

--- a/packages/trpc/src/routers/sonarqube/procedures/index.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/index.ts
@@ -1,4 +1,4 @@
-export { getProjects } from "./getProjects/index.js";
+export { getProjectsProcedure as getProjects } from "./getProjects/index.js";
 export { getProjectProcedure as getProject } from "./getProject/index.js";
 export { getProjectIssuesProcedure as getProjectIssues } from "./getProjectIssues/index.js";
 export { getQualityGateDetailsProcedure as getQualityGateDetails } from "./getQualityGateDetails/index.js";


### PR DESCRIPTION
Add optional pullRequest parameter throughout the SonarQube subsystem:
- Schema: issuesQueryParamsSchema gains optional pullRequest field
- Client methods (getComponent, getMeasures, getQualityGateStatus, getIssues) now forward pullRequest to SonarQube API when supplied
- Procedures (getProject, getQualityGateDetails, getProjectIssues):
  * Accept optional pullRequest input forwarded to client methods
  * Use .strict() for input validation
  * Throw NOT_FOUND (with disambiguating message for PR vs project) and INTERNAL_SERVER_ERROR on upstream failures
  * Extended test coverage: PR passthrough, PR-omitted regression, 404/5xx error mapping, strictness validation
- New OpenAPI REST proxy routes:
  * GET /rest/v1/sonar/list proxies getProjects with pagination limit safeguard (offset > 10k returns empty page)
  * GET /rest/v1/sonar/get proxies getProject with PR support
  * GET /rest/v1/sonar/gate proxies getQualityGateDetails with PR support
  * GET /rest/v1/sonar/issues proxies getProjectIssues with PR support

Enables pull-request-scoped quality data retrieval for code review workflows.
