### PR TITLE
EPMDEDP-16713: feat: Add SonarQube branch scope support

### DIFF
--- a/apps/server/src/config/openapi.ts
+++ b/apps/server/src/config/openapi.ts
@@ -260,10 +260,11 @@ export function registerOpenApi(
     Querystring: {
       projectKey: string;
       pullRequest?: string;
+      branch?: string;
     };
   }>("/rest/v1/sonar/get", async (req, res) => {
     try {
-      const { projectKey, pullRequest } = req.query;
+      const { projectKey, pullRequest, branch } = req.query;
       if (!projectKey) {
         return res.code(400).send({ error: "projectKey is required" });
       }
@@ -271,7 +272,8 @@ export function registerOpenApi(
       const caller = await buildCaller(req, res);
       return await caller.sonarqube.getProject({
         componentKey: projectKey,
-        pullRequest,
+        pullRequest: pullRequest || undefined,
+        branch: branch || undefined,
       });
     } catch (error) {
       return handleTRPCError(error, res);
@@ -283,10 +285,11 @@ export function registerOpenApi(
     Querystring: {
       projectKey: string;
       pullRequest?: string;
+      branch?: string;
     };
   }>("/rest/v1/sonar/gate", async (req, res) => {
     try {
-      const { projectKey, pullRequest } = req.query;
+      const { projectKey, pullRequest, branch } = req.query;
       if (!projectKey) {
         return res.code(400).send({ error: "projectKey is required" });
       }
@@ -294,7 +297,8 @@ export function registerOpenApi(
       const caller = await buildCaller(req, res);
       return await caller.sonarqube.getQualityGateDetails({
         projectKey,
-        pullRequest,
+        pullRequest: pullRequest || undefined,
+        branch: branch || undefined,
       });
     } catch (error) {
       return handleTRPCError(error, res);
@@ -306,6 +310,7 @@ export function registerOpenApi(
     Querystring: {
       projectKey: string;
       pullRequest?: string;
+      branch?: string;
       types?: string;
       severities?: string;
       statuses?: string;
@@ -320,6 +325,7 @@ export function registerOpenApi(
       const {
         projectKey,
         pullRequest,
+        branch,
         types,
         severities,
         statuses,
@@ -344,7 +350,8 @@ export function registerOpenApi(
       const caller = await buildCaller(req, res);
       return await caller.sonarqube.getProjectIssues({
         componentKeys: projectKey,
-        pullRequest,
+        pullRequest: pullRequest || undefined,
+        branch: branch || undefined,
         types,
         severities,
         statuses,

--- a/packages/shared/src/models/sonarqube/index.ts
+++ b/packages/shared/src/models/sonarqube/index.ts
@@ -12,3 +12,6 @@ export * from "./schemas.js";
 
 // TypeScript Types
 export * from "./types.js";
+
+// Utilities
+export * from "./utils.js";

--- a/packages/shared/src/models/sonarqube/schemas.ts
+++ b/packages/shared/src/models/sonarqube/schemas.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from "zod";
+import { withScopeMutuallyExclusive } from "./utils.js";
 
 // =============================================================================
 // Paging
@@ -255,16 +256,24 @@ export const issuesSearchResponseSchema = z.object({
 
 /**
  * Issues query parameters for /api/issues/search
+ *
+ * `pullRequest` and `branch` are mutually exclusive at the SonarQube API
+ * layer; `.refine` rejects callers that send both.
  */
-export const issuesQueryParamsSchema = z.object({
-  componentKeys: z.string(), // Project key
-  resolved: z.enum(["true", "false"]).optional().default("false"),
-  types: z.string().optional(), // Comma-separated: BUG,VULNERABILITY,CODE_SMELL
-  severities: z.string().optional(), // Comma-separated: BLOCKER,CRITICAL,MAJOR,MINOR,INFO
-  statuses: z.string().optional(),
-  p: z.number().int().min(1).optional().default(1),
-  ps: z.number().int().min(1).max(500).optional().default(25),
-  s: z.string().optional(), // Sort field
-  asc: z.enum(["true", "false"]).optional(),
-  pullRequest: z.string().optional(), // Forward to SonarQube /api/issues/search&pullRequest=<id>
-});
+export const issuesQueryParamsSchema = withScopeMutuallyExclusive(
+  z
+    .object({
+      componentKeys: z.string(), // Project key
+      resolved: z.enum(["true", "false"]).optional().default("false"),
+      types: z.string().optional(), // Comma-separated: BUG,VULNERABILITY,CODE_SMELL
+      severities: z.string().optional(), // Comma-separated: BLOCKER,CRITICAL,MAJOR,MINOR,INFO
+      statuses: z.string().optional(),
+      p: z.number().int().min(1).optional().default(1),
+      ps: z.number().int().min(1).max(500).optional().default(25),
+      s: z.string().optional(), // Sort field
+      asc: z.enum(["true", "false"]).optional(),
+      pullRequest: z.string().min(1).optional(), // Forward to SonarQube /api/issues/search&pullRequest=<id>
+      branch: z.string().min(1).optional(), // Forward to SonarQube /api/issues/search&branch=<name>
+    })
+    .strict()
+);

--- a/packages/shared/src/models/sonarqube/utils.ts
+++ b/packages/shared/src/models/sonarqube/utils.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+/**
+ * Wraps a Zod schema with a refinement that rejects objects where both
+ * `pullRequest` and `branch` are present. The two fields are mutually
+ * exclusive at the SonarQube API layer.
+ *
+ * The error is attached to the `branch` path so form libraries surface it
+ * on the correct field.
+ */
+export function withScopeMutuallyExclusive<TOutput extends { pullRequest?: string; branch?: string }>(
+  schema: z.ZodType<TOutput>
+) {
+  return schema.refine((v) => !(v.pullRequest && v.branch), {
+    message: "pullRequest and branch are mutually exclusive",
+    path: ["branch"],
+  });
+}

--- a/packages/trpc/src/clients/sonarqube/index.test.ts
+++ b/packages/trpc/src/clients/sonarqube/index.test.ts
@@ -40,7 +40,7 @@ describe("createSonarQubeClient", () => {
   });
 });
 
-describe("SonarQubeClient pullRequest passthrough", () => {
+describe("SonarQubeClient scope passthrough", () => {
   const BASE = "https://sonar.example.com";
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;
@@ -73,30 +73,54 @@ describe("SonarQubeClient pullRequest passthrough", () => {
 
   it("getComponent appends pullRequest when supplied", async () => {
     const client = await newClient();
-    await client.getComponent("my-proj", "123");
+    await client.getComponent("my-proj", { pullRequest: "123" });
     const url = capturedUrl();
     expect(url).toContain("component=my-proj");
     expect(url).toContain("pullRequest=123");
+    expect(url).not.toContain("branch=");
   });
 
-  it("getComponent omits pullRequest when undefined", async () => {
+  it("getComponent appends branch when supplied", async () => {
+    const client = await newClient();
+    await client.getComponent("my-proj", { branch: "main" });
+    const url = capturedUrl();
+    expect(url).toContain("component=my-proj");
+    expect(url).toContain("branch=main");
+    expect(url).not.toContain("pullRequest=");
+  });
+
+  it("getComponent omits scope params when scope is undefined", async () => {
     const client = await newClient();
     await client.getComponent("my-proj");
-    expect(capturedUrl()).not.toContain("pullRequest=");
+    const url = capturedUrl();
+    expect(url).not.toContain("pullRequest=");
+    expect(url).not.toContain("branch=");
   });
 
   it("getMeasures appends pullRequest when supplied", async () => {
     const client = await newClient();
-    await client.getMeasures("my-proj", ["bugs"], "123");
+    await client.getMeasures("my-proj", ["bugs"], { pullRequest: "123" });
     const url = capturedUrl();
     expect(url).toContain("component=my-proj");
     expect(url).toContain("pullRequest=123");
+    expect(url).not.toContain("branch=");
   });
 
-  it("getMeasures omits pullRequest when undefined", async () => {
+  it("getMeasures appends branch when supplied", async () => {
+    const client = await newClient();
+    await client.getMeasures("my-proj", ["bugs"], { branch: "main" });
+    const url = capturedUrl();
+    expect(url).toContain("component=my-proj");
+    expect(url).toContain("branch=main");
+    expect(url).not.toContain("pullRequest=");
+  });
+
+  it("getMeasures omits scope params when scope is undefined", async () => {
     const client = await newClient();
     await client.getMeasures("my-proj", ["bugs"]);
-    expect(capturedUrl()).not.toContain("pullRequest=");
+    const url = capturedUrl();
+    expect(url).not.toContain("pullRequest=");
+    expect(url).not.toContain("branch=");
   });
 
   it("getQualityGateStatus appends pullRequest when supplied", async () => {
@@ -107,13 +131,29 @@ describe("SonarQubeClient pullRequest passthrough", () => {
       })
     );
     const client = await newClient();
-    await client.getQualityGateStatus("my-proj", "123");
+    await client.getQualityGateStatus("my-proj", { pullRequest: "123" });
     const url = capturedUrl();
     expect(url).toContain("projectKey=my-proj");
     expect(url).toContain("pullRequest=123");
+    expect(url).not.toContain("branch=");
   });
 
-  it("getQualityGateStatus omits pullRequest when undefined", async () => {
+  it("getQualityGateStatus appends branch when supplied", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ projectStatus: { status: "OK", conditions: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const client = await newClient();
+    await client.getQualityGateStatus("my-proj", { branch: "main" });
+    const url = capturedUrl();
+    expect(url).toContain("projectKey=my-proj");
+    expect(url).toContain("branch=main");
+    expect(url).not.toContain("pullRequest=");
+  });
+
+  it("getQualityGateStatus omits scope params when scope is undefined", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ projectStatus: { status: "OK", conditions: [] } }), {
         status: 200,
@@ -122,44 +162,48 @@ describe("SonarQubeClient pullRequest passthrough", () => {
     );
     const client = await newClient();
     await client.getQualityGateStatus("my-proj");
-    expect(capturedUrl()).not.toContain("pullRequest=");
+    const url = capturedUrl();
+    expect(url).not.toContain("pullRequest=");
+    expect(url).not.toContain("branch=");
   });
 
+  const emptyIssuesResp = new Response(
+    JSON.stringify({
+      total: 0,
+      p: 1,
+      ps: 25,
+      paging: { pageIndex: 1, pageSize: 25, total: 0 },
+      issues: [],
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+
   it("getIssues appends pullRequest when supplied", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          total: 0,
-          p: 1,
-          ps: 25,
-          paging: { pageIndex: 1, pageSize: 25, total: 0 },
-          issues: [],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      )
-    );
+    fetchMock.mockResolvedValueOnce(emptyIssuesResp.clone());
     const client = await newClient();
     await client.getIssues({ componentKeys: "my-proj", resolved: "false", p: 1, ps: 25, pullRequest: "123" });
     const url = capturedUrl();
     expect(url).toContain("componentKeys=my-proj");
     expect(url).toContain("pullRequest=123");
+    expect(url).not.toContain("branch=");
   });
 
-  it("getIssues omits pullRequest when undefined", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          total: 0,
-          p: 1,
-          ps: 25,
-          paging: { pageIndex: 1, pageSize: 25, total: 0 },
-          issues: [],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      )
-    );
+  it("getIssues appends branch when supplied", async () => {
+    fetchMock.mockResolvedValueOnce(emptyIssuesResp.clone());
+    const client = await newClient();
+    await client.getIssues({ componentKeys: "my-proj", resolved: "false", p: 1, ps: 25, branch: "main" });
+    const url = capturedUrl();
+    expect(url).toContain("componentKeys=my-proj");
+    expect(url).toContain("branch=main");
+    expect(url).not.toContain("pullRequest=");
+  });
+
+  it("getIssues omits scope params when neither supplied", async () => {
+    fetchMock.mockResolvedValueOnce(emptyIssuesResp.clone());
     const client = await newClient();
     await client.getIssues({ componentKeys: "my-proj", resolved: "false", p: 1, ps: 25 });
-    expect(capturedUrl()).not.toContain("pullRequest=");
+    const url = capturedUrl();
+    expect(url).not.toContain("pullRequest=");
+    expect(url).not.toContain("branch=");
   });
 });

--- a/packages/trpc/src/clients/sonarqube/index.ts
+++ b/packages/trpc/src/clients/sonarqube/index.ts
@@ -81,6 +81,16 @@ export interface SonarQubeClientConfig {
 }
 
 /**
+ * SonarQube scope selector. SonarQube treats pullRequest and branch as
+ * mutually exclusive at the API level; callers enforce that invariant.
+ * Passing neither targets the default branch of the project.
+ */
+export interface SonarScope {
+  pullRequest?: string;
+  branch?: string;
+}
+
+/**
  * Client for SonarQube API.
  *
  * Features:
@@ -220,13 +230,16 @@ export class SonarQubeClient {
    * Get a single component/project by exact key
    *
    * @param componentKey - The project/component key
-   * @param pullRequest - Optional pull request id; forwarded to Sonar as `pullRequest=<id>`
+   * @param scope - Optional SonarQube scope. Pass `pullRequest` or `branch`
+   *   (mutually exclusive at the SonarQube API level). Forwarded as
+   *   `pullRequest=<id>` / `branch=<name>` respectively.
    * @returns Component data, or null if not found
    */
-  async getComponent(componentKey: string, pullRequest?: string): Promise<ComponentShowResponse | null> {
+  async getComponent(componentKey: string, scope?: SonarScope): Promise<ComponentShowResponse | null> {
     const endpoint = this.buildEndpoint("/api/components/show", {
       component: componentKey,
-      pullRequest,
+      pullRequest: scope?.pullRequest,
+      branch: scope?.branch,
     });
 
     try {
@@ -244,7 +257,7 @@ export class SonarQubeClient {
    *
    * @param componentKey - The project/component key
    * @param metricKeys - Array of metric keys to fetch
-   * @param pullRequest - Optional pull request id; forwarded to Sonar as `pullRequest=<id>`
+   * @param scope - Optional SonarQube scope (pullRequest xor branch).
    * @returns Component with measures
    *
    * @example
@@ -254,12 +267,13 @@ export class SonarQubeClient {
   async getMeasures(
     componentKey: string,
     metricKeys: readonly string[] = SONARQUBE_METRIC_KEYS,
-    pullRequest?: string
+    scope?: SonarScope
   ): Promise<MeasuresComponentResponse> {
     const endpoint = this.buildEndpoint("/api/measures/component", {
       component: componentKey,
       metricKeys: metricKeys.join(","),
-      pullRequest,
+      pullRequest: scope?.pullRequest,
+      branch: scope?.branch,
     });
 
     return this.fetchJson<MeasuresComponentResponse>(endpoint);
@@ -295,17 +309,18 @@ export class SonarQubeClient {
    * Get quality gate status for a project
    *
    * @param projectKey - The project key
-   * @param pullRequest - Optional pull request id; forwarded to Sonar as `pullRequest=<id>`
+   * @param scope - Optional SonarQube scope (pullRequest xor branch).
    * @returns Quality gate status
    *
    * @example
    * const client = createSonarQubeClient();
    * const status = await client.getQualityGateStatus("my-project");
    */
-  async getQualityGateStatus(projectKey: string, pullRequest?: string): Promise<QualityGateStatusResponse> {
+  async getQualityGateStatus(projectKey: string, scope?: SonarScope): Promise<QualityGateStatusResponse> {
     const endpoint = this.buildEndpoint("/api/qualitygates/project_status", {
       projectKey,
-      pullRequest,
+      pullRequest: scope?.pullRequest,
+      branch: scope?.branch,
     });
 
     return this.fetchJson<QualityGateStatusResponse>(endpoint);
@@ -339,6 +354,7 @@ export class SonarQubeClient {
       s: params.s,
       asc: params.asc,
       pullRequest: params.pullRequest,
+      branch: params.branch,
     });
 
     return this.fetchJson<IssuesSearchResponse>(endpoint);

--- a/packages/trpc/src/routers/sonarqube/procedures/getProject/index.test.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProject/index.test.ts
@@ -93,11 +93,48 @@ describe("sonarqube.getProject", () => {
     const caller = createCaller(mockContext);
     await caller.sonarqube.getProject({ componentKey: "my-service", pullRequest: "123" });
 
-    expect(mockGetComponent).toHaveBeenCalledWith("my-service", "123");
-    expect(mockGetMeasures).toHaveBeenCalledWith("my-service", expect.any(Array), "123");
+    expect(mockGetComponent).toHaveBeenCalledWith("my-service", { pullRequest: "123", branch: undefined });
+    expect(mockGetMeasures).toHaveBeenCalledWith("my-service", expect.any(Array), {
+      pullRequest: "123",
+      branch: undefined,
+    });
   });
 
-  it("should omit pullRequest from upstream call when not supplied (UI regression)", async () => {
+  it("should forward branch when supplied", async () => {
+    mockGetComponent.mockResolvedValueOnce({
+      component: { key: "my-service", name: "My Service" },
+    });
+    mockGetMeasures.mockResolvedValueOnce({});
+    mockParseMeasures.mockReturnValueOnce({});
+
+    const caller = createCaller(mockContext);
+    await caller.sonarqube.getProject({ componentKey: "my-service", branch: "main" });
+
+    expect(mockGetComponent).toHaveBeenCalledWith("my-service", { pullRequest: undefined, branch: "main" });
+    expect(mockGetMeasures).toHaveBeenCalledWith("my-service", expect.any(Array), {
+      pullRequest: undefined,
+      branch: "main",
+    });
+  });
+
+  it("should throw NOT_FOUND with branch message when branch 404", async () => {
+    mockGetComponent.mockResolvedValueOnce(null);
+
+    const caller = createCaller(mockContext);
+    await expect(caller.sonarqube.getProject({ componentKey: "my-service", branch: "feat/x" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "branch feat/x not found",
+    });
+  });
+
+  it("should reject pullRequest and branch at once", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.sonarqube.getProject({ componentKey: "my-service", pullRequest: "123", branch: "main" })
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+
+  it("should omit scope params from upstream call when not supplied (UI regression)", async () => {
     mockGetComponent.mockResolvedValueOnce({
       component: { key: "my-service", name: "My Service" },
     });

--- a/packages/trpc/src/routers/sonarqube/procedures/getProject/index.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProject/index.ts
@@ -7,34 +7,41 @@ import {
   QualityGateStatusValue,
   SONARQUBE_METRIC_KEYS,
   projectWithMetricsSchema,
+  withScopeMutuallyExclusive,
 } from "@my-project/shared";
+import { notFoundMessage } from "../../utils.js";
 
 /**
  * Get a single SonarQube project (via `/api/components/show`) with its measures.
  * Throws NOT_FOUND when the component does not exist.
  *
- * When `pullRequest` is supplied, forwards `&pullRequest=<id>` to both
- * `/api/components/show` and `/api/measures/component`.
+ * When `pullRequest` or `branch` is supplied, forwards the corresponding
+ * scope param to both `/api/components/show` and `/api/measures/component`.
+ * The two are mutually exclusive at the SonarQube API layer.
  */
 export const getProjectProcedure = protectedProcedure
   .input(
-    z
-      .object({
-        componentKey: z.string().describe("SonarQube component/project key"),
-        pullRequest: z.string().optional().describe("Optional SonarQube pull-request id"),
-      })
-      .strict()
+    withScopeMutuallyExclusive(
+      z
+        .object({
+          componentKey: z.string().describe("SonarQube component/project key"),
+          pullRequest: z.string().min(1).optional().describe("Optional SonarQube pull-request id"),
+          branch: z.string().min(1).optional().describe("Optional SonarQube branch name"),
+        })
+        .strict()
+    )
   )
   .output(projectWithMetricsSchema)
   .query(async ({ input }) => {
-    const { componentKey, pullRequest } = input;
+    const { componentKey, pullRequest, branch } = input;
     const sonarqubeClient = createSonarQubeClient();
+    const scope = pullRequest || branch ? { pullRequest, branch } : undefined;
 
     try {
       // Fetch component and measures in parallel — measures failures are tolerated.
       const [componentResponse, measuresResponse] = await Promise.all([
-        sonarqubeClient.getComponent(componentKey, pullRequest),
-        sonarqubeClient.getMeasures(componentKey, SONARQUBE_METRIC_KEYS, pullRequest).catch((error) => {
+        sonarqubeClient.getComponent(componentKey, scope),
+        sonarqubeClient.getMeasures(componentKey, SONARQUBE_METRIC_KEYS, scope).catch((error) => {
           console.warn(`[SonarQube] Failed to fetch measures for ${componentKey}:`, error);
           return null;
         }),
@@ -44,7 +51,7 @@ export const getProjectProcedure = protectedProcedure
         console.warn(`[SonarQube] Component not found: ${componentKey}`);
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: pullRequest ? `pull request ${pullRequest} not found` : `project ${componentKey} not found`,
+          message: notFoundMessage(componentKey, pullRequest, branch),
         });
       }
 

--- a/packages/trpc/src/routers/sonarqube/procedures/getProjectIssues/index.test.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProjectIssues/index.test.ts
@@ -106,6 +106,43 @@ describe("sonarqube.getProjectIssues", () => {
     const forwarded = mockGetIssues.mock.calls[0][0];
     expect(forwarded.resolved).toBe("false");
     expect(forwarded.pullRequest).toBeUndefined();
+    expect(forwarded.branch).toBeUndefined();
+  });
+
+  it("should forward branch when supplied", async () => {
+    mockGetIssues.mockResolvedValueOnce(emptyResp);
+
+    const caller = createCaller(mockContext);
+    await caller.sonarqube.getProjectIssues({ componentKeys: "my-service", branch: "main", p: 1, ps: 25 });
+
+    expect(mockGetIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ componentKeys: "my-service", branch: "main" })
+    );
+  });
+
+  it("should reject pullRequest and branch at once", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.sonarqube.getProjectIssues({
+        componentKeys: "my-service",
+        pullRequest: "123",
+        branch: "main",
+        p: 1,
+        ps: 25,
+      })
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+
+  it("should throw NOT_FOUND with branch message on Sonar 404 (branch)", async () => {
+    mockGetIssues.mockRejectedValueOnce(new Error("SonarQube API request failed: 404 Not Found"));
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.sonarqube.getProjectIssues({ componentKeys: "my-service", branch: "feat/x", p: 1, ps: 25 })
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "branch feat/x not found",
+    });
   });
 
   it("should reject unknown fields via .strict()", async () => {

--- a/packages/trpc/src/routers/sonarqube/procedures/getProjectIssues/index.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getProjectIssues/index.ts
@@ -2,15 +2,18 @@ import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createSonarQubeClient } from "../../../../clients/sonarqube/index.js";
 import { issuesQueryParamsSchema, issuesSearchResponseSchema } from "@my-project/shared";
+import { notFoundMessage } from "../../utils.js";
 
 /**
  * Paginated issue search for a SonarQube project (via `/api/issues/search`).
  *
- * `pullRequest?` is plumbed through `issuesQueryParamsSchema` so it reaches
- * Sonar as `&pullRequest=<id>` when supplied.
+ * `pullRequest?` / `branch?` are plumbed through `issuesQueryParamsSchema`
+ * so they reach Sonar as `&pullRequest=<id>` / `&branch=<name>` when
+ * supplied. The two are mutually exclusive at the SonarQube API layer;
+ * `issuesQueryParamsSchema` already rejects callers that send both.
  */
 export const getProjectIssuesProcedure = protectedProcedure
-  .input(issuesQueryParamsSchema.strict())
+  .input(issuesQueryParamsSchema)
   .output(issuesSearchResponseSchema)
   .query(async ({ input }) => {
     const sonarqubeClient = createSonarQubeClient();
@@ -27,9 +30,7 @@ export const getProjectIssuesProcedure = protectedProcedure
       if (error instanceof Error && /:\s*404\b/.test(error.message)) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: input.pullRequest
-            ? `pull request ${input.pullRequest} not found`
-            : `project ${input.componentKeys} not found`,
+          message: notFoundMessage(input.componentKeys, input.pullRequest, input.branch),
           cause: error,
         });
       }

--- a/packages/trpc/src/routers/sonarqube/procedures/getQualityGateDetails/index.test.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getQualityGateDetails/index.test.ts
@@ -36,7 +36,7 @@ describe("sonarqube.getQualityGateDetails", () => {
 
     expect(result.projectStatus.status).toBe("OK");
     expect(result.projectStatus.conditions).toHaveLength(1);
-    expect(mockGetQualityGateStatus).toHaveBeenCalledWith("my-service", undefined);
+    expect(mockGetQualityGateStatus).toHaveBeenCalledWith("my-service", { pullRequest: undefined, branch: undefined });
   });
 
   it("should return status=NONE verbatim on never-analyzed project", async () => {
@@ -56,10 +56,40 @@ describe("sonarqube.getQualityGateDetails", () => {
     const caller = createCaller(mockContext);
     await caller.sonarqube.getQualityGateDetails({ projectKey: "my-service", pullRequest: "123" });
 
-    expect(mockGetQualityGateStatus).toHaveBeenCalledWith("my-service", "123");
+    expect(mockGetQualityGateStatus).toHaveBeenCalledWith("my-service", { pullRequest: "123", branch: undefined });
   });
 
-  it("should omit pullRequest from upstream call when not supplied (UI regression)", async () => {
+  it("should forward branch when supplied", async () => {
+    mockGetQualityGateStatus.mockResolvedValueOnce({
+      projectStatus: { status: "OK", conditions: [] },
+    });
+
+    const caller = createCaller(mockContext);
+    await caller.sonarqube.getQualityGateDetails({ projectKey: "my-service", branch: "main" });
+
+    expect(mockGetQualityGateStatus).toHaveBeenCalledWith("my-service", { pullRequest: undefined, branch: "main" });
+  });
+
+  it("should throw NOT_FOUND with branch message on Sonar 404 (branch)", async () => {
+    mockGetQualityGateStatus.mockRejectedValueOnce(new Error("SonarQube API request failed: 404 Not Found"));
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.sonarqube.getQualityGateDetails({ projectKey: "my-service", branch: "feat/x" })
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "branch feat/x not found",
+    });
+  });
+
+  it("should reject pullRequest and branch at once", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.sonarqube.getQualityGateDetails({ projectKey: "my-service", pullRequest: "123", branch: "main" })
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+
+  it("should omit scope params from upstream call when not supplied (UI regression)", async () => {
     mockGetQualityGateStatus.mockResolvedValueOnce({
       projectStatus: { status: "OK", conditions: [] },
     });
@@ -67,7 +97,7 @@ describe("sonarqube.getQualityGateDetails", () => {
     const caller = createCaller(mockContext);
     await caller.sonarqube.getQualityGateDetails({ projectKey: "my-service" });
 
-    expect(mockGetQualityGateStatus.mock.calls[0][1]).toBeUndefined();
+    expect(mockGetQualityGateStatus.mock.calls[0][1]).toEqual({ pullRequest: undefined, branch: undefined });
   });
 
   it("should reject unknown fields via .strict()", async () => {

--- a/packages/trpc/src/routers/sonarqube/procedures/getQualityGateDetails/index.ts
+++ b/packages/trpc/src/routers/sonarqube/procedures/getQualityGateDetails/index.ts
@@ -2,30 +2,35 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createSonarQubeClient } from "../../../../clients/sonarqube/index.js";
-import { qualityGateStatusResponseSchema } from "@my-project/shared";
+import { qualityGateStatusResponseSchema, withScopeMutuallyExclusive } from "@my-project/shared";
+import { notFoundMessage } from "../../utils.js";
 
 /**
  * Fetches the quality gate status (overall + per-condition) for a project.
  *
- * When `pullRequest` is supplied, forwards `&pullRequest=<id>` to
- * `/api/qualitygates/project_status`.
+ * When `pullRequest` or `branch` is supplied, forwards the corresponding
+ * scope param to `/api/qualitygates/project_status`. The two are mutually
+ * exclusive at the SonarQube API layer.
  */
 export const getQualityGateDetailsProcedure = protectedProcedure
   .input(
-    z
-      .object({
-        projectKey: z.string().describe("SonarQube project key"),
-        pullRequest: z.string().optional().describe("Optional SonarQube pull-request id"),
-      })
-      .strict()
+    withScopeMutuallyExclusive(
+      z
+        .object({
+          projectKey: z.string().describe("SonarQube project key"),
+          pullRequest: z.string().min(1).optional().describe("Optional SonarQube pull-request id"),
+          branch: z.string().min(1).optional().describe("Optional SonarQube branch name"),
+        })
+        .strict()
+    )
   )
   .output(qualityGateStatusResponseSchema)
   .query(async ({ input }) => {
-    const { projectKey, pullRequest } = input;
+    const { projectKey, pullRequest, branch } = input;
     const sonarqubeClient = createSonarQubeClient();
 
     try {
-      const qgResponse = await sonarqubeClient.getQualityGateStatus(projectKey, pullRequest);
+      const qgResponse = await sonarqubeClient.getQualityGateStatus(projectKey, { pullRequest, branch });
       console.info(`[SonarQube] Quality gate status for ${projectKey}: ${qgResponse.projectStatus.status}`);
       return qgResponse;
     } catch (error) {
@@ -37,7 +42,7 @@ export const getQualityGateDetailsProcedure = protectedProcedure
       if (error instanceof Error && /:\s*404\b/.test(error.message)) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: pullRequest ? `pull request ${pullRequest} not found` : `project ${projectKey} not found`,
+          message: notFoundMessage(projectKey, pullRequest, branch),
           cause: error,
         });
       }

--- a/packages/trpc/src/routers/sonarqube/utils.ts
+++ b/packages/trpc/src/routers/sonarqube/utils.ts
@@ -1,0 +1,5 @@
+export const notFoundMessage = (projectKey: string, pullRequest?: string, branch?: string): string => {
+  if (pullRequest) return `pull request ${pullRequest} not found`;
+  if (branch) return `branch ${branch} not found`;
+  return `project ${projectKey} not found`;
+};


### PR DESCRIPTION
- Extend SonarQube procedures (getProject, getProjectIssues, getQualityGateDetails) to accept an optional `branch` alongside `pullRequest`, plumbed through to the SonarQube API.
- Introduce `SonarScope` ({ pullRequest?, branch? }) as the client-level scope selector; the two fields are mutually exclusive at the SonarQube API layer and validation rejects callers that send both.
- Extract shared `notFoundMessage` and `withScopeMutuallyExclusive` helpers so procedure error wording and scope refinement stay consistent across endpoints.
- Expose `branch` on the REST proxy endpoints (`/rest/v1/sonar/get`, `/gate`, issues search) so external callers can target a specific branch.
- Tighten scope inputs with `.min(1)` to reject empty strings before they reach Sonar.
