### PR TITLE
EPMDEDP-16739: fix: Block branch deletion when used by a deployment flow

### DIFF
--- a/apps/client/src/k8s/api/groups/KRCI/CDPipeline/hooks/index.ts
+++ b/apps/client/src/k8s/api/groups/KRCI/CDPipeline/hooks/index.ts
@@ -13,6 +13,7 @@ export { useCRUD as useCDPipelineCRUD } from "./useCRUD";
 export * from "./useWatchCDPipelineByAutotest";
 export * from "./useWatchCDPipelineByApplication";
 export * from "./useWatchCDPipelineByCodebaseBranch";
+export * from "./useWatchCDPipelineByInputDockerStream";
 export * from "./useWatchCDPipelineByStageAutotest";
 
 export const useCDPipelinePermissions = createUsePermissionsHook(k8sCDPipelineConfig);

--- a/apps/client/src/k8s/api/groups/KRCI/CDPipeline/hooks/useWatchCDPipelineByInputDockerStream/index.test.tsx
+++ b/apps/client/src/k8s/api/groups/KRCI/CDPipeline/hooks/useWatchCDPipelineByInputDockerStream/index.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useWatchCDPipelineByInputDockerStream } from "./index";
+
+const mockWatchListData = {
+  array: [
+    {
+      metadata: { name: "cdp-1" },
+      spec: { inputDockerStreams: ["app-1-main", "app-2-develop"] },
+    },
+    {
+      metadata: { name: "cdp-2" },
+      spec: { inputDockerStreams: ["app-3-feature"] },
+    },
+  ],
+};
+const mockUseCDPipelineWatchList = vi.fn();
+
+vi.mock("..", () => ({
+  useCDPipelineWatchList: (params: unknown) => mockUseCDPipelineWatchList(params),
+}));
+
+describe("useWatchCDPipelineByInputDockerStream", () => {
+  beforeEach(() => {
+    mockUseCDPipelineWatchList.mockReturnValue({
+      data: mockWatchListData,
+    });
+  });
+
+  it("should return undefined data when inputDockerStream is missing", () => {
+    const { result } = renderHook(() => useWatchCDPipelineByInputDockerStream(undefined, "default"));
+
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should disable underlying watch when no input docker stream", () => {
+    renderHook(() => useWatchCDPipelineByInputDockerStream(undefined, "default"));
+
+    expect(mockUseCDPipelineWatchList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: "default",
+        queryOptions: { enabled: false },
+      })
+    );
+  });
+
+  it("should return the CDPipeline whose inputDockerStreams contains the branch", () => {
+    const { result } = renderHook(() => useWatchCDPipelineByInputDockerStream("app-2-develop", "default"));
+
+    expect(result.current.data).toEqual(mockWatchListData.array[0]);
+  });
+
+  it("should return undefined data when no CDPipeline references the branch", () => {
+    const { result } = renderHook(() => useWatchCDPipelineByInputDockerStream("app-99-missing", "default"));
+
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/apps/client/src/k8s/api/groups/KRCI/CDPipeline/hooks/useWatchCDPipelineByInputDockerStream/index.ts
+++ b/apps/client/src/k8s/api/groups/KRCI/CDPipeline/hooks/useWatchCDPipelineByInputDockerStream/index.ts
@@ -1,0 +1,24 @@
+import React from "react";
+import { useCDPipelineWatchList } from "..";
+
+export const useWatchCDPipelineByInputDockerStream = (
+  inputDockerStream: string | undefined,
+  namespace: string | undefined
+) => {
+  const cdPipelineListWatch = useCDPipelineWatchList({
+    namespace,
+    queryOptions: {
+      enabled: !!inputDockerStream,
+    },
+  });
+
+  const data = React.useMemo(() => {
+    if (!inputDockerStream) {
+      return undefined;
+    }
+
+    return cdPipelineListWatch.data.array.find((item) => item.spec.inputDockerStreams.includes(inputDockerStream));
+  }, [inputDockerStream, cdPipelineListWatch.data.array]);
+
+  return { data };
+};

--- a/apps/client/src/modules/platform/codebases/components/CodebaseBranchActionsMenu/hooks/useDeletionConflictItem.ts
+++ b/apps/client/src/modules/platform/codebases/components/CodebaseBranchActionsMenu/hooks/useDeletionConflictItem.ts
@@ -1,8 +1,9 @@
 import {
   useWatchCDPipelineByCodebaseBranch,
+  useWatchCDPipelineByInputDockerStream,
   useWatchCDPipelineByStageAutotest,
 } from "@/k8s/api/groups/KRCI/CDPipeline";
-import { Codebase, CodebaseBranch, isAutotest, isLibrary } from "@my-project/shared";
+import { Codebase, CodebaseBranch, isApplication, isAutotest } from "@my-project/shared";
 
 export const useDeletionConflictItem = (codebaseBranch: CodebaseBranch, codebase: Codebase) => {
   const codebaseBranchSpecName = codebaseBranch.spec.branchName;
@@ -14,15 +15,18 @@ export const useDeletionConflictItem = (codebaseBranch: CodebaseBranch, codebase
   );
 
   const cdPipelineByCodebaseBranchWatch = useWatchCDPipelineByCodebaseBranch(
-    !isLibrary(codebase) && !isAutotest(codebase) ? codebaseBranchMetadataName : undefined,
+    isApplication(codebase) ? codebaseBranchMetadataName : undefined,
     codebase.metadata.namespace
   );
 
-  if (cdPipelineByStageAutotestWatch.data) {
-    return cdPipelineByStageAutotestWatch.data;
-  }
+  const cdPipelineByInputDockerStreamWatch = useWatchCDPipelineByInputDockerStream(
+    isApplication(codebase) ? codebaseBranchMetadataName : undefined,
+    codebase.metadata.namespace
+  );
 
-  if (cdPipelineByCodebaseBranchWatch.data) {
-    return cdPipelineByCodebaseBranchWatch.data;
-  }
+  return (
+    cdPipelineByStageAutotestWatch.data ??
+    cdPipelineByCodebaseBranchWatch.data ??
+    cdPipelineByInputDockerStreamWatch.data
+  );
 };


### PR DESCRIPTION
Prevent deletion of a CodebaseBranch if it is referenced by a CDPipeline via spec.inputDockerStreams. Previously, only Stage qualityGate references were checked, so branches used purely as deployment inputs (app-name-branch tuples in CDPipeline.spec.inputDockerStreams) could be deleted without warning, breaking the linked deployment flow.

Add useWatchCDPipelineByInputDockerStream hook to detect branches in inputDockerStreams and integrate it into useDeletionConflictItem so the existing ConflictItemError surfaces a clear message and a link to the conflicting CDPipeline, blocking the delete operation.

