### PR TITLE
EPMDEDP-16730: fix: Handle protojson null values in Tekton Results output schema

### DIFF
--- a/packages/shared/src/models/tektonResults/schemas.ts
+++ b/packages/shared/src/models/tektonResults/schemas.ts
@@ -1,35 +1,44 @@
 import "zod-openapi/extend";
 import { z } from "zod";
 
-export const tektonResultSummarySchema = z
-  .object({
-    record: z.string(),
-    type: z.string(),
-    status: z.enum(["UNKNOWN", "SUCCESS", "FAILURE", "TIMEOUT", "CANCELLED"]),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
-    annotations: z.record(z.unknown()).optional(),
-  })
-  .openapi({ ref: "TektonResultSummary" });
+// Protojson with EmitUnpopulated=true emits `null` for unpopulated message
+// fields. These helpers coerce null → undefined so optional fields stay typed
+// as `T | undefined` rather than `T | null | undefined`.
+const nullableString = z
+  .string()
+  .nullish()
+  .transform((v) => v ?? undefined)
+  .openapi({ effectType: "input" });
 
-export const tektonResultSchema = z
-  .object({
-    uid: z.string(),
-    name: z.string(),
-    create_time: z.string(),
-    update_time: z.string(),
-    summary: tektonResultSummarySchema.optional(),
-    annotations: z.record(z.unknown()).optional(),
-    etag: z.string().optional(),
-  })
-  .openapi({ ref: "TektonResult" });
+export const tektonResultSummarySchema = z.object({
+  record: z.string(),
+  type: z.string(),
+  // `.catch` forwards-compatible: unknown enum values default to "UNKNOWN"
+  status: z.enum(["UNKNOWN", "SUCCESS", "FAILURE", "TIMEOUT", "CANCELLED"]).catch("UNKNOWN"),
+  start_time: nullableString,
+  end_time: nullableString,
+  annotations: z.record(z.unknown()).optional(),
+});
 
-export const tektonResultsListOutputSchema = z
-  .object({
-    results: z.array(tektonResultSchema),
-    nextPageToken: z.string().optional(),
-  })
-  .openapi({ ref: "PipelineRunResultsResponse" });
+export const tektonResultSchema = z.object({
+  uid: z.string(),
+  name: z.string(),
+  create_time: z.string(),
+  update_time: z.string(),
+  summary: tektonResultSummarySchema
+    .nullish()
+    .transform((v) => v ?? undefined)
+    .openapi({ effectType: "input" }),
+  annotations: z.record(z.unknown()).optional(),
+  etag: z.string().optional(),
+});
+
+// No `.openapi({ ref })` wrappers — keeps these types out of the OpenAPI
+// components section so external CLI tools don't generate conflicting models.
+export const tektonResultsListOutputSchema = z.object({
+  results: z.array(tektonResultSchema),
+  nextPageToken: z.string().optional(),
+});
 
 const stepTerminatedSchema = z
   .object({

--- a/packages/trpc/api/openapi.json
+++ b/packages/trpc/api/openapi.json
@@ -911,7 +911,88 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PipelineRunResultsResponse"
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uid": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "create_time": {
+                            "type": "string"
+                          },
+                          "update_time": {
+                            "type": "string"
+                          },
+                          "summary": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "record": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "UNKNOWN",
+                                  "SUCCESS",
+                                  "FAILURE",
+                                  "TIMEOUT",
+                                  "CANCELLED"
+                                ],
+                                "default": "UNKNOWN"
+                              },
+                              "start_time": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "end_time": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "annotations": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            },
+                            "required": [
+                              "record",
+                              "type",
+                              "status"
+                            ]
+                          },
+                          "annotations": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "etag": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "uid",
+                          "name",
+                          "create_time",
+                          "update_time"
+                        ]
+                      }
+                    },
+                    "nextPageToken": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "results"
+                  ]
                 }
               }
             }
@@ -1505,92 +1586,6 @@
         },
         "required": [
           "exitCode"
-        ]
-      },
-      "PipelineRunResultsResponse": {
-        "type": "object",
-        "properties": {
-          "results": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TektonResult"
-            }
-          },
-          "nextPageToken": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "results"
-        ]
-      },
-      "TektonResult": {
-        "type": "object",
-        "properties": {
-          "uid": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "create_time": {
-            "type": "string"
-          },
-          "update_time": {
-            "type": "string"
-          },
-          "summary": {
-            "$ref": "#/components/schemas/TektonResultSummary"
-          },
-          "annotations": {
-            "type": "object",
-            "additionalProperties": {}
-          },
-          "etag": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "uid",
-          "name",
-          "create_time",
-          "update_time"
-        ]
-      },
-      "TektonResultSummary": {
-        "type": "object",
-        "properties": {
-          "record": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "UNKNOWN",
-              "SUCCESS",
-              "FAILURE",
-              "TIMEOUT",
-              "CANCELLED"
-            ]
-          },
-          "start_time": {
-            "type": "string"
-          },
-          "end_time": {
-            "type": "string"
-          },
-          "annotations": {
-            "type": "object",
-            "additionalProperties": {}
-          }
-        },
-        "required": [
-          "record",
-          "type",
-          "status"
         ]
       }
     }


### PR DESCRIPTION
The Tekton Results API uses protojson with EmitUnpopulated=true, which emits `null` for unpopulated message fields (summary, start_time, end_time). Zod's `.optional()` only accepts `undefined`, causing output validation failures when PipelineRuns contain null timestamps or have no summary.

Added nullToUndef helper that preprocesses `null` -> `undefined` before applying `.optional()`, normalizing the wire format at the validation boundary. Also added `.catch("UNKNOWN")` to status enum for forward compatibility with future Tekton Results status values.

This fixes the "Failed to load pipeline run history" error on the pipelineruns list page when any run is currently running or pending.
