### PR TITLE
EPMDEDP-16744: fix: Reflect created, updated, and deleted resources without page refresh

### DIFF
--- a/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.test.tsx
+++ b/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.test.tsx
@@ -423,4 +423,277 @@ describe("useResourceCRUDMutation", () => {
       });
     });
   });
+
+  describe("Cache update on success", () => {
+    const itemQueryKey = ["k8s:watchItem", "test-cluster", "default", "resources", "test-resource"];
+    const listQueryKeyNoLabels = ["k8s:watchList", "test-cluster", "default", "resources"];
+    const listQueryKeyWithLabels = ["k8s:watchList", "test-cluster", "default", "resources", "tier,frontend"];
+
+    const mockFreshResource = {
+      apiVersion: "test.group/v1",
+      kind: "Resource",
+      metadata: {
+        name: "test-resource",
+        namespace: "default",
+        uid: "uid-1",
+        resourceVersion: "200",
+      },
+      spec: { applications: ["a", "b"] },
+    };
+
+    it("should write item cache after a successful update", async () => {
+      vi.mocked(mockTrpcClient.k8s.update.mutate).mockResolvedValue(mockFreshResource);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-update-cache", k8sOperation.update), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      expect(queryClient.getQueryData(itemQueryKey)).toEqual(mockFreshResource);
+    });
+
+    it("should patch list caches that already contain the item on update", async () => {
+      const stalePrev = {
+        apiVersion: "test.group/v1",
+        kind: "ResourceList",
+        metadata: { resourceVersion: "100" },
+        items: new Map([
+          [
+            "test-resource",
+            { ...mockFreshResource, metadata: { ...mockFreshResource.metadata, resourceVersion: "100" } },
+          ],
+        ]),
+      };
+      queryClient.setQueryData(listQueryKeyNoLabels, stalePrev);
+      queryClient.setQueryData(listQueryKeyWithLabels, {
+        ...stalePrev,
+        items: new Map(stalePrev.items),
+      });
+
+      vi.mocked(mockTrpcClient.k8s.update.mutate).mockResolvedValue(mockFreshResource);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-update-list", k8sOperation.update), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      const updatedPlain = queryClient.getQueryData<typeof stalePrev>(listQueryKeyNoLabels);
+      expect(updatedPlain?.items.get("test-resource")?.metadata.resourceVersion).toBe("200");
+      expect(updatedPlain?.metadata.resourceVersion).toBe("200");
+
+      const updatedLabeled = queryClient.getQueryData<typeof stalePrev>(listQueryKeyWithLabels);
+      expect(updatedLabeled?.items.get("test-resource")?.metadata.resourceVersion).toBe("200");
+    });
+
+    it("should not add the item to lists that don't contain it on update", async () => {
+      const otherList = {
+        apiVersion: "test.group/v1",
+        kind: "ResourceList",
+        metadata: { resourceVersion: "50" },
+        items: new Map(),
+      };
+      queryClient.setQueryData(listQueryKeyWithLabels, otherList);
+
+      vi.mocked(mockTrpcClient.k8s.update.mutate).mockResolvedValue(mockFreshResource);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-update-no-add", k8sOperation.update), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      const after = queryClient.getQueryData<typeof otherList>(listQueryKeyWithLabels);
+      expect(after?.items.has("test-resource")).toBe(false);
+    });
+
+    it("should write item cache but not lists on create", async () => {
+      const otherList = {
+        apiVersion: "test.group/v1",
+        kind: "ResourceList",
+        metadata: { resourceVersion: "50" },
+        items: new Map(),
+      };
+      queryClient.setQueryData(listQueryKeyNoLabels, otherList);
+
+      vi.mocked(mockTrpcClient.k8s.create.mutate).mockResolvedValue(mockFreshResource);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-create-cache", k8sOperation.create), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      expect(queryClient.getQueryData(itemQueryKey)).toEqual(mockFreshResource);
+      const list = queryClient.getQueryData<typeof otherList>(listQueryKeyNoLabels);
+      expect(list?.items.has("test-resource")).toBe(false);
+    });
+
+    it("should invalidate every list cache for the resource type on create", async () => {
+      // Label selectors aren't known at mutation time, so on create we mark every
+      // list (labeled and unlabeled) for the resource type as stale and force a
+      // refetch — ensuring the new item appears when consumers (re)mount, even
+      // when the watch was unsubscribed during navigation.
+      const seedList = {
+        apiVersion: "test.group/v1",
+        kind: "ResourceList",
+        metadata: { resourceVersion: "50" },
+        items: new Map(),
+      };
+      queryClient.setQueryData(listQueryKeyNoLabels, seedList);
+      queryClient.setQueryData(listQueryKeyWithLabels, { ...seedList, items: new Map() });
+
+      vi.mocked(mockTrpcClient.k8s.create.mutate).mockResolvedValue(mockFreshResource);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-create-invalidate", k8sOperation.create), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      expect(queryClient.getQueryState(listQueryKeyNoLabels)?.isInvalidated).toBe(true);
+      expect(queryClient.getQueryState(listQueryKeyWithLabels)?.isInvalidated).toBe(true);
+    });
+
+    it("should use server-assigned name from response for cache key on create (generateName)", async () => {
+      // Resources created with generateName have no name on the draft; the API
+      // server assigns one and returns it in the response. The cache key must
+      // use the server-assigned name, not the draft's empty value.
+      const draftWithoutName = {
+        ...mockResource,
+        metadata: { ...mockResource.metadata, name: undefined as unknown as string },
+      };
+      const generated = {
+        ...mockFreshResource,
+        metadata: { ...mockFreshResource.metadata, name: "generated-xyz" },
+      };
+      const generatedItemKey = ["k8s:watchItem", "test-cluster", "default", "resources", "generated-xyz"];
+
+      vi.mocked(mockTrpcClient.k8s.create.mutate).mockResolvedValue(generated);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-create-generate-name", k8sOperation.create), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: draftWithoutName,
+        resourceConfig: mockResourceConfig,
+      });
+
+      expect(queryClient.getQueryData(generatedItemKey)).toEqual(generated);
+    });
+
+    it("should remove item cache and prune lists on delete", async () => {
+      queryClient.setQueryData(itemQueryKey, mockFreshResource);
+      queryClient.setQueryData(listQueryKeyNoLabels, {
+        apiVersion: "test.group/v1",
+        kind: "ResourceList",
+        metadata: { resourceVersion: "100" },
+        items: new Map([["test-resource", mockFreshResource]]),
+      });
+
+      vi.mocked(mockTrpcClient.k8s.delete.mutate).mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-delete-cache", k8sOperation.delete), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      expect(queryClient.getQueryData(itemQueryKey)).toBeUndefined();
+      const list = queryClient.getQueryData<{ items: Map<string, unknown> }>(listQueryKeyNoLabels);
+      expect(list?.items.has("test-resource")).toBe(false);
+    });
+
+    it("should not downgrade item cache when WebSocket already advanced resourceVersion", async () => {
+      const newer = {
+        ...mockFreshResource,
+        metadata: { ...mockFreshResource.metadata, resourceVersion: "300" },
+      };
+      queryClient.setQueryData(itemQueryKey, newer);
+
+      // Server response is older than what's already in cache (race with watch event)
+      vi.mocked(mockTrpcClient.k8s.update.mutate).mockResolvedValue(mockFreshResource);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-no-downgrade", k8sOperation.update), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      const after = queryClient.getQueryData<typeof newer>(itemQueryKey);
+      expect(after?.metadata.resourceVersion).toBe("300");
+    });
+
+    it("should not downgrade list cache when stored item has a newer resourceVersion", async () => {
+      const newerInList = {
+        ...mockFreshResource,
+        metadata: { ...mockFreshResource.metadata, resourceVersion: "300" },
+      };
+      queryClient.setQueryData(listQueryKeyNoLabels, {
+        apiVersion: "test.group/v1",
+        kind: "ResourceList",
+        metadata: { resourceVersion: "300" },
+        items: new Map([["test-resource", newerInList]]),
+      });
+
+      vi.mocked(mockTrpcClient.k8s.update.mutate).mockResolvedValue(mockFreshResource);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-list-no-downgrade", k8sOperation.update), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      const after = queryClient.getQueryData<{
+        metadata: { resourceVersion?: string };
+        items: Map<string, { metadata: { resourceVersion?: string } }>;
+      }>(listQueryKeyNoLabels);
+      expect(after?.items.get("test-resource")?.metadata.resourceVersion).toBe("300");
+      expect(after?.metadata.resourceVersion).toBe("300");
+    });
+
+    it("should use cluster scope key when resource is cluster-scoped", async () => {
+      const clusterScopedConfig: K8sResourceConfig = { ...mockResourceConfig, clusterScoped: true };
+      const clusterScopedItemKey = ["k8s:watchItem", "test-cluster", "__cluster__", "resources", "test-resource"];
+
+      vi.mocked(mockTrpcClient.k8s.update.mutate).mockResolvedValue(mockFreshResource);
+
+      const { result } = renderHook(() => useResourceCRUDMutation("test-cluster-scoped", k8sOperation.update), {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+      });
+
+      await result.current.mutateAsync({
+        resource: mockResource,
+        resourceConfig: clusterScopedConfig,
+      });
+
+      expect(queryClient.getQueryData(clusterScopedItemKey)).toEqual(mockFreshResource);
+    });
+  });
 });

--- a/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.tsx
+++ b/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.tsx
@@ -1,14 +1,30 @@
 import { useTRPCClient } from "@/core/providers/trpc";
 import { showToast, ToastOptions } from "@/core/components/Snackbar";
 import { useClusterStore } from "@/k8s/store";
-import { K8sOperation, k8sOperation, K8sResourceConfig, KubeObjectDraft } from "@my-project/shared";
-import { useMutation } from "@tanstack/react-query";
+import { K8sOperation, k8sOperation, K8sResourceConfig, KubeObjectBase, KubeObjectDraft } from "@my-project/shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useShallow } from "zustand/react/shallow";
+import { getK8sWatchItemQueryCacheKey, getK8sWatchListQueryCacheKey } from "../useWatch/query-keys";
+import { CustomKubeObjectList } from "../useWatch/types";
 
 type UseResourceCRUDMutationReturnType<
   KubeObjectData,
   Operation extends K8sOperation,
 > = Operation extends typeof k8sOperation.delete ? void : KubeObjectData;
+
+// Compare two K8s resourceVersion strings as integers; missing/invalid is treated
+// as -Infinity so we always prefer a defined value. Matches the watch event
+// handler's effective behavior (useWatchList.onWatchEvent skips only when current
+// is strictly greater), so equal versions still overwrite — a no-op when the data
+// is identical and a safe convergence point when the watch event races the mutation
+// response.
+const isNewer = (incoming: string | undefined, current: string | undefined): boolean => {
+  const a = incoming ? parseInt(incoming, 10) : NaN;
+  const b = current ? parseInt(current, 10) : NaN;
+  if (Number.isNaN(b)) return true;
+  if (Number.isNaN(a)) return false;
+  return a >= b;
+};
 
 interface Message {
   message: string;
@@ -42,6 +58,7 @@ export const useResourceCRUDMutation = <KubeObjectData extends KubeObjectDraft, 
   options?: UseResourceCRUDMutationOptions<KubeObjectData>
 ) => {
   const trpc = useTRPCClient();
+  const queryClient = useQueryClient();
   const showMessages = options?.showMessages ?? true;
 
   const { namespace, clusterName } = useClusterStore(
@@ -173,7 +190,72 @@ export const useResourceCRUDMutation = <KubeObjectData extends KubeObjectDraft, 
     onMutate: ({ resource }) => {
       options?.callbacks?.onMutate?.(resource);
     },
-    onSuccess: (_data, { resource }) => {
+    onSuccess: (data, { resource, resourceConfig }) => {
+      // Patch the watch caches with the server's response. Consumers otherwise
+      // depend solely on the K8s WebSocket event, which can be delayed or
+      // missed (watch restart, 410 Gone, tab throttling, watch unsubscribed
+      // during navigation) — leaving stale data until a full page refresh.
+      const ns = resourceConfig.clusterScoped ? undefined : (resource.metadata.namespace ?? namespace);
+      // For generateName flows, the draft has no name; the API server assigns one
+      // and returns it in the response. Prefer the response name when available.
+      const responseName = (data as KubeObjectBase | undefined)?.metadata?.name;
+      const name = responseName ?? resource.metadata.name;
+      const itemQueryKey = getK8sWatchItemQueryCacheKey(clusterName, ns, resourceConfig.pluralName, name);
+      const listQueryPrefix = getK8sWatchListQueryCacheKey(clusterName, ns, resourceConfig.pluralName);
+
+      // CREATE and UPDATE both write the item cache when a fresh resource is returned.
+      if ((operation === k8sOperation.create || operation === k8sOperation.update) && data) {
+        const fresh = data as KubeObjectBase;
+        queryClient.setQueryData<KubeObjectBase>(itemQueryKey, (prev) =>
+          isNewer(fresh.metadata.resourceVersion, prev?.metadata.resourceVersion) ? fresh : prev
+        );
+      }
+
+      // UPDATE: patch every list cache that already holds this item so consumers
+      // see fresh data without waiting for the watch event.
+      if (operation === k8sOperation.update && data && name) {
+        const fresh = data as KubeObjectBase;
+        const freshRV = fresh.metadata.resourceVersion;
+        const matches = queryClient.getQueriesData<CustomKubeObjectList<KubeObjectBase>>({ queryKey: listQueryPrefix });
+        for (const [key, prev] of matches) {
+          if (!prev) continue;
+          const existing = prev.items.get(name);
+          if (!existing || !isNewer(freshRV, existing.metadata.resourceVersion)) continue;
+          const newItems = new Map(prev.items);
+          newItems.set(name, fresh);
+          queryClient.setQueryData<CustomKubeObjectList<KubeObjectBase>>(key, {
+            ...prev,
+            metadata: {
+              ...prev.metadata,
+              resourceVersion: isNewer(freshRV, prev.metadata.resourceVersion)
+                ? (freshRV ?? prev.metadata.resourceVersion)
+                : prev.metadata.resourceVersion,
+            },
+            items: newItems,
+          });
+        }
+      }
+
+      // DELETE: clear the item cache and prune from every list cache that holds it.
+      if (operation === k8sOperation.delete && name) {
+        queryClient.removeQueries({ queryKey: itemQueryKey });
+        const matches = queryClient.getQueriesData<CustomKubeObjectList<KubeObjectBase>>({ queryKey: listQueryPrefix });
+        for (const [key, prev] of matches) {
+          if (!prev?.items.has(name)) continue;
+          const newItems = new Map(prev.items);
+          newItems.delete(name);
+          queryClient.setQueryData<CustomKubeObjectList<KubeObjectBase>>(key, { ...prev, items: newItems });
+        }
+      }
+
+      // CREATE: invalidate every list cache for the resource type. Label selectors
+      // aren't known at mutation time, so we can't surgically insert the new item;
+      // we mark all variants stale and force a refetch (refetchType "all" because
+      // list queries set refetchOnMount: false, so a remount alone wouldn't refresh).
+      if (operation === k8sOperation.create) {
+        queryClient.invalidateQueries({ queryKey: listQueryPrefix, refetchType: "all" });
+      }
+
       options?.callbacks?.onSuccess?.(resource);
     },
     onError: (error, { resource }) => {


### PR DESCRIPTION
Patch the K8s watch caches with the API server's mutation response and invalidate list queries on create, so the UI reflects the user's own actions immediately instead of waiting for a watch event that may be delayed, missed, or unavailable (watch unsubscribed during navigation, 410 Gone, server-emitted error).

- Item cache write on create/update, guarded by resourceVersion to avoid downgrades
- List cache patch on update; list cache prune on delete
- List query invalidation on create with refetchType "all" to bridge the refetchOnMount: false default and force a refresh of all label-variants
- Prefer the server-assigned name from the response for cache keys, so generateName flows write under the correct key

