### PR TITLE
EPMDEDP-16730: feat: Add SCA REST endpoints with Dep-Track integration

### DIFF
--- a/apps/server/src/config/openapi.sca.test.ts
+++ b/apps/server/src/config/openapi.sca.test.ts
@@ -1,0 +1,365 @@
+// Integration tests for the four SCA REST routes registered by registerOpenApi:
+//   GET /rest/v1/sca/list
+//   GET /rest/v1/sca/get
+//   GET /rest/v1/sca/components
+//   GET /rest/v1/sca/findings
+//
+// Mocking strategy: `@my-project/trpc` is mocked at module level so that
+// `createCaller` returns a stub caller whose individual procedure methods can
+// be configured per-test. `createContext` is a no-op that returns an empty
+// object (the stub caller never actually reads the context).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { TRPCError } from "@trpc/server";
+import type { DBSessionStore } from "@/clients/db-session-store/index.js";
+
+// ---------------------------------------------------------------------------
+// Module mock — must be declared before any import that transitively imports
+// the real @my-project/trpc so Vitest can hoist it correctly.
+//
+// `vi.hoisted` runs before the vi.mock factory (which itself is hoisted to the
+// top of the file), so `stubCaller` is available when the factory closure
+// executes. Without vi.hoisted the closure would see an uninitialized binding.
+// ---------------------------------------------------------------------------
+
+const stubCaller = vi.hoisted(() => ({
+  dependencyTrack: {
+    getProjects: vi.fn(),
+    getProjectByNameAndVersion: vi.fn(),
+    getProjectMetrics: vi.fn(),
+    getComponents: vi.fn(),
+    getFindingsByProject: vi.fn(),
+  },
+  k8s: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("@my-project/trpc", async (importActual) => {
+  // Spread the real module so type-only re-exports (TRPCError, etc.) remain
+  // available; only replace the caller factory and context creator.
+  const actual = await importActual<typeof import("@my-project/trpc")>();
+  return {
+    ...actual,
+    createContext: vi.fn().mockReturnValue({}),
+    createCaller: vi.fn().mockReturnValue(stubCaller),
+  };
+});
+
+// Import AFTER mocks are declared so Vitest resolves the mocked module.
+import { registerOpenApi } from "./openapi.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// `registerOpenApi` accepts DBSessionStore (a concrete class). In tests we
+// never reach any code path that calls methods on the store because createCaller
+// is fully mocked, so a cast is safe here.
+const MOCK_SESSION_STORE = {
+  get: vi.fn(),
+  set: vi.fn(),
+  destroy: vi.fn(),
+  cleanup: vi.fn(),
+} as unknown as DBSessionStore;
+
+const MOCK_OIDC_CONFIG = {
+  issuerURL: "https://oidc.example.com",
+  clientID: "client-id",
+  clientSecret: "client-secret",
+  scope: "openid",
+  codeChallengeMethod: "S256",
+};
+
+function buildFastify(): FastifyInstance {
+  const app = Fastify({ logger: false });
+
+  // The routes read `req.session` inside buildCaller. createContext is mocked
+  // to return {} so the value is never consumed, but the property accessor must
+  // not throw. Fastify's `decorateRequest` with an object getter-setter covers
+  // this; `null` is not accepted by the typings, so we cast via unknown.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.decorateRequest("session", null as any);
+
+  registerOpenApi(app, {
+    sessionStore: MOCK_SESSION_STORE,
+    oidcConfig: MOCK_OIDC_CONFIG,
+    portalUrl: "http://localhost:8000",
+  });
+
+  return app;
+}
+
+/** A minimal DependencyTrack project fixture. */
+const MOCK_PROJECT = {
+  uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  name: "my-service",
+  version: "main",
+  metrics: {
+    critical: 0,
+    high: 1,
+    medium: 2,
+    low: 3,
+    unassigned: 0,
+    vulnerabilities: 6,
+    components: 42,
+  },
+};
+
+/** A minimal finding fixture. */
+function makeFinding(severity: string, name: string, vulnId: string) {
+  return {
+    component: { name },
+    vulnerability: { severity, vulnId, description: "desc" },
+    analysis: { isSuppressed: false },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /rest/v1/sca/list", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = buildFastify();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("happy path — returns items and totalCount from caller", async () => {
+    stubCaller.dependencyTrack.getProjects.mockResolvedValue({
+      projects: [MOCK_PROJECT],
+      totalCount: 1,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/list",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ items: unknown[]; totalCount: number }>();
+    expect(body.items).toHaveLength(1);
+    expect(body.totalCount).toBe(1);
+    expect(body.items[0]).toMatchObject({ uuid: MOCK_PROJECT.uuid });
+  });
+
+  it("returns 400 when pageNumber is not a positive integer", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/list?pageNumber=abc",
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ error: string }>();
+    expect(body.error).toMatch(/pageNumber/);
+  });
+});
+
+describe("GET /rest/v1/sca/get", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = buildFastify();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("happy path — returns project and latest metrics snapshot", async () => {
+    // k8s.get resolves branch from codebase CR
+    stubCaller.k8s.get.mockResolvedValue({
+      spec: { defaultBranch: "main" },
+    });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+    stubCaller.dependencyTrack.getProjectMetrics.mockResolvedValue([
+      { critical: 0, high: 0 },
+      { critical: 1, high: 2 },
+    ]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/get?codebase=my-service",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      status: string;
+      project: { uuid: string };
+      metrics: unknown;
+    }>();
+    expect(body.status).toBe("OK");
+    expect(body.project.uuid).toBe(MOCK_PROJECT.uuid);
+    // latestMetricsSnapshot returns the last element of the series
+    expect(body.metrics).toEqual({ critical: 1, high: 2 });
+  });
+
+  it("returns 400 when codebase query param is missing", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/get",
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ error: string }>();
+    expect(body.error).toMatch(/codebase/);
+  });
+
+  it("returns 503 when Dep-Track is not configured", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockRejectedValue(
+      new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "DEPENDENCY_TRACK_URL environment variable is not configured",
+        cause: { kind: "sca_not_configured", missing: "DEPENDENCY_TRACK_URL" },
+      })
+    );
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/get?codebase=my-service&branch=main",
+    });
+
+    expect(res.statusCode).toBe(503);
+    const body = res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+  });
+
+  it("returns 404 when codebase CR does not exist", async () => {
+    stubCaller.k8s.get.mockRejectedValue(
+      new TRPCError({ code: "NOT_FOUND", message: "not found" })
+    );
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/get?codebase=missing-svc",
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{ reason: string }>();
+    expect(body.reason).toBe("codebase_not_found");
+  });
+});
+
+describe("GET /rest/v1/sca/components", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = buildFastify();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("happy path — returns component list with totalCount", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+    stubCaller.dependencyTrack.getComponents.mockResolvedValue({
+      components: [{ uuid: "comp-1", name: "lodash", version: "4.17.21" }],
+      totalCount: 1,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&branch=main",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      status: string;
+      items: unknown[];
+      totalCount: number;
+    }>();
+    expect(body.status).toBe("OK");
+    expect(body.items).toHaveLength(1);
+    expect(body.totalCount).toBe(1);
+  });
+
+  it("returns 400 when codebase is missing", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/codebase/);
+  });
+
+  it("returns 400 when pageNumber is invalid", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&pageNumber=0",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/pageNumber/);
+  });
+});
+
+describe("GET /rest/v1/sca/findings", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = buildFastify();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("happy path — returns sorted findings with truncated flag", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+    stubCaller.dependencyTrack.getFindingsByProject.mockResolvedValue([
+      makeFinding("LOW", "axios", "CVE-2023-001"),
+      makeFinding("CRITICAL", "lodash", "CVE-2022-002"),
+    ]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/findings?codebase=my-service&branch=main",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      status: string;
+      items: Array<{ vulnerability: { severity: string } }>;
+      truncated: boolean;
+    }>();
+    expect(body.status).toBe("OK");
+    expect(body.truncated).toBe(false);
+    // CRITICAL should be sorted first
+    expect(body.items[0]?.vulnerability.severity).toBe("CRITICAL");
+  });
+
+  it("returns 400 when codebase is missing", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/findings",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/codebase/);
+  });
+});

--- a/apps/server/src/config/openapi.ts
+++ b/apps/server/src/config/openapi.ts
@@ -5,6 +5,18 @@ import {
   createContext,
   type RouterInput,
 } from "@my-project/trpc";
+import { k8sCodebaseConfig } from "@my-project/shared";
+import {
+  classifyBranchResolution,
+  clampPageSize,
+  isScaNotConfiguredError,
+  latestMetricsSnapshot,
+  parseBoolQuery,
+  sortFindings,
+  toZeroIndexedPage,
+  truncateFindings,
+  type ResolvedBranch,
+} from "./sca-helpers.js";
 import { TRPCError } from "@trpc/server";
 import { getHTTPStatusCodeFromError } from "@trpc/server/http";
 import { generateOpenApiDocument } from "trpc-to-openapi";
@@ -363,6 +375,304 @@ export function registerOpenApi(
       });
     } catch (error) {
       return handleTRPCError(error, res);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dependency-Track — view proxies for `krci sca`
+  // ---------------------------------------------------------------------------
+
+  // Attempt to classify a thrown error. TRPCErrors (e.g. UNAUTHORIZED) go
+  // through `handleTRPCError` so the caller gets the correct status. Any other
+  // error originating from the Dep-Track client is translated to 502 Bad
+  // Gateway; upstream-unconfigured TRPCErrors (INTERNAL_SERVER_ERROR whose
+  // message mentions the DT env vars) are translated to 503.
+  const handleScaError = (error: unknown, res: FastifyReply): never => {
+    if (isScaNotConfiguredError(error)) {
+      res.status(503).send({
+        error: {
+          code: "SERVICE_UNAVAILABLE",
+          message: "Dependency-Track integration is not configured",
+        },
+      });
+      throw error;
+    }
+    if (error instanceof TRPCError) {
+      return handleTRPCError(error, res);
+    }
+    // Non-TRPCError thrown from DT client (network / 5xx / timeout) → 502.
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Dependency-Track request failed";
+    res.status(502).send({ error: { code: "BAD_GATEWAY", message } });
+    throw error;
+  };
+
+  // Resolves the Dep-Track `version` value for a given codebase. When the
+  // caller supplies `branch`, that value is returned verbatim. When `branch`
+  // is empty/undefined, the Codebase CR is read via the same in-process
+  // caller the UI uses (`caller.k8s.get`) and `spec.defaultBranch` is
+  // returned. The Portal's default cluster/namespace come from the same env
+  // vars that power `caller.config.get()`, so the CLI does not need to know
+  // or send them.
+  async function resolveBranch(
+    caller: Awaited<ReturnType<typeof buildCaller>>,
+    codebase: string,
+    branch?: string
+  ): Promise<ResolvedBranch> {
+    const clusterName = process.env.DEFAULT_CLUSTER_NAME || "";
+    const namespace = process.env.DEFAULT_CLUSTER_NAMESPACE || "";
+
+    return classifyBranchResolution(branch, async () =>
+      caller.k8s.get({
+        clusterName,
+        namespace,
+        name: codebase,
+        resourceConfig: k8sCodebaseConfig,
+      })
+    );
+  }
+
+  function sendResolveBranchFailure(
+    res: FastifyReply,
+    failure: Extract<ResolvedBranch, { ok: false }>,
+    codebase: string
+  ) {
+    const body =
+      failure.reason === "codebase_not_found"
+        ? {
+            reason: failure.reason,
+            message: `Codebase '${codebase}' not found`,
+          }
+        : {
+            reason: failure.reason,
+            message: `Codebase '${codebase}' has no spec.defaultBranch configured`,
+          };
+    return res.code(404).send(body);
+  }
+
+  // GET /rest/v1/sca/list (protected) — proxies dependencyTrack.getProjects
+  fastify.get<{
+    Querystring: {
+      pageNumber?: string;
+      pageSize?: string;
+      searchTerm?: string;
+      onlyRoot?: "true" | "false";
+      excludeInactive?: "true" | "false";
+    };
+  }>("/rest/v1/sca/list", async (req, res) => {
+    try {
+      const { pageNumber, pageSize, searchTerm, onlyRoot, excludeInactive } =
+        req.query;
+      const parsedPageNumber = parsePositiveIntQuery(pageNumber);
+      const parsedPageSize = parsePositiveIntQuery(pageSize);
+      if (parsedPageNumber === "invalid") {
+        return res
+          .code(400)
+          .send({ error: "pageNumber must be a positive integer" });
+      }
+      if (parsedPageSize === "invalid") {
+        return res
+          .code(400)
+          .send({ error: "pageSize must be a positive integer" });
+      }
+
+      const caller = await buildCaller(req, res);
+      // CLI is 1-indexed (matches sonar). tRPC procedure is 0-indexed. Subtract 1.
+      // Clamp pageSize to the procedure ceiling.
+      const result = await caller.dependencyTrack.getProjects({
+        pageNumber: toZeroIndexedPage(parsedPageNumber),
+        pageSize: clampPageSize(parsedPageSize),
+        searchTerm: searchTerm || undefined,
+        onlyRoot: parseBoolQuery(onlyRoot) ?? true,
+        excludeInactive: parseBoolQuery(excludeInactive) ?? true,
+      });
+
+      return {
+        items: result.projects ?? [],
+        totalCount: result.totalCount ?? 0,
+      };
+    } catch (error) {
+      return handleScaError(error, res);
+    }
+  });
+
+  // GET /rest/v1/sca/get (protected) — proxies dependencyTrack.getProjectByNameAndVersion + getProjectMetrics
+  fastify.get<{
+    Querystring: {
+      codebase: string;
+      branch?: string;
+    };
+  }>("/rest/v1/sca/get", async (req, res) => {
+    try {
+      const { codebase, branch } = req.query;
+      if (!codebase) {
+        return res.code(400).send({ error: "codebase is required" });
+      }
+
+      const caller = await buildCaller(req, res);
+      const resolved = await resolveBranch(
+        caller,
+        codebase,
+        branch || undefined
+      );
+      if (!resolved.ok) {
+        return sendResolveBranchFailure(res, resolved, codebase);
+      }
+
+      const project = await caller.dependencyTrack.getProjectByNameAndVersion({
+        projectName: codebase,
+        defaultBranch: resolved.branch,
+      });
+
+      if (!project) {
+        return { status: "NONE" as const };
+      }
+
+      // `getProjectMetrics` returns a time series; the CLI wants the latest snapshot.
+      const series = await caller.dependencyTrack.getProjectMetrics({
+        uuid: project.uuid,
+      });
+      const latestMetrics = latestMetricsSnapshot(series);
+
+      return {
+        status: "OK" as const,
+        project: {
+          ...project,
+          version: resolved.branch,
+        },
+        metrics: latestMetrics,
+      };
+    } catch (error) {
+      return handleScaError(error, res);
+    }
+  });
+
+  // GET /rest/v1/sca/components (protected) — proxies dependencyTrack.getComponents
+  fastify.get<{
+    Querystring: {
+      codebase: string;
+      branch?: string;
+      pageNumber?: string;
+      pageSize?: string;
+      onlyOutdated?: "true" | "false";
+      onlyDirect?: "true" | "false";
+    };
+  }>("/rest/v1/sca/components", async (req, res) => {
+    try {
+      const {
+        codebase,
+        branch,
+        pageNumber,
+        pageSize,
+        onlyOutdated,
+        onlyDirect,
+      } = req.query;
+      if (!codebase) {
+        return res.code(400).send({ error: "codebase is required" });
+      }
+      const parsedPageNumber = parsePositiveIntQuery(pageNumber);
+      const parsedPageSize = parsePositiveIntQuery(pageSize);
+      if (parsedPageNumber === "invalid") {
+        return res
+          .code(400)
+          .send({ error: "pageNumber must be a positive integer" });
+      }
+      if (parsedPageSize === "invalid") {
+        return res
+          .code(400)
+          .send({ error: "pageSize must be a positive integer" });
+      }
+
+      const caller = await buildCaller(req, res);
+      const resolved = await resolveBranch(
+        caller,
+        codebase,
+        branch || undefined
+      );
+      if (!resolved.ok) {
+        return sendResolveBranchFailure(res, resolved, codebase);
+      }
+
+      const project = await caller.dependencyTrack.getProjectByNameAndVersion({
+        projectName: codebase,
+        defaultBranch: resolved.branch,
+      });
+
+      if (!project) {
+        return { status: "NONE" as const, items: [], totalCount: 0 };
+      }
+
+      const components = await caller.dependencyTrack.getComponents({
+        uuid: project.uuid,
+        pageNumber: toZeroIndexedPage(parsedPageNumber),
+        pageSize: clampPageSize(parsedPageSize),
+        onlyOutdated: parseBoolQuery(onlyOutdated),
+        onlyDirect: parseBoolQuery(onlyDirect),
+      });
+
+      return {
+        status: "OK" as const,
+        items: components.components ?? [],
+        totalCount: components.totalCount ?? 0,
+      };
+    } catch (error) {
+      return handleScaError(error, res);
+    }
+  });
+
+  // GET /rest/v1/sca/findings (protected) — proxies dependencyTrack.getFindingsByProject
+  fastify.get<{
+    Querystring: {
+      codebase: string;
+      branch?: string;
+      suppressed?: "true" | "false";
+      source?: string;
+    };
+  }>("/rest/v1/sca/findings", async (req, res) => {
+    try {
+      const { codebase, branch, suppressed, source } = req.query;
+      if (!codebase) {
+        return res.code(400).send({ error: "codebase is required" });
+      }
+
+      const caller = await buildCaller(req, res);
+      const resolved = await resolveBranch(
+        caller,
+        codebase,
+        branch || undefined
+      );
+      if (!resolved.ok) {
+        return sendResolveBranchFailure(res, resolved, codebase);
+      }
+
+      const project = await caller.dependencyTrack.getProjectByNameAndVersion({
+        projectName: codebase,
+        defaultBranch: resolved.branch,
+      });
+
+      if (!project) {
+        return { status: "NONE" as const, items: [], truncated: false };
+      }
+
+      const all = await caller.dependencyTrack.getFindingsByProject({
+        uuid: project.uuid,
+        suppressed: parseBoolQuery(suppressed),
+        source: source || undefined,
+      });
+
+      // Deterministic sort per spec §D10, then truncate at SCA_FINDINGS_MAX.
+      const sorted = sortFindings(all);
+      const { items, truncated } = truncateFindings(sorted);
+
+      return {
+        status: "OK" as const,
+        items,
+        truncated,
+      };
+    } catch (error) {
+      return handleScaError(error, res);
     }
   });
 

--- a/apps/server/src/config/sca-helpers.test.ts
+++ b/apps/server/src/config/sca-helpers.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+import {
+  classifyBranchResolution,
+  clampPageSize,
+  isScaNotConfiguredError,
+  latestMetricsSnapshot,
+  parseBoolQuery,
+  SCA_FINDINGS_MAX,
+  sortFindings,
+  toZeroIndexedPage,
+  truncateFindings,
+} from "./sca-helpers.js";
+
+describe("sortFindings", () => {
+  it("sorts severity desc then component name asc then vulnId asc", () => {
+    const input = [
+      {
+        component: { name: "c" },
+        vulnerability: { severity: "MEDIUM", vulnId: "CVE-1" },
+      },
+      {
+        component: { name: "a" },
+        vulnerability: { severity: "CRITICAL", vulnId: "CVE-2" },
+      },
+      {
+        component: { name: "a" },
+        vulnerability: { severity: "CRITICAL", vulnId: "CVE-1" },
+      },
+      {
+        component: { name: "b" },
+        vulnerability: { severity: "UNASSIGNED", vulnId: "CVE-1" },
+      },
+    ];
+    const sorted = sortFindings(input);
+    expect(
+      sorted.map(
+        (f) =>
+          `${f.vulnerability.severity}|${f.component.name}|${f.vulnerability.vulnId}`
+      )
+    ).toEqual([
+      "CRITICAL|a|CVE-1",
+      "CRITICAL|a|CVE-2",
+      "MEDIUM|c|CVE-1",
+      "UNASSIGNED|b|CVE-1",
+    ]);
+  });
+
+  it("treats unknown severities as lowest rank", () => {
+    const input = [
+      {
+        component: { name: "a" },
+        vulnerability: { severity: "WEIRD", vulnId: "X" },
+      },
+      {
+        component: { name: "a" },
+        vulnerability: { severity: "LOW", vulnId: "X" },
+      },
+    ];
+    expect(sortFindings(input)[0]?.vulnerability.severity).toBe("LOW");
+  });
+
+  it("does not mutate its input", () => {
+    const input = [
+      {
+        component: { name: "c" },
+        vulnerability: { severity: "LOW", vulnId: "Z" },
+      },
+      {
+        component: { name: "a" },
+        vulnerability: { severity: "HIGH", vulnId: "A" },
+      },
+    ];
+    const snapshot = JSON.stringify(input);
+    sortFindings(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+});
+
+describe("truncateFindings", () => {
+  it("passes through when under the cap", () => {
+    const small = Array.from({ length: 10 }, (_, i) => ({ id: i }));
+    const { items, truncated } = truncateFindings(small);
+    expect(items).toHaveLength(10);
+    expect(truncated).toBe(false);
+  });
+
+  it("caps at SCA_FINDINGS_MAX and flags truncated", () => {
+    const big = Array.from({ length: SCA_FINDINGS_MAX + 1 }, (_, i) => ({
+      id: i,
+    }));
+    const { items, truncated } = truncateFindings(big);
+    expect(items).toHaveLength(SCA_FINDINGS_MAX);
+    expect(truncated).toBe(true);
+  });
+
+  it("keeps the first SCA_FINDINGS_MAX rows (stable slice)", () => {
+    const big = Array.from({ length: SCA_FINDINGS_MAX + 5 }, (_, i) => ({
+      id: i,
+    }));
+    const { items } = truncateFindings(big);
+    expect(items[0]).toEqual({ id: 0 });
+    expect(items[items.length - 1]).toEqual({ id: SCA_FINDINGS_MAX - 1 });
+  });
+});
+
+describe("toZeroIndexedPage", () => {
+  it("passes through undefined", () => {
+    expect(toZeroIndexedPage(undefined)).toBeUndefined();
+  });
+
+  it("subtracts 1 for positive values", () => {
+    expect(toZeroIndexedPage(1)).toBe(0);
+    expect(toZeroIndexedPage(3)).toBe(2);
+  });
+
+  it("clamps non-positive inputs to 0 (defensive)", () => {
+    expect(toZeroIndexedPage(0)).toBe(0);
+    expect(toZeroIndexedPage(-5)).toBe(0);
+  });
+});
+
+describe("clampPageSize", () => {
+  it("passes through undefined", () => {
+    expect(clampPageSize(undefined)).toBeUndefined();
+  });
+
+  it("clamps values above max to max", () => {
+    expect(clampPageSize(500)).toBe(100);
+  });
+
+  it("leaves values at or below max unchanged", () => {
+    expect(clampPageSize(50)).toBe(50);
+    expect(clampPageSize(100)).toBe(100);
+  });
+});
+
+describe("latestMetricsSnapshot", () => {
+  it("returns the last element of a non-empty series", () => {
+    expect(latestMetricsSnapshot([1, 2, 3])).toBe(3);
+  });
+
+  it("returns undefined for empty or missing series", () => {
+    expect(latestMetricsSnapshot([])).toBeUndefined();
+    expect(latestMetricsSnapshot(undefined)).toBeUndefined();
+  });
+});
+
+describe("parseBoolQuery", () => {
+  it("recognises literal true/false", () => {
+    expect(parseBoolQuery("true")).toBe(true);
+    expect(parseBoolQuery("false")).toBe(false);
+  });
+
+  it("returns undefined for anything else", () => {
+    expect(parseBoolQuery(undefined)).toBeUndefined();
+    expect(parseBoolQuery("")).toBeUndefined();
+    expect(parseBoolQuery("yes")).toBeUndefined();
+    expect(parseBoolQuery("1")).toBeUndefined();
+  });
+});
+
+describe("classifyBranchResolution", () => {
+  it("returns the explicit branch verbatim without fetching", async () => {
+    let fetched = false;
+    const result = await classifyBranchResolution("release/1.0", async () => {
+      fetched = true;
+      return null;
+    });
+    expect(result).toEqual({ ok: true, branch: "release/1.0" });
+    expect(fetched).toBe(false);
+  });
+
+  it("reads spec.defaultBranch when branch is omitted", async () => {
+    const result = await classifyBranchResolution(undefined, async () => ({
+      spec: { defaultBranch: "develop" },
+    }));
+    expect(result).toEqual({ ok: true, branch: "develop" });
+  });
+
+  it("returns codebase_not_found when fetcher returns null", async () => {
+    const result = await classifyBranchResolution(undefined, async () => null);
+    expect(result).toEqual({ ok: false, reason: "codebase_not_found" });
+  });
+
+  it("returns codebase_not_found on NOT_FOUND TRPCError", async () => {
+    const result = await classifyBranchResolution(undefined, async () => {
+      throw new TRPCError({ code: "NOT_FOUND", message: "nope" });
+    });
+    expect(result).toEqual({ ok: false, reason: "codebase_not_found" });
+  });
+
+  it("returns default_branch_missing when spec.defaultBranch is empty string", async () => {
+    const result = await classifyBranchResolution(undefined, async () => ({
+      spec: { defaultBranch: "" },
+    }));
+    expect(result).toEqual({ ok: false, reason: "default_branch_missing" });
+  });
+
+  it("returns default_branch_missing when spec.defaultBranch is missing", async () => {
+    const result = await classifyBranchResolution(undefined, async () => ({
+      spec: {},
+    }));
+    expect(result).toEqual({ ok: false, reason: "default_branch_missing" });
+  });
+
+  it("returns default_branch_missing when resource has no spec", async () => {
+    const result = await classifyBranchResolution(undefined, async () => ({}));
+    expect(result).toEqual({ ok: false, reason: "default_branch_missing" });
+  });
+
+  it("re-throws non-NOT_FOUND errors", async () => {
+    await expect(
+      classifyBranchResolution(undefined, async () => {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "upstream exploded",
+        });
+      })
+    ).rejects.toThrow("upstream exploded");
+  });
+});
+
+describe("isScaNotConfiguredError", () => {
+  it("returns true for DEPENDENCY_TRACK_URL cause discriminator", () => {
+    const err = new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "DEPENDENCY_TRACK_URL environment variable is not configured",
+      cause: { kind: "sca_not_configured", missing: "DEPENDENCY_TRACK_URL" },
+    });
+    expect(isScaNotConfiguredError(err)).toBe(true);
+  });
+
+  it("returns true for DEPENDENCY_TRACK_API_KEY cause discriminator", () => {
+    const err = new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message:
+        "DEPENDENCY_TRACK_API_KEY environment variable is not configured",
+      cause: {
+        kind: "sca_not_configured",
+        missing: "DEPENDENCY_TRACK_API_KEY",
+      },
+    });
+    expect(isScaNotConfiguredError(err)).toBe(true);
+  });
+
+  it("returns false for INTERNAL_SERVER_ERROR without the cause discriminator", () => {
+    // An unrelated INTERNAL_SERVER_ERROR must not be classified as 503.
+    const err = new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "DEPENDENCY_TRACK_URL environment variable is not configured",
+    });
+    expect(isScaNotConfiguredError(err)).toBe(false);
+  });
+
+  it("returns false when cause.kind differs", () => {
+    const err = new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "some other config error",
+      cause: { kind: "other_error" },
+    });
+    expect(isScaNotConfiguredError(err)).toBe(false);
+  });
+
+  it("rejects unrelated TRPCErrors", () => {
+    const err = new TRPCError({ code: "UNAUTHORIZED", message: "auth" });
+    expect(isScaNotConfiguredError(err)).toBe(false);
+  });
+
+  it("rejects plain Errors and non-errors", () => {
+    expect(
+      isScaNotConfiguredError(
+        new Error("DEPENDENCY_TRACK_URL is not configured")
+      )
+    ).toBe(false);
+    expect(isScaNotConfiguredError(undefined)).toBe(false);
+    expect(isScaNotConfiguredError("boom")).toBe(false);
+  });
+});

--- a/apps/server/src/config/sca-helpers.ts
+++ b/apps/server/src/config/sca-helpers.ts
@@ -1,0 +1,147 @@
+// Pure helpers for the `/rest/v1/sca/*` routes. Kept in a sibling module so
+// they can be unit-tested without spinning up Fastify; the routes in
+// `openapi.ts` delegate to these functions.
+
+import { TRPCError } from "@trpc/server";
+
+/** Dep-Track-native severity rank for deterministic sort (HIGH value = more severe). */
+const SCA_SEVERITY_RANK: Record<string, number> = {
+  CRITICAL: 5,
+  HIGH: 4,
+  MEDIUM: 3,
+  LOW: 2,
+  INFO: 1,
+  UNASSIGNED: 0,
+};
+
+/** Upper bound on the findings response; upstream is unpaginated. */
+export const SCA_FINDINGS_MAX = 1000;
+
+/** Upper bound on the components / list pageSize (matches current tRPC procedure ceiling). */
+const SCA_PAGE_SIZE_MAX = 100;
+
+/**
+ * Sort findings by severity desc, component.name asc, vulnerability.vulnId asc.
+ * Pure; operates on a shallow copy of the input.
+ */
+export function sortFindings<
+  T extends {
+    vulnerability: { severity: string; vulnId: string };
+    component: { name: string };
+  },
+>(findings: readonly T[]): T[] {
+  return [...findings].sort((a, b) => {
+    const sa = SCA_SEVERITY_RANK[a.vulnerability.severity] ?? -1;
+    const sb = SCA_SEVERITY_RANK[b.vulnerability.severity] ?? -1;
+    if (sa !== sb) return sb - sa;
+
+    const na = a.component.name ?? "";
+    const nb = b.component.name ?? "";
+    if (na !== nb) return na < nb ? -1 : 1;
+
+    const va = a.vulnerability.vulnId ?? "";
+    const vb = b.vulnerability.vulnId ?? "";
+    return va < vb ? -1 : va > vb ? 1 : 0;
+  });
+}
+
+/**
+ * Cap findings at SCA_FINDINGS_MAX. Returns the (possibly sliced) array and a
+ * flag indicating whether truncation occurred.
+ */
+export function truncateFindings<T>(findings: readonly T[]): {
+  items: T[];
+  truncated: boolean;
+} {
+  if (findings.length > SCA_FINDINGS_MAX) {
+    return { items: findings.slice(0, SCA_FINDINGS_MAX), truncated: true };
+  }
+  return { items: findings as T[], truncated: false };
+}
+
+/** Translate a CLI 1-indexed page number to the 0-indexed form expected by the tRPC procedure. */
+export function toZeroIndexedPage(
+  oneIndexed: number | undefined
+): number | undefined {
+  if (oneIndexed === undefined) return undefined;
+  return Math.max(0, oneIndexed - 1);
+}
+
+/** Clamp a user-supplied pageSize to the procedure ceiling. */
+export function clampPageSize(
+  requested: number | undefined,
+  max: number = SCA_PAGE_SIZE_MAX
+): number | undefined {
+  if (requested === undefined) return undefined;
+  return Math.min(requested, max);
+}
+
+/** Return the latest snapshot from a Dep-Track metrics time series, or undefined when empty. */
+export function latestMetricsSnapshot<T>(
+  series: readonly T[] | undefined
+): T | undefined {
+  if (!Array.isArray(series) || series.length === 0) return undefined;
+  return series[series.length - 1];
+}
+
+/** "true"/"false" query-string values → boolean; any other value → undefined. */
+export function parseBoolQuery(raw: string | undefined): boolean | undefined {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return undefined;
+}
+
+export type ResolvedBranch =
+  | { ok: true; branch: string }
+  | { ok: false; reason: "codebase_not_found" | "default_branch_missing" };
+
+/**
+ * Classify the branch-resolution outcome given the caller's branch input and
+ * the Codebase resource fetch result. Split out from `openapi.ts` so the
+ * branch-resolution decision tree can be unit-tested without the K8s layer.
+ */
+export async function classifyBranchResolution(
+  branch: string | undefined,
+  fetchResource: () => Promise<{ spec?: unknown } | null>
+): Promise<ResolvedBranch> {
+  if (branch) {
+    return { ok: true, branch };
+  }
+
+  let resource: { spec?: unknown } | null;
+  try {
+    resource = await fetchResource();
+  } catch (error) {
+    if (error instanceof TRPCError && error.code === "NOT_FOUND") {
+      return { ok: false, reason: "codebase_not_found" };
+    }
+    throw error;
+  }
+
+  if (!resource) {
+    return { ok: false, reason: "codebase_not_found" };
+  }
+  const spec = resource.spec as { defaultBranch?: unknown } | null | undefined;
+  const defaultBranch = spec?.defaultBranch;
+  if (typeof defaultBranch !== "string" || defaultBranch === "") {
+    return { ok: false, reason: "default_branch_missing" };
+  }
+  return { ok: true, branch: defaultBranch };
+}
+
+/**
+ * Matches the "Dep-Track env var X is not configured" TRPCError emitted by
+ * `createDependencyTrackClient()`. Used by the REST handlers to translate that
+ * specific INTERNAL_SERVER_ERROR into HTTP 503 Service Unavailable.
+ *
+ * Detection strategy: check the typed `cause.kind` discriminator attached to
+ * the error at throw-site. The regex fallback is intentionally removed — it was
+ * fragile and tied to message text. Any older callers that relied on the regex
+ * now use the same structured cause path since both throw-sites were updated.
+ */
+export function isScaNotConfiguredError(error: unknown): boolean {
+  if (!(error instanceof TRPCError)) return false;
+  if (error.code !== "INTERNAL_SERVER_ERROR") return false;
+  const cause = error.cause as Record<string, unknown> | null | undefined;
+  return cause?.kind === "sca_not_configured";
+}

--- a/packages/trpc/src/clients/dependencyTrack/index.test.ts
+++ b/packages/trpc/src/clients/dependencyTrack/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { TRPCError } from "@trpc/server";
 import { DependencyTrackClient } from "./index.js";
 
 const originalEnv = process.env;
@@ -20,12 +21,57 @@ describe("createDependencyTrackClient", () => {
     expect(() => createDependencyTrackClient()).toThrow("DEPENDENCY_TRACK_URL");
   });
 
+  it("attaches sca_not_configured cause when DEPENDENCY_TRACK_URL is missing", async () => {
+    delete process.env.DEPENDENCY_TRACK_URL;
+    const { createDependencyTrackClient } = await import("./index.js");
+
+    let caught: unknown;
+    try {
+      createDependencyTrackClient();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(TRPCError);
+    const trpcErr = caught as TRPCError;
+    expect(trpcErr.code).toBe("INTERNAL_SERVER_ERROR");
+    // TRPCError wraps plain objects in an UnknownCauseError instance, so use
+    // objectContaining rather than a deep-equality check on the constructor.
+    expect(trpcErr.cause).toMatchObject({
+      kind: "sca_not_configured",
+      missing: "DEPENDENCY_TRACK_URL",
+    });
+  });
+
   it("should throw when DEPENDENCY_TRACK_API_KEY is not set", async () => {
     process.env.DEPENDENCY_TRACK_URL = "https://dt.example.com";
     delete process.env.DEPENDENCY_TRACK_API_KEY;
     const { createDependencyTrackClient } = await import("./index.js");
 
     expect(() => createDependencyTrackClient()).toThrow("DEPENDENCY_TRACK_API_KEY");
+  });
+
+  it("attaches sca_not_configured cause when DEPENDENCY_TRACK_API_KEY is missing", async () => {
+    process.env.DEPENDENCY_TRACK_URL = "https://dt.example.com";
+    delete process.env.DEPENDENCY_TRACK_API_KEY;
+    const { createDependencyTrackClient } = await import("./index.js");
+
+    let caught: unknown;
+    try {
+      createDependencyTrackClient();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(TRPCError);
+    const trpcErr = caught as TRPCError;
+    expect(trpcErr.code).toBe("INTERNAL_SERVER_ERROR");
+    // TRPCError wraps plain objects in an UnknownCauseError instance, so use
+    // objectContaining rather than a deep-equality check on the constructor.
+    expect(trpcErr.cause).toMatchObject({
+      kind: "sca_not_configured",
+      missing: "DEPENDENCY_TRACK_API_KEY",
+    });
   });
 
   it("should return client when env is configured", async () => {

--- a/packages/trpc/src/clients/dependencyTrack/index.ts
+++ b/packages/trpc/src/clients/dependencyTrack/index.ts
@@ -66,6 +66,7 @@ export function createDependencyTrackClient(): DependencyTrackClient {
     throw new TRPCError({
       code: "INTERNAL_SERVER_ERROR",
       message: "DEPENDENCY_TRACK_URL environment variable is not configured",
+      cause: { kind: "sca_not_configured", missing: "DEPENDENCY_TRACK_URL" },
     });
   }
 
@@ -73,6 +74,7 @@ export function createDependencyTrackClient(): DependencyTrackClient {
     throw new TRPCError({
       code: "INTERNAL_SERVER_ERROR",
       message: "DEPENDENCY_TRACK_API_KEY environment variable is not configured",
+      cause: { kind: "sca_not_configured", missing: "DEPENDENCY_TRACK_API_KEY" },
     });
   }
 


### PR DESCRIPTION
Add REST endpoints that proxy to tRPC procedures for software composition analysis operations, integrating with Dependency-Track. Includes:

- Pure helper functions for findings sorting by severity, truncation, pagination, and branch resolution
- REST route handlers that delegate to tRPC procedures via createCaller
- Comprehensive unit tests for all helper functions
- Proper error handling for SCA configuration and TRPCError translation

The REST API contract mirrors the tRPC procedures but uses hand-written routes due to incompatibility between fastifyTRPCOpenApiPlugin and tRPC v11. The helper module is separated to enable unit testing without spinning up Fastify.
