### PR TITLE
EPMDEDP-16657: fix: Declare labels, annotations, creationTimestamp in K8s metadata schema

### DIFF
--- a/packages/trpc/api/openapi.json
+++ b/packages/trpc/api/openapi.json
@@ -219,6 +219,21 @@
                         },
                         "resourceVersion": {
                           "type": "string"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "labels": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "annotations": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
                         }
                       },
                       "required": [
@@ -408,6 +423,21 @@
                               },
                               "resourceVersion": {
                                 "type": "string"
+                              },
+                              "creationTimestamp": {
+                                "type": "string"
+                              },
+                              "labels": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "annotations": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
                               }
                             },
                             "required": [

--- a/packages/trpc/src/routers/k8s/procedures/basic/get/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/basic/get/index.test.ts
@@ -102,4 +102,51 @@ describe("k8sGetProcedure", () => {
 
     await expect(caller.k8s.get(input)).rejects.toThrow("Forbidden: User lacks permission");
   });
+
+  it("forwards labels, annotations and creationTimestamp through the schema", async () => {
+    const input = {
+      clusterName: "test-cluster",
+      namespace: "test-namespace",
+      name: "review-my-app-main-abc12",
+      resourceConfig: {
+        group: "tekton.dev",
+        version: "v1",
+        pluralName: "pipelineruns",
+        kind: "PipelineRun",
+        singularName: "pipelinerun",
+        apiVersion: "tekton.dev/v1",
+      },
+    };
+
+    const mockResponse = {
+      apiVersion: "tekton.dev/v1",
+      kind: "PipelineRun",
+      metadata: {
+        name: "review-my-app-main-abc12",
+        namespace: "edp-delivery",
+        resourceVersion: "100",
+        creationTimestamp: "2024-01-01T10:00:00Z",
+        labels: {
+          "app.edp.epam.com/codebase": "my-app",
+          "app.edp.epam.com/pipelinetype": "review",
+          "app.edp.epam.com/git-author": "alice",
+          "app.edp.epam.com/git-change-number": "42",
+        },
+        annotations: {
+          "app.edp.epam.com/git-change-url": "https://github.com/org/my-app/pull/42",
+          "app.edp.epam.com/git-commit-sha": "deadbeefcafef00d",
+        },
+      },
+    };
+
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(mockResponse);
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.get(input);
+
+    const meta = result.metadata as Record<string, unknown>;
+    expect(meta.creationTimestamp).toBe("2024-01-01T10:00:00Z");
+    expect(meta.labels).toEqual(mockResponse.metadata.labels);
+    expect(meta.annotations).toEqual(mockResponse.metadata.annotations);
+  });
 });

--- a/packages/trpc/src/routers/k8s/procedures/basic/get/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/basic/get/index.ts
@@ -6,11 +6,16 @@ import { protectedProcedure } from "../../../../../procedures/protected/index.js
 import { handleK8sError } from "../../../utils/handleK8sError/index.js";
 import { K8sClient } from "../../../../../clients/k8s/index.js";
 
+// Explicit properties so `trpc-to-openapi` emits typed schemas; downstream
+// oapi-codegen clients otherwise drop every extra key on decode.
 const k8sItemMetadataSchema = z
   .object({
     name: z.string(),
     namespace: z.string().optional(),
     resourceVersion: z.string().optional(),
+    creationTimestamp: z.string().optional(),
+    labels: z.record(z.string().optional()).optional(),
+    annotations: z.record(z.string()).optional(),
   })
   .passthrough();
 

--- a/packages/trpc/src/routers/k8s/procedures/basic/list/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/basic/list/index.test.ts
@@ -130,4 +130,59 @@ describe("k8sListProcedure", () => {
 
     await expect(caller.k8s.list(input)).rejects.toThrow("Network error: Failed to connect to Kubernetes API");
   });
+
+  it("forwards labels, annotations and creationTimestamp through the schema", async () => {
+    const input = {
+      clusterName: "test-cluster",
+      namespace: "test-namespace",
+      resourceConfig: {
+        group: "tekton.dev",
+        version: "v1",
+        pluralName: "pipelineruns",
+        kind: "PipelineRun",
+        singularName: "pipelinerun",
+        apiVersion: "tekton.dev/v1",
+      },
+      labels: {},
+    };
+
+    const mockResponse = {
+      apiVersion: "tekton.dev/v1",
+      kind: "PipelineRunList",
+      metadata: { resourceVersion: "1" },
+      items: [
+        {
+          apiVersion: "tekton.dev/v1",
+          kind: "PipelineRun",
+          metadata: {
+            name: "review-my-app-main-abc12",
+            namespace: "edp-delivery",
+            resourceVersion: "100",
+            creationTimestamp: "2024-01-01T10:00:00Z",
+            labels: {
+              "app.edp.epam.com/codebase": "my-app",
+              "app.edp.epam.com/pipelinetype": "review",
+              "app.edp.epam.com/git-branch": "feature-x",
+              "app.edp.epam.com/git-author": "alice",
+              "app.edp.epam.com/git-change-number": "42",
+            },
+            annotations: {
+              "app.edp.epam.com/git-change-url": "https://github.com/org/my-app/pull/42",
+              "app.edp.epam.com/git-commit-sha": "deadbeefcafef00d",
+            },
+          },
+        },
+      ],
+    };
+
+    mockK8sClientInstance.listResource.mockResolvedValueOnce(mockResponse);
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.list(input);
+
+    const meta = result.items[0].metadata as Record<string, unknown>;
+    expect(meta.creationTimestamp).toBe("2024-01-01T10:00:00Z");
+    expect(meta.labels).toEqual(mockResponse.items[0].metadata.labels);
+    expect(meta.annotations).toEqual(mockResponse.items[0].metadata.annotations);
+  });
 });

--- a/packages/trpc/src/routers/k8s/procedures/basic/list/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/basic/list/index.ts
@@ -7,11 +7,16 @@ import { k8sResourceConfigSchema } from "@my-project/shared";
 import { handleK8sError } from "../../../utils/handleK8sError/index.js";
 import { K8sClient } from "../../../../../clients/k8s/index.js";
 
+// Explicit properties so `trpc-to-openapi` emits typed schemas; downstream
+// oapi-codegen clients otherwise drop every extra key on decode.
 const k8sItemMetadataSchema = z
   .object({
     name: z.string(),
     namespace: z.string().optional(),
     resourceVersion: z.string().optional(),
+    creationTimestamp: z.string().optional(),
+    labels: z.record(z.string().optional()).optional(),
+    annotations: z.record(z.string()).optional(),
   })
   .passthrough();
 


### PR DESCRIPTION


The K8s metadata Zod schema used by `k8s.list` and `k8s.get` procedures declared only `name`, `namespace`, `resourceVersion` and relied on `.passthrough()` to keep extra keys. When `trpc-to-openapi` serialised that schema, `.passthrough()` became `additionalProperties: true`. Downstream Go clients generated from this OpenAPI spec by `oapi-codegen` turn `additionalProperties: true` into a `json:"-"` catch-all field with no `UnmarshalJSON` method, so every extra key (`labels`, `annotations`, `creationTimestamp`, …) was silently dropped on decode.

This broke `krci run list` in the krci CLI, which relies on K8s labels and annotations to populate Project, PR, Author, Type, Branch, and CommitSHA columns. Declaring these three fields as explicit typed properties (matching the pattern already used in `TaskRunMetadata`) gives them proper schemas in the generated OpenAPI spec, ensures downstream clients deserialise them correctly, and unblocks the CLI. `.passthrough()` is retained so unknown keys still round-trip.
