### PR TITLE
EPMDEDP-16732: feat: Allow filtering pipeline runs by any platform-registered projects

### DIFF
--- a/apps/client/src/core/components/form/components/FormCombobox/index.tsx
+++ b/apps/client/src/core/components/form/components/FormCombobox/index.tsx
@@ -151,6 +151,7 @@ export const FormCombobox = <TData,>({
         disabled: option.disabled,
         icon: option.icon,
         keywords: option.keywords,
+        kind: option.kind,
       })),
     [options]
   );

--- a/apps/client/src/core/components/form/types.ts
+++ b/apps/client/src/core/components/form/types.ts
@@ -7,6 +7,8 @@ export interface SelectOption {
   icon?: React.ReactNode;
   /** Matched by searchable combobox filters (cmdk keywords). */
   keywords?: string[];
+  /** See `ComboboxOption.kind`. Honored by standard (non-renderOption) Combobox variants. */
+  kind?: "item" | "separator";
 }
 
 // Re-export React for convenience

--- a/apps/client/src/core/components/ui/combobox/index.tsx
+++ b/apps/client/src/core/components/ui/combobox/index.tsx
@@ -11,6 +11,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "@/core/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/core/components/ui/popover";
 import { cn } from "@/core/utils/classname";
@@ -22,6 +23,9 @@ const renderIcon = (icon: React.ReactNode, sizeClass = "size-4"): React.ReactNod
   return <span className={cn("flex shrink-0 items-center justify-center", sizeClass)}>{toElement(icon)}</span>;
 };
 
+const renderSeparator = (option: ComboboxOption): React.ReactNode =>
+  option.kind === "separator" ? <CommandSeparator key={option.value} className="my-1" /> : null;
+
 export interface ComboboxOption {
   value: string;
   label: string | React.ReactNode;
@@ -29,6 +33,11 @@ export interface ComboboxOption {
   icon?: React.ReactNode;
   /** Extra strings matched by the search filter (cmdk `keywords`). */
   keywords?: string[];
+  /**
+   * "separator" renders a non-selectable cmdk CommandSeparator instead of a CommandItem.
+   * `value` is still used as a React key; pick a sentinel that can't collide with real values.
+   */
+  kind?: "item" | "separator";
 }
 
 export interface ComboboxProps {
@@ -111,6 +120,7 @@ export const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
               <CommandEmpty>{emptyText}</CommandEmpty>
               <CommandGroup>
                 {options.map((option) => {
+                  if (option.kind === "separator") return renderSeparator(option);
                   const isSelected = singleValue === option.value;
                   return (
                     <CommandItem
@@ -253,6 +263,7 @@ const ComboboxMultiple = React.forwardRef<HTMLButtonElement, ComboboxMultiplePro
               <CommandEmpty>{emptyText}</CommandEmpty>
               <CommandGroup>
                 {options.map((option) => {
+                  if (option.kind === "separator") return renderSeparator(option);
                   const isSelected = value.includes(option.value);
                   return (
                     <CommandItem

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.ts
@@ -19,6 +19,10 @@ export const pipelineRunFilterControlNames = {
   NAMESPACES: "namespaces",
 } as const;
 
+// Sentinel for the inert separator option in the codebase combobox. Stripped
+// downstream so a crafted `?codebases=__divider__` URL can't leak into filtering.
+export const CODEBASE_DIVIDER_VALUE = "__divider__";
+
 export const defaultPipelineRunFilterValues: PipelineRunListFilterValues = {
   [pipelineRunFilterControlNames.SEARCH]: "",
   [pipelineRunFilterControlNames.CODEBASES]: [],
@@ -31,7 +35,8 @@ export const defaultPipelineRunFilterValues: PipelineRunListFilterValues = {
 export const matchFunctions: MatchFunctions<PipelineRun, PipelineRunListFilterValues> = {
   [pipelineRunFilterControlNames.SEARCH]: createSearchMatchFunction<PipelineRun>(),
   [pipelineRunFilterControlNames.CODEBASES]: (item, value) => {
-    if (!value || value.length === 0) return true;
+    const realValues = new Set(value?.filter((v) => v !== CODEBASE_DIVIDER_VALUE));
+    if (realValues.size === 0) return true;
 
     const pipelineRunType = item?.metadata?.labels?.[pipelineRunLabels.pipelineType];
     // Results adapter omits spec.params, so deploy/clean history must fall back to the codebase label.
@@ -51,7 +56,7 @@ export const matchFunctions: MatchFunctions<PipelineRun, PipelineRunListFilterVa
         return false;
       }
 
-      return Object.keys(appPayloadValue).some((key) => value.includes(key));
+      return Object.keys(appPayloadValue).some((key) => realValues.has(key));
     }
 
     const itemCodebase = item?.metadata?.labels?.[pipelineRunLabels.codebase];
@@ -60,7 +65,7 @@ export const matchFunctions: MatchFunctions<PipelineRun, PipelineRunListFilterVa
       return false;
     }
 
-    return value.includes(itemCodebase);
+    return realValues.has(itemCodebase);
   },
   [pipelineRunFilterControlNames.CODEBASE_BRANCHES]: (item, value) => {
     if (!value || value.length === 0) return true;

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/index.tsx
@@ -1,8 +1,10 @@
 import type { SelectOption } from "@/core/components/form";
 import { ValueOf } from "@/core/types/global";
 import { capitalizeFirstLetter } from "@/core/utils/format/capitalizeFirstLetter";
+import { sortByName } from "@/core/utils/sortByName";
 import { FilterTypeWithOptionAll } from "@/k8s/types";
 import { Button } from "@/core/components/ui/button";
+import { useCodebaseWatchList } from "@/k8s/api/groups/KRCI/Codebase";
 import {
   PipelineRun,
   pipelineRunLabels,
@@ -18,7 +20,7 @@ const pipelineRunStatusLabels: Record<string, string> = {
   [pipelineRunStatus.unknown]: "Running / Pending",
 };
 import React from "react";
-import { pipelineRunFilterControlNames } from "./constants";
+import { CODEBASE_DIVIDER_VALUE, pipelineRunFilterControlNames } from "./constants";
 import { usePipelineRunFilter } from "./hooks/usePipelineRunFilter";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
@@ -36,13 +38,22 @@ export const PipelineRunFilter = ({
 }) => {
   const { form, reset, isDefaultValue } = usePipelineRunFilter();
 
-  const codebaseOptions = React.useMemo(() => {
+  const activeCodebases = React.useMemo(() => {
     const set = new Set(
       pipelineRuns?.map(({ metadata: { labels } }) => labels?.[pipelineRunLabels.codebase]).filter(Boolean) as string[]
     );
 
-    return Array.from(set);
+    return Array.from(set).sort(sortByName);
   }, [pipelineRuns]);
+
+  const codebasesWatch = useCodebaseWatchList();
+  const otherCodebases = React.useMemo(() => {
+    const activeSet = new Set(activeCodebases);
+    return codebasesWatch.data.array
+      .map((codebase) => codebase.metadata.name)
+      .filter((name): name is string => Boolean(name) && !activeSet.has(name))
+      .sort(sortByName);
+  }, [codebasesWatch.data.array, activeCodebases]);
 
   const codebaseBranchOptions = React.useMemo(() => {
     const set = new Set(
@@ -55,8 +66,6 @@ export const PipelineRunFilter = ({
 
   const allowedNamespaces = useClusterStore(useShallow((state) => state.allowedNamespaces));
   const showNamespaceFilter = allowedNamespaces.length > 1;
-
-  const namespaceOptions = React.useMemo(() => allowedNamespaces, [allowedNamespaces]);
 
   const pipelineTypeOptions: SelectOption[] = React.useMemo(
     () => [
@@ -77,10 +86,14 @@ export const PipelineRunFilter = ({
     []
   );
 
-  const codebaseComboboxOptions = React.useMemo(
-    () => codebaseOptions.map((value) => ({ label: value, value })),
-    [codebaseOptions]
-  );
+  const codebaseComboboxOptions = React.useMemo<SelectOption[]>(() => {
+    const activeOptions: SelectOption[] = activeCodebases.map((value) => ({ label: value, value }));
+    const otherOptions: SelectOption[] = otherCodebases.map((value) => ({ label: value, value }));
+    if (activeOptions.length === 0 || otherOptions.length === 0) {
+      return [...activeOptions, ...otherOptions];
+    }
+    return [...activeOptions, { value: CODEBASE_DIVIDER_VALUE, label: "", kind: "separator" }, ...otherOptions];
+  }, [activeCodebases, otherCodebases]);
 
   const branchComboboxOptions = React.useMemo(
     () => codebaseBranchOptions.map((value) => ({ label: value, value })),
@@ -88,8 +101,8 @@ export const PipelineRunFilter = ({
   );
 
   const namespaceComboboxOptions = React.useMemo(
-    () => namespaceOptions.map((value) => ({ label: value, value })),
-    [namespaceOptions]
+    () => allowedNamespaces.map((value) => ({ label: value, value })),
+    [allowedNamespaces]
   );
 
   return (

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-list/components/Pipelines/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-list/components/Pipelines/index.tsx
@@ -4,6 +4,7 @@ import { useUnifiedPipelineRunList } from "@/modules/platform/tekton/hooks/useUn
 import { HistoryLoadingFooter } from "@/modules/platform/tekton/components/HistoryLoadingFooter";
 import { FilterProvider } from "@/core/providers/Filter/provider";
 import {
+  CODEBASE_DIVIDER_VALUE,
   defaultPipelineRunFilterValues,
   matchFunctions,
   pipelineRunFilterControlNames,
@@ -51,11 +52,14 @@ function PipelinesContent() {
   const status = useStore(form.store, (s) => s.values.status);
   const codebases = useStore(form.store, (s) => s.values.codebases);
 
+  // Guard against a crafted URL injecting the sentinel into URL-synced filter state.
+  const sanitizedCodebases = React.useMemo(() => codebases.filter((c) => c !== CODEBASE_DIVIDER_VALUE), [codebases]);
+
   const { mergedPipelineRuns, isLoading, isHistoryLoading, historyQuery } = useUnifiedPipelineRunList({
     searchTerm: debouncedSearch,
     pipelineType,
     status,
-    codebases,
+    codebases: sanitizedCodebases,
   });
 
   return (


### PR DESCRIPTION
Previously the codebase filter only listed codebases extracted from currently visible pipeline runs, preventing users from filtering by codebases without recent activity. Source the full codebase list via the watch hook, group active (with recent runs) above the rest, and add combobox separator support to visually divide the two groups. Sanitize the separator sentinel in both the match function and the URL-synced filter state to keep crafted URLs from leaking it into downstream queries.
