### PR TITLE
EPMDEDP-16730: feat(sca): Implement server-side severity filtering with auto-paging and cancellation

### DIFF
--- a/apps/server/src/config/development/index.ts
+++ b/apps/server/src/config/development/index.ts
@@ -35,7 +35,13 @@ export class LocalFastifyServer {
       "TEKTON_RESULTS_URL",
     ]);
 
-    this.fastify = Fastify({ logger: false, maxParamLength: 5000 });
+    this.fastify = Fastify({
+      logger: false,
+      maxParamLength: 5000,
+      // Mirror prod's requestTimeout so dev/prod divergence doesn't mask handler
+      // deadline bugs. 30 s matches the production ceiling; CLI timeout is 45 s.
+      requestTimeout: 30_000,
+    });
   }
 
   static validateRequiredEnv(keys: string[]) {

--- a/apps/server/src/config/openapi.sca.test.ts
+++ b/apps/server/src/config/openapi.sca.test.ts
@@ -16,6 +16,7 @@ import type { DBSessionStore } from "@/clients/db-session-store/index.js";
 import { createMockedDBSessionStore } from "@my-project/trpc/__mocks__/context.js";
 import { mockSession } from "@my-project/trpc/__mocks__/session.js";
 import type { CustomSession } from "@my-project/trpc";
+import { SCA_PAGE_SIZE_MAX_PAGES } from "./sca-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Module mock — must be declared before any import that transitively imports
@@ -310,6 +311,305 @@ describe("GET /rest/v1/sca/components", () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.json<{ error: string }>().error).toMatch(/pageNumber/);
+  });
+
+  it("returns 400 when severity is malformed", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&severity=garbage",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(
+      /CRITICAL\|HIGH\|MEDIUM\|LOW\|INFO\|UNASSIGNED/
+    );
+  });
+
+  it("severity absent → exactly one upstream getComponents call", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+    stubCaller.dependencyTrack.getComponents.mockResolvedValue({
+      components: [{ uuid: "c", name: "axios", version: "1.0" }],
+      totalCount: 42,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(stubCaller.dependencyTrack.getComponents).toHaveBeenCalledTimes(1);
+    expect(res.json<{ totalCount: number }>().totalCount).toBe(42);
+  });
+
+  it("severity filter matches across multiple upstream pages", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+
+    const zeroes = { critical: 0, high: 0, medium: 0, low: 0, unassigned: 0 };
+    const page0 = Array.from({ length: 100 }, (_, i) => ({
+      uuid: `p0-${i}`,
+      name: `pkg0-${i}`,
+      version: "1.0",
+      metrics: { ...zeroes, medium: 1 },
+    }));
+    // Match at index 17 in the second page — after the 100-row upstream page.
+    const page1 = Array.from({ length: 20 }, (_, i) => ({
+      uuid: `p1-${i}`,
+      name: `pkg1-${i}`,
+      version: "1.0",
+      metrics: i === 17 ? { ...zeroes, high: 2 } : { ...zeroes, low: 1 },
+    }));
+
+    stubCaller.dependencyTrack.getComponents
+      .mockResolvedValueOnce({ components: page0, totalCount: 120 })
+      .mockResolvedValueOnce({ components: page1, totalCount: 120 });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&severity=HIGH",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(stubCaller.dependencyTrack.getComponents).toHaveBeenCalledTimes(2);
+    const body = res.json<{
+      status: string;
+      items: Array<{ uuid: string }>;
+      totalCount: number;
+    }>();
+    expect(body.status).toBe("OK");
+    expect(body.totalCount).toBe(1);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]?.uuid).toBe("p1-17");
+    expect(res.json<{ truncated: boolean }>().truncated).toBe(false);
+  });
+
+  it("severity filter with NONE project → no upstream getComponents call", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      null
+    );
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&severity=HIGH",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(stubCaller.dependencyTrack.getComponents).not.toHaveBeenCalled();
+    expect(
+      res.json<{
+        status: string;
+        items: unknown[];
+        totalCount: number;
+        truncated: boolean;
+      }>()
+    ).toEqual({ status: "NONE", items: [], totalCount: 0, truncated: false });
+  });
+
+  it("severity filter with zero matches returns empty OK payload", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+
+    const zeroes = { critical: 0, high: 0, medium: 0, low: 0, unassigned: 0 };
+    stubCaller.dependencyTrack.getComponents.mockResolvedValueOnce({
+      components: [
+        { uuid: "a", name: "a", version: "1", metrics: { ...zeroes, low: 2 } },
+      ],
+      totalCount: 1,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&severity=HIGH,CRITICAL",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(
+      res.json<{
+        status: string;
+        items: unknown[];
+        totalCount: number;
+        truncated: boolean;
+      }>()
+    ).toEqual({ status: "OK", items: [], totalCount: 0, truncated: false });
+  });
+
+  it("safety-cap truncation surfaces on the wire — truncated: true", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+
+    // Upstream always returns one HIGH component but claims 10_000 total rows.
+    // The loop must exhaust SCA_PAGE_SIZE_MAX_PAGES iterations and set truncated.
+    const zeroes = { critical: 0, high: 0, medium: 0, low: 0, unassigned: 0 };
+    stubCaller.dependencyTrack.getComponents.mockResolvedValue({
+      components: [
+        {
+          uuid: "high-1",
+          name: "evil-pkg",
+          version: "1.0",
+          metrics: { ...zeroes, high: 1 },
+        },
+      ],
+      totalCount: 10_000,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&severity=HIGH",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ truncated: boolean; items: unknown[] }>();
+    expect(body.truncated).toBe(true);
+    // getComponents must have been called exactly SCA_PAGE_SIZE_MAX_PAGES times.
+    expect(stubCaller.dependencyTrack.getComponents).toHaveBeenCalledTimes(
+      SCA_PAGE_SIZE_MAX_PAGES
+    );
+  });
+
+  it("severity filter paginates AFTER filtering", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+
+    const zeroes = { critical: 0, high: 0, medium: 0, low: 0, unassigned: 0 };
+    // 70 matching HIGH components in one upstream batch.
+    const page0 = Array.from({ length: 70 }, (_, i) => ({
+      uuid: `u-${i}`,
+      name: `p-${String(i).padStart(2, "0")}`,
+      version: "1.0",
+      metrics: { ...zeroes, high: 1 },
+    }));
+    stubCaller.dependencyTrack.getComponents.mockResolvedValueOnce({
+      components: page0,
+      totalCount: 70,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&severity=HIGH&pageNumber=2&pageSize=50",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      items: Array<{ uuid: string }>;
+      totalCount: number;
+    }>();
+    expect(body.totalCount).toBe(70);
+    expect(body.items).toHaveLength(20); // rows 51..70
+    expect(body.items[0]?.uuid).toBe("u-50");
+    expect(body.items.at(-1)?.uuid).toBe("u-69");
+  });
+});
+
+describe("GET /rest/v1/sca/components — request abort cancels severity loop", () => {
+  // These tests need to capture req.raw from inside a live Fastify request so
+  // they can emit 'close' mid-iteration and verify the loop stops. A dedicated
+  // Fastify instance is used to attach an onRequest hook that exposes the raw
+  // Node IncomingMessage reference.
+
+  let app: FastifyInstance;
+  let capturedRaw: import("http").IncomingMessage | null = null;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    capturedRaw = null;
+
+    app = Fastify({ logger: false });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    app.decorateRequest("session", null as any);
+
+    // Capture req.raw before the route handler runs so the stub can emit
+    // 'close' on the underlying stream to trigger req.signal abortion.
+    app.addHook("onRequest", async (req) => {
+      capturedRaw = req.raw;
+      // Access req.signal to force Fastify to attach the AbortController listener
+      // on req.raw. Without this the lazy getter never wires up the 'close' → abort.
+      void req.signal;
+    });
+
+    registerOpenApi(app, {
+      sessionStore: MOCK_SESSION_STORE,
+      oidcConfig: MOCK_OIDC_CONFIG,
+      portalUrl: "http://localhost:8000",
+    });
+
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("emitting close on req.raw after page 1 stops further getComponents calls", async () => {
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
+
+    const zeroes = { critical: 0, high: 0, medium: 0, low: 0, unassigned: 0 };
+
+    // On the first call: resolve normally, then emit 'close' to simulate client disconnect.
+    stubCaller.dependencyTrack.getComponents.mockImplementationOnce(
+      async () => {
+        const result = {
+          components: [
+            {
+              uuid: "high-1",
+              name: "evil-pkg",
+              version: "1.0",
+              metrics: { ...zeroes, high: 1 },
+            },
+          ],
+          totalCount: 10_000, // large enough to keep looping
+        };
+        // Emit 'close' synchronously after resolving so the signal is aborted
+        // before the next iteration's pre-flight check fires.
+        if (capturedRaw) {
+          capturedRaw.emit("close");
+        }
+        return result;
+      }
+    );
+
+    // Subsequent calls should never be reached because the loop aborts.
+    stubCaller.dependencyTrack.getComponents.mockResolvedValue({
+      components: [
+        {
+          uuid: "high-2",
+          name: "another-pkg",
+          version: "2.0",
+          metrics: { ...zeroes, high: 1 },
+        },
+      ],
+      totalCount: 10_000,
+    });
+
+    // The handler will reject/throw due to AbortError — Fastify maps it to a
+    // non-2xx status. We only care that getComponents was called once.
+    await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/components?codebase=my-service&severity=HIGH",
+    });
+
+    // The loop must have stopped after the first call — abort fired before page 2.
+    expect(stubCaller.dependencyTrack.getComponents).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/server/src/config/openapi.ts
+++ b/apps/server/src/config/openapi.ts
@@ -9,9 +9,15 @@ import { k8sCodebaseConfig } from "@my-project/shared";
 import {
   classifyBranchResolution,
   clampPageSize,
+  componentMatchesSeverity,
+  fetchAllComponents,
   isScaNotConfiguredError,
   latestMetricsSnapshot,
+  paginate,
   parseBoolQuery,
+  parseSeverityCsv,
+  SCA_PAGE_SIZE_MAX,
+  SCA_PAGE_SIZE_MAX_PAGES,
   sortFindings,
   toZeroIndexedPage,
   truncateFindings,
@@ -23,6 +29,20 @@ import { generateOpenApiDocument } from "trpc-to-openapi";
 import { STATUS_CODES } from "node:http";
 import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import type { DBSessionStore } from "@/clients/db-session-store";
+
+/**
+ * The element type of the `components` array returned by the DependencyTrack
+ * `getComponents` tRPC procedure. Declared once here so the severity-filter
+ * branch and related helpers share the same type without repeating the
+ * `Awaited<ReturnType<...>>` unwrapping at every call site.
+ */
+type DtComponents = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof createCaller>["dependencyTrack"]["getComponents"]
+    >
+  >["components"]
+>;
 
 interface OidcConfig {
   issuerURL: string;
@@ -563,6 +583,7 @@ export function registerOpenApi(
       pageSize?: string;
       onlyOutdated?: "true" | "false";
       onlyDirect?: "true" | "false";
+      severity?: string;
     };
   }>("/rest/v1/sca/components", async (req, res) => {
     try {
@@ -573,6 +594,7 @@ export function registerOpenApi(
         pageSize,
         onlyOutdated,
         onlyDirect,
+        severity,
       } = req.query;
       if (!codebase) {
         return res.code(400).send({ error: "codebase is required" });
@@ -588,6 +610,14 @@ export function registerOpenApi(
         return res
           .code(400)
           .send({ error: "pageSize must be a positive integer" });
+      }
+
+      const parsedSeverity = parseSeverityCsv(severity);
+      if (parsedSeverity === "invalid") {
+        return res.code(400).send({
+          error:
+            "severity must be a comma-separated list of CRITICAL|HIGH|MEDIUM|LOW|INFO|UNASSIGNED",
+        });
       }
 
       const caller = await buildCaller(req, res);
@@ -606,21 +636,84 @@ export function registerOpenApi(
       });
 
       if (!project) {
-        return { status: "NONE" as const, items: [], totalCount: 0 };
+        return {
+          status: "NONE" as const,
+          items: [],
+          totalCount: 0,
+          truncated: false,
+        };
+      }
+
+      const { uuid } = project;
+      const filterOpts = {
+        onlyOutdated: parseBoolQuery(onlyOutdated),
+        onlyDirect: parseBoolQuery(onlyDirect),
+      };
+
+      if (parsedSeverity) {
+        // req.signal fires on client disconnect (tab closed, CLI Ctrl-C) and
+        // when Fastify's requestTimeout (30 s) fires. Threading it into
+        // fetchAllComponents ensures the auto-paging loop stops promptly rather
+        // than continuing to issue Dep-Track requests for a gone connection.
+        const { items: all, truncated } = await fetchAllComponents<
+          DtComponents[number]
+        >(
+          (pageNumber, pageSize) =>
+            caller.dependencyTrack
+              .getComponents({
+                uuid,
+                pageNumber,
+                pageSize,
+                onlyOutdated: filterOpts.onlyOutdated,
+                onlyDirect: filterOpts.onlyDirect,
+              })
+              .then((r) => ({
+                components: r.components ?? [],
+                totalCount: r.totalCount,
+              })),
+          {
+            maxPages: SCA_PAGE_SIZE_MAX_PAGES,
+            upstreamPageSize: SCA_PAGE_SIZE_MAX,
+            signal: req.signal,
+          }
+        );
+
+        if (truncated) {
+          req.log.warn(
+            {
+              codebase,
+              uuid,
+              collected: all.length,
+              upstreamTotal: `>${SCA_PAGE_SIZE_MAX_PAGES * SCA_PAGE_SIZE_MAX}`,
+            },
+            "sca components severity filter hit safety cap — results are truncated"
+          );
+        }
+
+        const filtered = all.filter((c) =>
+          componentMatchesSeverity(c, parsedSeverity)
+        );
+        const page = paginate(filtered, parsedPageNumber, parsedPageSize);
+        return {
+          status: "OK" as const,
+          items: page.items,
+          totalCount: page.totalCount,
+          truncated,
+        };
       }
 
       const components = await caller.dependencyTrack.getComponents({
-        uuid: project.uuid,
+        uuid,
         pageNumber: toZeroIndexedPage(parsedPageNumber),
         pageSize: clampPageSize(parsedPageSize),
-        onlyOutdated: parseBoolQuery(onlyOutdated),
-        onlyDirect: parseBoolQuery(onlyDirect),
+        ...filterOpts,
       });
 
       return {
         status: "OK" as const,
         items: components.components ?? [],
         totalCount: components.totalCount ?? 0,
+        truncated: false,
       };
     } catch (error) {
       return handleScaError(error, res);

--- a/apps/server/src/config/production/index.ts
+++ b/apps/server/src/config/production/index.ts
@@ -40,6 +40,13 @@ export class ProductionFastifyServer {
       logger: true,
       trustProxy: true,
       maxParamLength: 5000,
+      // Hard upper bound on any single REST handler's wall-clock. Portal is a
+      // low-latency API layer; we do not accept requests longer than 30 s.
+      // Severity-filter auto-paging that cannot complete within this budget
+      // returns HTTP 408 — the caller narrows the query or retries. The
+      // CLI-side http.Client.Timeout sits just above (45 s) so the 408
+      // surfaces as a clean application response, not a transport drop.
+      requestTimeout: 30_000,
     });
   }
 

--- a/apps/server/src/config/sca-helpers.test.ts
+++ b/apps/server/src/config/sca-helpers.test.ts
@@ -4,9 +4,13 @@ import { TRPCError } from "@trpc/server";
 import {
   classifyBranchResolution,
   clampPageSize,
+  componentMatchesSeverity,
+  fetchAllComponents,
   isScaNotConfiguredError,
   latestMetricsSnapshot,
+  paginate,
   parseBoolQuery,
+  parseSeverityCsv,
   SCA_FINDINGS_MAX,
   sortFindings,
   toZeroIndexedPage,
@@ -276,5 +280,271 @@ describe("isScaNotConfiguredError", () => {
     ).toBe(false);
     expect(isScaNotConfiguredError(undefined)).toBe(false);
     expect(isScaNotConfiguredError("boom")).toBe(false);
+  });
+});
+
+describe("parseSeverityCsv", () => {
+  it("returns undefined for empty input", () => {
+    expect(parseSeverityCsv(undefined)).toBeUndefined();
+    expect(parseSeverityCsv("")).toBeUndefined();
+  });
+
+  it("parses a single severity case-insensitively", () => {
+    const result = parseSeverityCsv("high");
+    expect(result).toBeInstanceOf(Set);
+    expect([...(result as Set<string>)]).toEqual(["HIGH"]);
+  });
+
+  it("parses a comma-separated list and canonicalises to upper case", () => {
+    const result = parseSeverityCsv("Critical,high");
+    expect([...(result as Set<string>)].sort()).toEqual(["CRITICAL", "HIGH"]);
+  });
+
+  it("trims whitespace and collapses duplicates", () => {
+    const result = parseSeverityCsv(" HIGH , high ,critical");
+    expect([...(result as Set<string>)].sort()).toEqual(["CRITICAL", "HIGH"]);
+  });
+
+  it("returns 'invalid' on any unknown token", () => {
+    expect(parseSeverityCsv("high,garbage")).toBe("invalid");
+    expect(parseSeverityCsv("weird")).toBe("invalid");
+  });
+
+  it("returns undefined when only commas are supplied", () => {
+    expect(parseSeverityCsv(",,,")).toBeUndefined();
+  });
+});
+
+describe("componentMatchesSeverity", () => {
+  const component = (
+    counts: Partial<{
+      critical: number;
+      high: number;
+      medium: number;
+      low: number;
+      unassigned: number;
+    }>
+  ) => ({
+    metrics: {
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      unassigned: 0,
+      ...counts,
+    },
+  });
+
+  it("returns false when the component has no metrics", () => {
+    expect(componentMatchesSeverity({}, new Set(["HIGH"]))).toBe(false);
+    expect(componentMatchesSeverity({ metrics: null }, new Set(["HIGH"]))).toBe(
+      false
+    );
+  });
+
+  it("matches when the requested severity has a non-zero count", () => {
+    expect(
+      componentMatchesSeverity(component({ high: 2 }), new Set(["HIGH"]))
+    ).toBe(true);
+  });
+
+  it("does not match when the requested severity count is zero", () => {
+    expect(
+      componentMatchesSeverity(
+        component({ critical: 0, high: 0, medium: 5 }),
+        new Set(["HIGH"])
+      )
+    ).toBe(false);
+  });
+
+  it("INFO and UNASSIGNED both consult metrics.unassigned", () => {
+    expect(
+      componentMatchesSeverity(component({ unassigned: 1 }), new Set(["INFO"]))
+    ).toBe(true);
+    expect(
+      componentMatchesSeverity(
+        component({ unassigned: 1 }),
+        new Set(["UNASSIGNED"])
+      )
+    ).toBe(true);
+  });
+
+  it("OR semantics across multiple severities", () => {
+    expect(
+      componentMatchesSeverity(
+        component({ critical: 0, high: 1 }),
+        new Set(["CRITICAL", "HIGH"])
+      )
+    ).toBe(true);
+    expect(
+      componentMatchesSeverity(
+        component({ critical: 0, high: 0, medium: 0, low: 0, unassigned: 0 }),
+        new Set(["CRITICAL", "HIGH"])
+      )
+    ).toBe(false);
+  });
+});
+
+describe("fetchAllComponents", () => {
+  /** Build a fetchPage stub that returns pre-defined pages in order. */
+  function makePageFetcher<T>(
+    pages: Array<{ components: T[]; totalCount: number }>
+  ) {
+    let call = 0;
+    return async () => {
+      const page = pages[call++];
+      if (!page) return { components: [] as T[], totalCount: 0 };
+      return { components: page.components, totalCount: page.totalCount };
+    };
+  }
+
+  it("natural exhaustion after the first page — truncated: false", async () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const result = await fetchAllComponents(
+      makePageFetcher([{ components: items, totalCount: 3 }])
+    );
+    expect(result.items).toEqual(items);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("multi-page exhaustion (3 pages, 250 total) — all collected, truncated: false", async () => {
+    const page0 = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ id: 100 + i }));
+    const page2 = Array.from({ length: 50 }, (_, i) => ({ id: 200 + i }));
+    const result = await fetchAllComponents(
+      makePageFetcher([
+        { components: page0, totalCount: 250 },
+        { components: page1, totalCount: 250 },
+        { components: page2, totalCount: 250 },
+      ])
+    );
+    expect(result.items).toHaveLength(250);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("safety-cap trigger — first maxPages pages collected, truncated: true", async () => {
+    // Each page returns 100 items but totalCount says 10_000.
+    const onePage = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+    const pages = Array.from({ length: 5 }, () => ({
+      components: onePage,
+      totalCount: 10_000,
+    }));
+    const result = await fetchAllComponents(makePageFetcher(pages), {
+      maxPages: 3,
+    });
+    expect(result.items).toHaveLength(300);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("empty first page — items: [], truncated: false", async () => {
+    const result = await fetchAllComponents(
+      makePageFetcher([{ components: [], totalCount: 0 }])
+    );
+    expect(result.items).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("early-exit when upstream returns an empty batch before totalCount is reached — truncated: false", async () => {
+    // Upstream claims 1000 but stops yielding after one page of 50.
+    const page0 = Array.from({ length: 50 }, (_, i) => ({ id: i }));
+    const result = await fetchAllComponents(
+      makePageFetcher([
+        { components: page0, totalCount: 1000 },
+        { components: [], totalCount: 1000 }, // empty batch = end of stream
+      ])
+    );
+    // We collected 50 rows but totalCount is 1000. However, the empty batch
+    // broke the loop before the safety cap — we treat this as NOT truncated
+    // because upstream itself stopped yielding.
+    expect(result.items).toHaveLength(50);
+    expect(result.truncated).toBe(false);
+  });
+});
+
+describe("fetchAllComponents — signal cancellation", () => {
+  it("aborts mid-loop: signal fires after page 2, no further fetchPage calls", async () => {
+    const controller = new AbortController();
+    let callCount = 0;
+
+    const fetchPage = async (pageNumber: number) => {
+      callCount += 1;
+      // Fire the abort signal after page index 1 (second call) completes.
+      if (pageNumber === 1) {
+        controller.abort();
+      }
+      return {
+        components: [{ id: pageNumber }],
+        totalCount: 1000, // large enough to keep looping without the signal
+      };
+    };
+
+    await expect(
+      fetchAllComponents(fetchPage, {
+        maxPages: 10,
+        signal: controller.signal,
+      })
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    // Pages 0 and 1 ran. After page 1 aborted the controller, page 2 must NOT be fetched.
+    expect(callCount).toBe(2);
+  });
+
+  it("aborts before first iteration when signal is already fired", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    let callCount = 0;
+    const fetchPage = async () => {
+      callCount += 1;
+      return { components: [{ id: 1 }], totalCount: 100 };
+    };
+
+    await expect(
+      fetchAllComponents(fetchPage, { signal: controller.signal })
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(callCount).toBe(0);
+  });
+});
+
+describe("paginate", () => {
+  const items = Array.from({ length: 12 }, (_, i) => i);
+
+  it("slices the first page and reports true total", () => {
+    expect(paginate(items, 1, 5)).toEqual({
+      items: [0, 1, 2, 3, 4],
+      totalCount: 12,
+    });
+  });
+
+  it("slices a middle page", () => {
+    expect(paginate(items, 2, 5)).toEqual({
+      items: [5, 6, 7, 8, 9],
+      totalCount: 12,
+    });
+  });
+
+  it("returns a short last page", () => {
+    expect(paginate(items, 3, 5)).toEqual({
+      items: [10, 11],
+      totalCount: 12,
+    });
+  });
+
+  it("returns an empty slice when page is past the end but preserves totalCount", () => {
+    expect(paginate(items, 99, 5)).toEqual({ items: [], totalCount: 12 });
+  });
+
+  it("defaults pageSize to 25 when undefined", () => {
+    const result = paginate(items, undefined, undefined);
+    expect(result.items).toEqual(items);
+    expect(result.totalCount).toBe(12);
+  });
+
+  it("clamps pageSize to the upstream ceiling (100)", () => {
+    const many = Array.from({ length: 150 }, (_, i) => i);
+    const result = paginate(many, 1, 500);
+    expect(result.items).toHaveLength(100);
+    expect(result.totalCount).toBe(150);
   });
 });

--- a/apps/server/src/config/sca-helpers.ts
+++ b/apps/server/src/config/sca-helpers.ts
@@ -18,7 +18,30 @@ const SCA_SEVERITY_RANK: Record<string, number> = {
 export const SCA_FINDINGS_MAX = 1000;
 
 /** Upper bound on the components / list pageSize (matches current tRPC procedure ceiling). */
-const SCA_PAGE_SIZE_MAX = 100;
+export const SCA_PAGE_SIZE_MAX = 100;
+
+/** Canonical Dep-Track severity values. */
+export const SCA_SEVERITIES = [
+  "CRITICAL",
+  "HIGH",
+  "MEDIUM",
+  "LOW",
+  "INFO",
+  "UNASSIGNED",
+] as const;
+export type ScaSeverity = (typeof SCA_SEVERITIES)[number];
+export type SeveritySet = ReadonlySet<ScaSeverity>;
+
+/** Cap on auto-paging iterations when the severity filter triggers the full-project scan loop. */
+export const SCA_PAGE_SIZE_MAX_PAGES = 50;
+
+/**
+ * Default page size for the severity-filter pagination path.
+ * Mirrors the `pageSize.optional().default(25)` in the `getComponents` tRPC
+ * procedure — keeping both in sync prevents the two code paths from silently
+ * drifting apart.
+ */
+export const SCA_DEFAULT_PAGE_SIZE = 25;
 
 /**
  * Sort findings by severity desc, component.name asc, vulnerability.vulnId asc.
@@ -130,6 +153,83 @@ export async function classifyBranchResolution(
 }
 
 /**
+ * Parse a comma-separated severity query string into a canonical set.
+ * Case-insensitive; empty / undefined input returns undefined (no filter).
+ * Unknown token → "invalid" sentinel so the caller can respond 400.
+ */
+export function parseSeverityCsv(
+  raw: string | undefined
+): SeveritySet | "invalid" | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const allowed = new Set<string>(SCA_SEVERITIES);
+  const out = new Set<ScaSeverity>();
+  for (const token of raw.split(",")) {
+    const trimmed = token.trim();
+    if (trimmed === "") continue;
+    const upper = trimmed.toUpperCase();
+    if (!allowed.has(upper)) return "invalid";
+    out.add(upper as ScaSeverity);
+  }
+  if (out.size === 0) return undefined;
+  return out;
+}
+
+/** The metric counter fields this module reads off a DT component. */
+export interface VulnerabilityMetrics {
+  readonly critical: number;
+  readonly high: number;
+  readonly medium: number;
+  readonly low: number;
+  readonly unassigned: number;
+}
+
+/**
+ * Return true iff the component has at least one vulnerability at a severity
+ * present in `allowed`. Components without metrics match nothing.
+ *
+ * INFO and UNASSIGNED both consult `metrics.unassigned` — Dep-Track folds
+ * these together at the rollup level and the CLI's inclusive expansion
+ * already sends both when either is requested.
+ */
+export function componentMatchesSeverity(
+  component: { readonly metrics?: VulnerabilityMetrics | null },
+  allowed: SeveritySet
+): boolean {
+  const m = component.metrics;
+  if (!m) return false;
+  if (allowed.has("CRITICAL") && m.critical > 0) return true;
+  if (allowed.has("HIGH") && m.high > 0) return true;
+  if (allowed.has("MEDIUM") && m.medium > 0) return true;
+  if (allowed.has("LOW") && m.low > 0) return true;
+  if ((allowed.has("INFO") || allowed.has("UNASSIGNED")) && m.unassigned > 0)
+    return true;
+  return false;
+}
+
+/**
+ * Slice a 1-indexed page out of the given array. Returns the slice and the
+ * total row count of the input (caller reports it back as totalCount).
+ * Out-of-range page numbers yield an empty slice but still expose the true
+ * totalCount so callers can render "page X of Y" accurately.
+ */
+export function paginate<T>(
+  items: readonly T[],
+  pageNumber: number | undefined,
+  pageSize: number | undefined
+): { items: T[]; totalCount: number } {
+  const size = clampPageSize(pageSize) ?? SCA_DEFAULT_PAGE_SIZE;
+  const page = pageNumber === undefined ? 1 : Math.max(1, pageNumber);
+  const start = (page - 1) * size;
+  if (start >= items.length) {
+    return { items: [], totalCount: items.length };
+  }
+  return {
+    items: items.slice(start, start + size),
+    totalCount: items.length,
+  };
+}
+
+/**
  * Matches the "Dep-Track env var X is not configured" TRPCError emitted by
  * `createDependencyTrackClient()`. Used by the REST handlers to translate that
  * specific INTERNAL_SERVER_ERROR into HTTP 503 Service Unavailable.
@@ -144,4 +244,74 @@ export function isScaNotConfiguredError(error: unknown): boolean {
   if (error.code !== "INTERNAL_SERVER_ERROR") return false;
   const cause = error.cause as Record<string, unknown> | null | undefined;
   return cause?.kind === "sca_not_configured";
+}
+
+/**
+ * The shape of a single upstream page response for components. Generic so this
+ * module stays free of any Fastify / caller dependency — the caller injects the
+ * concrete upstream function via `fetchPage`.
+ */
+export interface ComponentFetchPage<T> {
+  components: readonly T[];
+  totalCount: number;
+}
+
+/**
+ * Fetch every component from an upstream paginated source, collecting all pages
+ * into a flat array. Stops when:
+ *   a) the collected length reaches `totalCount` reported by upstream, or
+ *   b) an upstream page returns an empty batch (upstream has stopped yielding), or
+ *   c) `maxPages` iterations are exhausted (safety cap), or
+ *   d) the optional `signal` fires (client disconnect / Fastify requestTimeout).
+ *
+ * Returns `{ items, truncated }` where `truncated` is `true` iff the loop
+ * exited via the safety cap while more data was still reported upstream.
+ * When `signal` fires mid-loop the in-flight `fetchPage` promise will reject
+ * (propagated naturally to the caller); no additional items are collected.
+ *
+ * @param fetchPage  Async function that fetches one page given (pageNumber, pageSize).
+ *                   `pageNumber` is 0-indexed.
+ * @param opts.maxPages           Safety cap on iterations (default: SCA_PAGE_SIZE_MAX_PAGES).
+ * @param opts.upstreamPageSize   Items per upstream request (default: SCA_PAGE_SIZE_MAX).
+ * @param opts.signal             Optional AbortSignal; loop exits immediately when aborted.
+ */
+export async function fetchAllComponents<T>(
+  fetchPage: (
+    pageNumber: number,
+    pageSize: number
+  ) => Promise<ComponentFetchPage<T>>,
+  opts?: { maxPages?: number; upstreamPageSize?: number; signal?: AbortSignal }
+): Promise<{ items: T[]; truncated: boolean }> {
+  const maxPages = opts?.maxPages ?? SCA_PAGE_SIZE_MAX_PAGES;
+  const upstreamPageSize = opts?.upstreamPageSize ?? SCA_PAGE_SIZE_MAX;
+  const signal = opts?.signal;
+
+  const out: T[] = [];
+  let total: number = Number.POSITIVE_INFINITY;
+  // Tracks whether the loop exited via safety cap (true) vs. natural completion
+  // (batch exhausted or totalCount reached). An empty batch from upstream is
+  // treated as authoritative end-of-stream even if totalCount says otherwise.
+  let hitSafetyCap = false;
+
+  for (let page = 0; page < maxPages; page += 1) {
+    // Honour caller-supplied cancellation before issuing each upstream request.
+    // If the signal already fired before the loop started this exits immediately.
+    if (signal?.aborted) {
+      throw new DOMException("fetchAllComponents aborted", "AbortError");
+    }
+
+    const res = await fetchPage(page, upstreamPageSize);
+    const batch = res.components;
+    // Empty batch = upstream has stopped yielding; treat as end-of-stream.
+    if (batch.length === 0) break;
+    out.push(...batch);
+    total = res.totalCount;
+    if (out.length >= total) break;
+    // If this was the last allowed iteration and we haven't finished, flag it.
+    if (page === maxPages - 1 && out.length < total) {
+      hitSafetyCap = true;
+    }
+  }
+
+  return { items: out, truncated: hitSafetyCap };
 }

--- a/packages/trpc/src/clients/dependencyTrack/index.ts
+++ b/packages/trpc/src/clients/dependencyTrack/index.ts
@@ -160,12 +160,25 @@ export class DependencyTrackClient {
     return queryString ? `${path}?${queryString}` : path;
   }
 
-  private async fetchJson<T>(endpoint: string): Promise<T>;
-  private async fetchJson<T>(endpoint: string, includeHeaders: true): Promise<{ data: T; headers: Headers }>;
-  private async fetchJson<T>(endpoint: string, includeHeaders?: boolean): Promise<T | { data: T; headers: Headers }> {
+  private async fetchJson<T>(endpoint: string, includeHeaders?: false, signal?: AbortSignal): Promise<T>;
+  private async fetchJson<T>(
+    endpoint: string,
+    includeHeaders: true,
+    signal?: AbortSignal
+  ): Promise<{ data: T; headers: Headers }>;
+  private async fetchJson<T>(
+    endpoint: string,
+    includeHeaders?: boolean,
+    signal?: AbortSignal
+  ): Promise<T | { data: T; headers: Headers }> {
     const url = `${this.apiBase}${endpoint}`;
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    // Combine the per-request timeout signal with an optional caller-supplied
+    // signal (e.g. sourced from req.signal on client disconnect). AbortSignal.any
+    // aborts as soon as the first of the two fires — requires Node >= 20.3.
+    const combinedSignal = signal !== undefined ? AbortSignal.any([controller.signal, signal]) : controller.signal;
 
     try {
       const response = await fetch(url, {
@@ -174,7 +187,7 @@ export class DependencyTrackClient {
           Accept: "application/json",
           "X-Api-Key": this.apiKey,
         },
-        signal: controller.signal,
+        signal: combinedSignal,
       });
 
       if (!response.ok) {
@@ -357,7 +370,7 @@ export class DependencyTrackClient {
    *   sortOrder: "asc"
    * });
    */
-  async getComponents(uuid: string, params: ComponentsQueryParams): Promise<ComponentsResponse> {
+  async getComponents(uuid: string, params: ComponentsQueryParams, signal?: AbortSignal): Promise<ComponentsResponse> {
     const endpoint = this.buildEndpoint(`/component/project/${uuid}`, {
       pageNumber: params.pageNumber,
       pageSize: params.pageSize,
@@ -367,7 +380,7 @@ export class DependencyTrackClient {
       onlyDirect: params.onlyDirect,
     });
 
-    const { data, headers } = await this.fetchJson<DependencyTrackComponent[]>(endpoint, true);
+    const { data, headers } = await this.fetchJson<DependencyTrackComponent[]>(endpoint, true, signal);
 
     return {
       components: data,


### PR DESCRIPTION
- Implement server-side auto-paging in /rest/v1/sca/components handler; when severity filter requested, scans all project dependencies before pagination, not post-page
- Add AbortSignal propagation through DependencyTrackClient to immediately cancel in-flight upstream requests on client disconnect (Fastify req.signal)
- Add requestTimeout: 30_000ms to Fastify config (both production and development) to enforce hard wall-clock handler deadline; portal is a low-latency API layer by design
- Return truncated:true when auto-paging loop hits safety cap before all upstream components inspected; client shows "incomplete results" cue
- Includes unit tests for severity parsing, component filtering logic, and auto-paging bounds (50 iterations, empty batch, totalCount reached)
