### PR TITLE
EPMDEDP-16746: feat: Add native deployment metrics on Stage Monitoring tab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,9 @@ SONAR_TOKEN = squ_xxxxxxx
 SONAR_HOST_URL = https://sonar.example.com/
 # Optional: public Web UI URL for browser links (falls back to SONAR_HOST_URL if not set)
 # SONAR_WEB_URL = https://sonarqube.example.com/
+
+# Prometheus base URL used by the Stage Monitoring tab to fetch deployment
+# metrics. Required to enable that tab. Examples:
+#   In-cluster runtime:   http://prom-prometheus.monitoring.svc:9090
+#   Local dev (via port-forward): http://localhost:9090
+PROMETHEUS_URL =

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/Monitoring.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/Monitoring.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MetricChart } from "./components/MetricChart";
+import { Toolbar } from "./components/Toolbar";
+import { RemoteClusterNotice } from "./components/RemoteClusterNotice";
+
+const meta: Meta = {
+  title: "CDPipelines/StageDetails/Monitoring/Tab",
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+};
+export default meta;
+
+const now = Math.floor(Date.now() / 1000);
+const series = (offset: number, scale: number) =>
+  Array.from({ length: 30 }, (_, i) => ({
+    t: now - (29 - i) * 60,
+    v: scale * (1 + Math.sin(i / 4 + offset) * 0.4),
+  }));
+
+export const FullTabWithData: StoryObj = {
+  render: () => (
+    <div className="space-y-4">
+      <Toolbar
+        range="1h"
+        onRangeChange={() => {}}
+        autoRefresh
+        onAutoRefreshChange={() => {}}
+        lastUpdatedAt={now}
+        isStale={false}
+      />
+      <MetricChart
+        title="CPU usage"
+        unit="cores"
+        isLoading={false}
+        error={null}
+        data={[
+          { app: "frontend", series: series(0, 0.4) },
+          { app: "api", series: series(1, 0.7) },
+        ]}
+      />
+      <MetricChart
+        title="Memory (working set)"
+        unit="MiB"
+        isLoading={false}
+        error={null}
+        data={[
+          { app: "frontend", series: series(0, 200 * 1024 * 1024) },
+          { app: "api", series: series(1, 350 * 1024 * 1024) },
+        ]}
+      />
+      <MetricChart
+        title="Container restarts"
+        unit="count"
+        isLoading={false}
+        error={null}
+        data={[
+          {
+            app: "frontend",
+            series: [
+              { t: now - 600, v: 0 },
+              { t: now, v: 0 },
+            ],
+          },
+          {
+            app: "api",
+            series: [
+              { t: now - 600, v: 1 },
+              { t: now, v: 2 },
+            ],
+          },
+        ]}
+      />
+    </div>
+  ),
+};
+
+export const FullTabRemoteCluster: StoryObj = {
+  render: () => <RemoteClusterNotice />,
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/MetricChart.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/MetricChart.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MetricChart } from "./index";
+
+const meta = {
+  title: "CDPipelines/StageDetails/Monitoring/MetricChart",
+  component: MetricChart,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof MetricChart>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const now = Math.floor(Date.now() / 1000);
+const sampleSeries = (offset: number, scale: number) =>
+  Array.from({ length: 30 }, (_, i) => ({
+    t: now - (29 - i) * 60,
+    v: scale * (1 + Math.sin(i / 4 + offset) * 0.4),
+  }));
+
+export const WithDataSingleApp: Story = {
+  args: {
+    title: "CPU usage",
+    unit: "cores",
+    isLoading: false,
+    error: null,
+    data: [{ app: "krci-portal", series: sampleSeries(0, 0.5) }],
+  },
+};
+
+export const WithDataMultipleApps: Story = {
+  args: {
+    title: "CPU usage",
+    unit: "cores",
+    isLoading: false,
+    error: null,
+    data: [
+      { app: "frontend", series: sampleSeries(0, 0.4) },
+      { app: "api", series: sampleSeries(1, 0.7) },
+      { app: "worker", series: sampleSeries(2, 0.3) },
+    ],
+  },
+};
+
+export const Loading: Story = {
+  args: { title: "CPU usage", unit: "cores", isLoading: true, error: null, data: [] },
+};
+
+export const Empty: Story = {
+  args: { title: "CPU usage", unit: "cores", isLoading: false, error: null, data: [] },
+};
+
+export const ErrorState: Story = {
+  args: {
+    title: "CPU usage",
+    unit: "cores",
+    isLoading: false,
+    error: new globalThis.Error("Metrics query timed out. Try a shorter range."),
+    data: [],
+  },
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/index.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import type { MetricChartProps } from "../../types";
+import { Card } from "@/core/components/ui/card";
+import { LoadingSpinner } from "@/core/components/ui/LoadingSpinner";
+
+const PALETTE = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#06b6d4", "#a855f7", "#84cc16"];
+
+function formatValue(unit: MetricChartProps["unit"], v: number): string {
+  if (unit === "cores") return v.toFixed(2);
+  if (unit === "MiB") return Math.round(v / (1024 * 1024)).toString();
+  return Math.round(v).toString();
+}
+
+function formatTimestamp(t: number): string {
+  return new Date(t * 1000).toLocaleTimeString();
+}
+
+/**
+ * Recharts expects a single data array with one row per timestamp and one
+ * column per series. We merge the per-app series into that wide form.
+ */
+function toRechartsRows(data: MetricChartProps["data"]): { entries: Array<Record<string, number>>; keys: string[] } {
+  const allTs = new Set<number>();
+  for (const s of data) for (const p of s.series) allTs.add(p.t);
+  const sortedTs = [...allTs].sort((a, b) => a - b);
+  const rowMap = new Map<number, Record<string, number>>();
+  for (const t of sortedTs) rowMap.set(t, { t });
+  for (const s of data) {
+    for (const p of s.series) {
+      rowMap.get(p.t)![s.app] = p.v;
+    }
+  }
+  return { entries: [...rowMap.values()], keys: data.map((s) => s.app) };
+}
+
+export const MetricChart: React.FC<MetricChartProps> = ({ title, unit, data, isLoading, error }) => {
+  const { entries, keys } = React.useMemo(() => toRechartsRows(data), [data]);
+  const isEmpty = !isLoading && !error && entries.length === 0;
+
+  return (
+    <Card className="p-4" data-tour={`stage-monitoring-${unit}`}>
+      <div className="flex items-baseline justify-between">
+        <h4 className="text-foreground text-base font-semibold">{title}</h4>
+        <span className="text-muted-foreground text-xs">{unit}</span>
+      </div>
+      <div className="mt-3 h-64 w-full">
+        {isLoading && (
+          <div className="flex h-full items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        )}
+        {!isLoading && error && (
+          <div className="text-destructive flex h-full items-center justify-center text-sm">{error.message}</div>
+        )}
+        {isEmpty && (
+          <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+            No data in selected time range
+          </div>
+        )}
+        {!isLoading && !error && entries.length > 0 && (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={entries}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="t" tickFormatter={formatTimestamp} minTickGap={32} />
+              <YAxis tickFormatter={(v: number) => formatValue(unit, v)} width={48} />
+              <Tooltip
+                labelFormatter={(t: number) => formatTimestamp(t)}
+                formatter={(v: number | undefined, app: string | undefined) => [
+                  v !== undefined ? formatValue(unit, v) : "",
+                  app ?? "",
+                ]}
+              />
+              <Legend />
+              {keys.map((app, i) => (
+                <Line
+                  key={app}
+                  type="monotone"
+                  dataKey={app}
+                  stroke={PALETTE[i % PALETTE.length]}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/RemoteClusterNotice/RemoteClusterNotice.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/RemoteClusterNotice/RemoteClusterNotice.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RemoteClusterNotice } from "./index";
+
+const meta = {
+  title: "CDPipelines/StageDetails/Monitoring/RemoteClusterNotice",
+  component: RemoteClusterNotice,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof RemoteClusterNotice>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/RemoteClusterNotice/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/RemoteClusterNotice/index.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { Info } from "lucide-react";
+import { Card } from "@/core/components/ui/card";
+
+export const RemoteClusterNotice: React.FC = () => (
+  <Card className="p-6">
+    <div className="flex items-start gap-3">
+      <Info className="text-primary mt-1 size-5 shrink-0" />
+      <div>
+        <h4 className="text-foreground text-base font-semibold">Coming soon for remote clusters</h4>
+        <p className="text-muted-foreground mt-1 text-sm">
+          We&apos;re working on making this work for remote clusters. For now, deployment metrics are available only for
+          stages running in the local cluster.
+        </p>
+      </div>
+    </div>
+  </Card>
+);

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Toolbar/Toolbar.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Toolbar/Toolbar.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Toolbar } from "./index";
+
+const meta = {
+  title: "CDPipelines/StageDetails/Monitoring/Toolbar",
+  component: Toolbar,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  args: {
+    range: "1h",
+    onRangeChange: () => {},
+    autoRefresh: true,
+    onAutoRefreshChange: () => {},
+    lastUpdatedAt: Math.floor(Date.now() / 1000),
+    isStale: false,
+  },
+} satisfies Meta<typeof Toolbar>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AutoRefreshOff: Story = {
+  args: { autoRefresh: false },
+};
+
+export const Stale: Story = {
+  args: { isStale: true },
+};
+
+export const NeverFetched: Story = {
+  args: { lastUpdatedAt: undefined },
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Toolbar/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Toolbar/index.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { Clock, RefreshCw, AlertTriangle } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/core/components/ui/select";
+import { Switch } from "@/core/components/ui/switch";
+import { Label } from "@/core/components/ui/label";
+import type { ToolbarProps } from "../../types";
+import { RANGE_OPTIONS } from "../../constants";
+
+function formatTimestamp(t: number): string {
+  return new Date(t * 1000).toLocaleTimeString();
+}
+
+export const Toolbar: React.FC<ToolbarProps> = ({
+  range,
+  onRangeChange,
+  autoRefresh,
+  onAutoRefreshChange,
+  lastUpdatedAt,
+  isStale,
+}) => {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 pb-3">
+      <div className="flex items-center gap-2">
+        <Clock className="text-muted-foreground size-4" />
+        <Select value={range} onValueChange={(v) => onRangeChange(v as ToolbarProps["range"])}>
+          <SelectTrigger className="w-44" aria-label="Select time range">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RANGE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="text-muted-foreground flex items-center gap-3 text-xs">
+        {lastUpdatedAt !== undefined && (
+          <span className="flex items-center gap-1">
+            {isStale && <AlertTriangle className="size-3.5 text-amber-500" aria-label="Refresh failed" />}
+            Last updated {formatTimestamp(lastUpdatedAt)}
+          </span>
+        )}
+        <Label className="flex items-center gap-2">
+          <RefreshCw className="size-3.5" />
+          <span>Auto-refresh</span>
+          <Switch checked={autoRefresh} onCheckedChange={onAutoRefreshChange} aria-label="Toggle auto-refresh" />
+        </Label>
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/constants.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/constants.ts
@@ -1,0 +1,13 @@
+import { type MetricRange } from "@my-project/shared";
+
+export const RANGE_OPTIONS: ReadonlyArray<{ value: MetricRange; label: string }> = [
+  { value: "5m", label: "Last 5 minutes" },
+  { value: "15m", label: "Last 15 minutes" },
+  { value: "1h", label: "Last 1 hour" },
+  { value: "6h", label: "Last 6 hours" },
+  { value: "24h", label: "Last 24 hours" },
+];
+
+export const DEFAULT_RANGE: MetricRange = "1h";
+export const DEFAULT_AUTO_REFRESH = true;
+export const REFRESH_INTERVAL_MS = 30_000;

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useDeploymentMetrics.test.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useDeploymentMetrics.test.tsx
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useDeploymentMetrics } from "./useDeploymentMetrics";
+import type { DeploymentMetricsOutput } from "@my-project/shared";
+
+const mockQuery = vi.fn();
+
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({
+    prometheus: {
+      getDeploymentMetrics: { query: mockQuery },
+    },
+  }),
+}));
+
+const okResponse: DeploymentMetricsOutput = {
+  cpu: [],
+  memory: [],
+  restarts: [],
+  range: "1h",
+  queriedAt: 1700000000,
+};
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, Wrapper };
+}
+
+describe("useDeploymentMetrics", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue(okResponse);
+  });
+
+  it("calls the tRPC client and exposes data", async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () =>
+        useDeploymentMetrics({
+          clusterName: "in-cluster",
+          namespace: "test-namespace",
+          applications: ["test-app"],
+          range: "1h",
+          autoRefresh: true,
+          enabled: true,
+        }),
+      { wrapper: Wrapper }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(okResponse);
+  });
+
+  it("uses a stable query key across applications reordering (cache hit)", async () => {
+    const { Wrapper } = makeWrapper();
+    const { result: a } = renderHook(
+      () =>
+        useDeploymentMetrics({
+          clusterName: "in-cluster",
+          namespace: "ns",
+          applications: ["b", "a"],
+          range: "1h",
+          autoRefresh: true,
+          enabled: true,
+        }),
+      { wrapper: Wrapper }
+    );
+    await waitFor(() => expect(a.current.isSuccess).toBe(true));
+
+    const { result: b } = renderHook(
+      () =>
+        useDeploymentMetrics({
+          clusterName: "in-cluster",
+          namespace: "ns",
+          applications: ["a", "b"],
+          range: "1h",
+          autoRefresh: true,
+          enabled: true,
+        }),
+      { wrapper: Wrapper }
+    );
+    await waitFor(() => expect(b.current.isSuccess).toBe(true));
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables refetchInterval when autoRefresh is false", async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () =>
+        useDeploymentMetrics({
+          clusterName: "in-cluster",
+          namespace: "ns",
+          applications: ["app"],
+          range: "1h",
+          autoRefresh: false,
+          enabled: true,
+        }),
+      { wrapper: Wrapper }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const initialCalls = mockQuery.mock.calls.length;
+    await new Promise((r) => setTimeout(r, 100));
+    expect(mockQuery.mock.calls.length).toBe(initialCalls);
+  });
+
+  it("respects enabled=false (no fetch)", async () => {
+    const { Wrapper } = makeWrapper();
+    renderHook(
+      () =>
+        useDeploymentMetrics({
+          clusterName: "in-cluster",
+          namespace: "ns",
+          applications: ["app"],
+          range: "1h",
+          autoRefresh: true,
+          enabled: false,
+        }),
+      { wrapper: Wrapper }
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("retains previous data across a rejected refetch (placeholderData: keepPreviousData)", async () => {
+    // Use retryDelay: 0 so the hook's retry: 1 fires immediately in tests.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+    });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    mockQuery.mockResolvedValueOnce(okResponse);
+    const { result, rerender } = renderHook(
+      ({ range }: { range: "1h" | "5m" }) =>
+        useDeploymentMetrics({
+          clusterName: "in-cluster",
+          namespace: "ns",
+          applications: ["app"],
+          range,
+          autoRefresh: true,
+          enabled: true,
+        }),
+      { wrapper: Wrapper, initialProps: { range: "1h" as "1h" | "5m" } }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(okResponse);
+
+    // Trigger a new query (different range -> different cache key) that never resolves.
+    // While the new query is in-flight, keepPreviousData serves the previous result
+    // as placeholder data so charts remain on screen.
+    let resolveNext!: (v: unknown) => void;
+    mockQuery.mockImplementationOnce(
+      () =>
+        new Promise((res) => {
+          resolveNext = res;
+        })
+    );
+    rerender({ range: "5m" });
+
+    // During the pending phase of the new key, previous data is visible as placeholder.
+    await waitFor(() => expect(result.current.isPlaceholderData).toBe(true));
+    expect(result.current.data).toEqual(okResponse);
+
+    // Clean up: resolve the pending query so the hook can settle.
+    resolveNext(okResponse);
+    await waitFor(() => expect(result.current.isPlaceholderData).toBe(false));
+  });
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useDeploymentMetrics.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useDeploymentMetrics.ts
@@ -1,0 +1,39 @@
+import { useTRPCClient } from "@/core/providers/trpc";
+import { sortByName } from "@/core/utils/sortByName";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import type { DeploymentMetricsOutput, MetricRange } from "@my-project/shared";
+import { REFRESH_INTERVAL_MS } from "../constants";
+
+export interface UseDeploymentMetricsParams {
+  clusterName: string;
+  namespace: string;
+  applications: string[];
+  range: MetricRange;
+  autoRefresh: boolean;
+  /** When false, the query is suspended (e.g. remote-cluster Stage). */
+  enabled: boolean;
+}
+
+export function useDeploymentMetrics(params: UseDeploymentMetricsParams) {
+  const trpc = useTRPCClient();
+  const { clusterName, namespace, applications, range, autoRefresh, enabled } = params;
+
+  // Stable cache key independent of input order.
+  const sortedApps = [...applications].sort(sortByName);
+
+  return useQuery<DeploymentMetricsOutput>({
+    queryKey: ["prometheus.getDeploymentMetrics", clusterName, namespace, sortedApps.join(","), range],
+    queryFn: () =>
+      trpc.prometheus.getDeploymentMetrics.query({
+        clusterName,
+        namespace,
+        applications,
+        range,
+      }),
+    enabled,
+    refetchInterval: autoRefresh ? REFRESH_INTERVAL_MS : false,
+    staleTime: REFRESH_INTERVAL_MS,
+    placeholderData: keepPreviousData,
+    retry: 1,
+  });
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/index.tsx
@@ -1,38 +1,117 @@
-import { LinkCreationService } from "@/k8s/services/link-creation";
-import { useQuickLinksUrlListWatch, useStageWatch } from "@/modules/platform/cdpipelines/pages/stage-details/hooks";
-import { quickLinkLabels, systemQuickLink } from "@my-project/shared";
+import * as React from "react";
+import { inClusterName } from "@my-project/shared";
 import { Card } from "@/core/components/ui/card";
+import { useStageWatch, usePipelineAppCodebasesWatch } from "@/modules/platform/cdpipelines/pages/stage-details/hooks";
+import { routeStageDetails } from "@/modules/platform/cdpipelines/pages/stage-details/route";
+import { Toolbar } from "./components/Toolbar";
+import { MetricChart } from "./components/MetricChart";
+import { RemoteClusterNotice } from "./components/RemoteClusterNotice";
+import { useDeploymentMetrics } from "./hooks/useDeploymentMetrics";
+import { DEFAULT_AUTO_REFRESH, DEFAULT_RANGE } from "./constants";
+import type { MetricRange } from "@my-project/shared";
 
-export const Monitoring = () => {
-  const quickLinksUrlListWatch = useQuickLinksUrlListWatch();
+export const Monitoring: React.FC = () => {
+  const params = routeStageDetails.useParams();
   const stageWatch = useStageWatch();
-
-  const quickLinksUrls = quickLinksUrlListWatch.data?.quickLinkURLs;
-  const monitoringQuickLinkBaseUrl = quickLinksUrls?.[systemQuickLink.monitoring];
-
-  const quickLinks = quickLinksUrlListWatch.data?.quickLinkList;
-  const monitoringQuickLink = quickLinks?.find((quickLink) => quickLink.metadata.name === systemQuickLink.monitoring);
-  const monitoringQuickLinkProvider = monitoringQuickLink?.metadata.labels?.[quickLinkLabels.provider];
-
   const stage = stageWatch.query.data;
+  const appCodebasesWatch = usePipelineAppCodebasesWatch();
+
+  const isRemoteCluster = stage !== undefined && stage.spec.clusterName !== inClusterName;
+
+  const [range, setRange] = React.useState<MetricRange>(DEFAULT_RANGE);
+  const [autoRefresh, setAutoRefresh] = React.useState<boolean>(DEFAULT_AUTO_REFRESH);
+
+  const applications = React.useMemo(
+    () => appCodebasesWatch.data.map((c) => c.metadata.name),
+    [appCodebasesWatch.data]
+  );
+
   const namespace = stage?.spec.namespace;
-  const clusterName = stage?.spec.clusterName;
+
+  const metrics = useDeploymentMetrics({
+    clusterName: params.clusterName,
+    namespace: namespace ?? "",
+    applications,
+    range,
+    autoRefresh,
+    enabled: !!namespace && !isRemoteCluster && !appCodebasesWatch.isLoading,
+  });
+
+  if (stageWatch.query.isLoading) {
+    return (
+      <Card className="p-6" data-tour="stage-monitoring">
+        <h3 className="text-foreground mb-4 text-xl font-semibold">Monitoring</h3>
+        <div className="text-muted-foreground text-sm">Loading…</div>
+      </Card>
+    );
+  }
+
+  if (isRemoteCluster) {
+    return (
+      <div data-tour="stage-monitoring">
+        <RemoteClusterNotice />
+      </div>
+    );
+  }
+
+  const errorObj = metrics.error as (Error & { data?: { code?: string } }) | null;
+  const errorCode = errorObj?.data?.code;
+  const errorMessage = (() => {
+    if (!errorObj) return null;
+    switch (errorCode) {
+      case "PRECONDITION_FAILED":
+        return "Metrics are not configured. Set PROMETHEUS_URL on the server.";
+      case "GATEWAY_TIMEOUT":
+        return "Metrics query timed out. Try a shorter range.";
+      case "BAD_GATEWAY":
+        return "Cannot reach Prometheus. Check that the metrics service is running.";
+      default:
+        return errorObj.message;
+    }
+  })();
+
+  const data = metrics.data;
+  const isLoading = metrics.isLoading;
+
+  // Suppress error in charts while keepPreviousData keeps the last successful
+  // payload visible; the Toolbar's stale indicator communicates the failure.
+  const error = errorMessage && !data ? new Error(errorMessage) : null;
+  const isStale = data !== undefined && metrics.isError;
+
+  if (!isLoading && !appCodebasesWatch.isLoading && applications.length === 0) {
+    return (
+      <Card className="p-6" data-tour="stage-monitoring">
+        <h3 className="text-foreground mb-4 text-xl font-semibold">Monitoring</h3>
+        <div className="text-muted-foreground text-sm">No applications deployed to this stage.</div>
+      </Card>
+    );
+  }
 
   return (
-    <Card className="p-6" data-tour="stage-monitoring">
-      <h3 className="text-foreground mb-4 text-xl font-semibold">Monitoring</h3>
-      <iframe
-        title="monitoring"
-        frameBorder="0"
-        height="800"
-        width="100%"
-        src={LinkCreationService.monitoring.createDashboardLink({
-          provider: monitoringQuickLinkProvider,
-          baseURL: monitoringQuickLinkBaseUrl,
-          namespace: namespace!,
-          clusterName,
-        })}
+    <div className="space-y-4" data-tour="stage-monitoring">
+      <Toolbar
+        range={range}
+        onRangeChange={setRange}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        lastUpdatedAt={data?.queriedAt}
+        isStale={isStale}
       />
-    </Card>
+      <MetricChart title="CPU usage" unit="cores" data={data?.cpu ?? []} isLoading={isLoading} error={error} />
+      <MetricChart
+        title="Memory (working set)"
+        unit="MiB"
+        data={data?.memory ?? []}
+        isLoading={isLoading}
+        error={error}
+      />
+      <MetricChart
+        title="Container restarts"
+        unit="count"
+        data={data?.restarts ?? []}
+        isLoading={isLoading}
+        error={error}
+      />
+    </div>
   );
 };

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/types.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/types.ts
@@ -1,0 +1,20 @@
+import type { MetricRange, MetricSeriesByApp } from "@my-project/shared";
+
+export type MetricKind = "cpu" | "memory" | "restarts";
+
+export interface MetricChartProps {
+  title: string;
+  unit: "cores" | "MiB" | "count";
+  data: MetricSeriesByApp[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export interface ToolbarProps {
+  range: MetricRange;
+  onRangeChange: (range: MetricRange) => void;
+  autoRefresh: boolean;
+  onAutoRefreshChange: (next: boolean) => void;
+  lastUpdatedAt: number | undefined;
+  isStale: boolean;
+}

--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -38,6 +38,7 @@ A Helm chart for KubeRocketCI Portal
 | configEnv.OIDC_ISSUER_URL | string | `"https://keycloak.example.com/realms/shared"` |  |
 | configEnv.OIDC_SCOPE | string | `"openid profile email"` |  |
 | configEnv.PORTAL_URL | string | `"https://portal.example.com"` |  |
+| configEnv.PROMETHEUS_URL | string | `"http://prometheus.monitoring.svc:9090"` |  |
 | configEnv.SERVER_PORT | int | `3000` |  |
 | configEnv.SONAR_HOST_URL | string | `"https://sonar.example.com/"` |  |
 | configEnv.TEKTON_RESULTS_URL | string | `"https://tekton-results.example.com"` |  |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -47,6 +47,10 @@ configEnv:
   DEPENDENCY_TRACK_URL: https://deptrack.example.com
   # DEPENDENCY_TRACK_WEB_URL: https://deptrack-public.example.com
   GITFUSION_URL: http://gitfusion.krci:8080
+  # PROMETHEUS_URL is the cluster-local Prometheus base URL used by the Monitoring.
+  # When unset, the tab returns PRECONDITION_FAILED.
+  # Example (in-cluster): http://prometheus.monitoring.svc:9090
+  PROMETHEUS_URL: http://prometheus.monitoring.svc:9090
 
 # -- Extends envFrom for the Deployment definition.
 # we expect to deserialize key-value pairs from the secret, e.g

--- a/packages/shared/src/models/index.ts
+++ b/packages/shared/src/models/index.ts
@@ -2,6 +2,7 @@ export * from "./auth/index.js";
 export * from "./dependencyTrack/index.js";
 export * from "./k8s/index.js";
 export * from "./k8s/groups/Capsule/index.js";
+export * from "./prometheus/index.js";
 export * from "./sonarqube/index.js";
 export * from "./user/index.js";
 export * from "./tektonResults/index.js";

--- a/packages/shared/src/models/prometheus/constants.ts
+++ b/packages/shared/src/models/prometheus/constants.ts
@@ -1,0 +1,22 @@
+export const METRIC_RANGE_VALUES = ["5m", "15m", "1h", "6h", "24h"] as const;
+
+export const PROMETHEUS_TIME_RANGES = {
+  "5m": 300,
+  "15m": 900,
+  "1h": 3600,
+  "6h": 21600,
+  "24h": 86400,
+} as const;
+
+// Step chosen so payload size stays bounded across all ranges.
+export const STEP_BY_RANGE = {
+  "5m": 15,
+  "15m": 30,
+  "1h": 30,
+  "6h": 120,
+  "24h": 300,
+} as const;
+
+export const MAX_APPLICATIONS = 50;
+
+export const PROMETHEUS_TIMEOUT_MS = 10_000;

--- a/packages/shared/src/models/prometheus/index.ts
+++ b/packages/shared/src/models/prometheus/index.ts
@@ -1,0 +1,3 @@
+export * from "./constants.js";
+export * from "./schemas.js";
+export * from "./types.js";

--- a/packages/shared/src/models/prometheus/schemas.ts
+++ b/packages/shared/src/models/prometheus/schemas.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { METRIC_RANGE_VALUES, MAX_APPLICATIONS } from "./constants.js";
+
+// namespace must match RFC-1123 to be safe inside the templated PromQL.
+export const deploymentMetricsInputSchema = z
+  .object({
+    clusterName: z.string().min(1),
+    namespace: z
+      .string()
+      .min(1)
+      .regex(
+        /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/,
+        "namespace must match RFC-1123 DNS label (lowercase alphanumeric, optional hyphens, max 63 chars, must start and end with alphanumeric)"
+      ),
+    applications: z.array(z.string().min(1)).max(MAX_APPLICATIONS),
+    range: z.enum(METRIC_RANGE_VALUES),
+  })
+  .strict();
+
+export const metricSeriesPointSchema = z.object({
+  t: z.number(), // unix seconds
+  v: z.number(),
+});
+
+export const metricSeriesByAppSchema = z.object({
+  app: z.string(),
+  series: z.array(metricSeriesPointSchema),
+});
+
+export const deploymentMetricsOutputSchema = z.object({
+  cpu: z.array(metricSeriesByAppSchema),
+  memory: z.array(metricSeriesByAppSchema),
+  restarts: z.array(metricSeriesByAppSchema),
+  range: z.enum(METRIC_RANGE_VALUES),
+  queriedAt: z.number(),
+});
+
+// Minimal subset of Prometheus query_range matrix shape used for response validation.
+export const promqlMatrixResponseSchema = z.object({
+  status: z.literal("success"),
+  data: z.object({
+    resultType: z.literal("matrix"),
+    result: z.array(
+      z.object({
+        metric: z.record(z.string(), z.string()),
+        values: z.array(z.tuple([z.number(), z.string()])),
+      })
+    ),
+  }),
+});

--- a/packages/shared/src/models/prometheus/types.ts
+++ b/packages/shared/src/models/prometheus/types.ts
@@ -1,0 +1,16 @@
+import type { z } from "zod";
+import type {
+  deploymentMetricsInputSchema,
+  deploymentMetricsOutputSchema,
+  promqlMatrixResponseSchema,
+  metricSeriesPointSchema,
+  metricSeriesByAppSchema,
+} from "./schemas.js";
+import type { METRIC_RANGE_VALUES } from "./constants.js";
+
+export type DeploymentMetricsInput = z.infer<typeof deploymentMetricsInputSchema>;
+export type DeploymentMetricsOutput = z.infer<typeof deploymentMetricsOutputSchema>;
+export type PromQLMatrixResponse = z.infer<typeof promqlMatrixResponseSchema>;
+export type MetricRange = (typeof METRIC_RANGE_VALUES)[number];
+export type MetricSeriesPoint = z.infer<typeof metricSeriesPointSchema>;
+export type MetricSeriesByApp = z.infer<typeof metricSeriesByAppSchema>;

--- a/packages/trpc/src/clients/prometheus/index.test.ts
+++ b/packages/trpc/src/clients/prometheus/index.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const originalEnv = process.env;
+
+describe("createPrometheusClient", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should throw TRPCError(PRECONDITION_FAILED) when PROMETHEUS_URL is not set", async () => {
+    delete process.env.PROMETHEUS_URL;
+    const { createPrometheusClient } = await import("./index.js");
+
+    expect(() => createPrometheusClient()).toThrowError(expect.objectContaining({ code: "PRECONDITION_FAILED" }));
+  });
+
+  it("should return a client when PROMETHEUS_URL is configured", async () => {
+    process.env.PROMETHEUS_URL = "http://prom.example:9090";
+    const { createPrometheusClient } = await import("./index.js");
+    const client = createPrometheusClient();
+
+    expect(client).toBeDefined();
+    expect(typeof client.rangeQuery).toBe("function");
+  });
+});
+
+describe("PrometheusClient.rangeQuery URL shape", () => {
+  const BASE = "http://prom.example:9090";
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: { resultType: "matrix", result: [] },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  async function newClient() {
+    const { PrometheusClient } = await import("./index.js");
+    return new PrometheusClient({ baseURL: BASE, timeoutMs: 500 });
+  }
+
+  function capturedUrl(): string {
+    const firstCall = fetchMock.mock.calls[0];
+    return String(firstCall[0]);
+  }
+
+  it("rangeQuery encodes query, integer start/end, and step with 's' suffix", async () => {
+    const client = await newClient();
+    await client.rangeQuery({
+      query: 'up{namespace="foo"}',
+      start: 1700000000.7,
+      end: 1700003600.2,
+      step: 30,
+    });
+    const url = capturedUrl();
+    expect(url).toContain("/api/v1/query_range?");
+    expect(url).toContain("query=up%7Bnamespace%3D%22foo%22%7D");
+    expect(url).toContain("start=1700000000");
+    expect(url).toContain("end=1700003600");
+    expect(url).toContain("step=30s");
+  });
+
+  it("rangeQuery happy path parses matrix shape", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: {
+            resultType: "matrix",
+            result: [
+              {
+                metric: { pod: "test-pod-abc123-xyz" },
+                values: [
+                  [1777712697, "0.0001"],
+                  [1777712727, "0.0002"],
+                ],
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    const client = await newClient();
+    const result = await client.rangeQuery({ query: "x", start: 0, end: 1, step: 1 });
+    expect(result.data.result[0]?.metric.pod).toBe("test-pod-abc123-xyz");
+    expect(result.data.result[0]?.values).toHaveLength(2);
+  });
+});
+
+describe("PrometheusClient timeout & errors", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("rangeQuery rejects with timeout message when fetch hangs past timeoutMs", async () => {
+    globalThis.fetch = vi.fn(
+      (_url: string, init: { signal?: AbortSignal } = {}) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        })
+    ) as unknown as typeof globalThis.fetch;
+
+    const { PrometheusClient } = await import("./index.js");
+    const client = new PrometheusClient({ baseURL: "http://x", timeoutMs: 10 });
+    await expect(client.rangeQuery({ query: "x", start: 0, end: 1, step: 1 })).rejects.toThrow(/timed out/i);
+  });
+
+  it("rangeQuery rejects with status text on non-2xx", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("bad query", { status: 400, statusText: "Bad Request" })
+      ) as unknown as typeof globalThis.fetch;
+
+    const { PrometheusClient } = await import("./index.js");
+    const client = new PrometheusClient({ baseURL: "http://x", timeoutMs: 500 });
+    await expect(client.rangeQuery({ query: "x", start: 0, end: 1, step: 1 })).rejects.toThrow(/400 Bad Request/);
+  });
+});

--- a/packages/trpc/src/clients/prometheus/index.ts
+++ b/packages/trpc/src/clients/prometheus/index.ts
@@ -1,0 +1,92 @@
+import { TRPCError } from "@trpc/server";
+import { promqlMatrixResponseSchema, PROMETHEUS_TIMEOUT_MS } from "@my-project/shared";
+import type { PromQLMatrixResponse } from "@my-project/shared";
+
+export interface PrometheusClientConfig {
+  baseURL: string;
+  timeoutMs: number;
+}
+
+/** Read PROMETHEUS_URL once at module load. */
+function loadConfig(): { baseURL: string } {
+  return {
+    baseURL: (process.env.PROMETHEUS_URL || "").replace(/\/$/, ""),
+  };
+}
+
+const moduleConfig = loadConfig();
+
+export function createPrometheusClient(): PrometheusClient {
+  if (!moduleConfig.baseURL) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "PROMETHEUS_URL environment variable is not configured",
+    });
+  }
+  return new PrometheusClient({
+    baseURL: moduleConfig.baseURL,
+    timeoutMs: PROMETHEUS_TIMEOUT_MS,
+  });
+}
+
+export interface RangeQueryParams {
+  query: string;
+  /** Unix seconds. */
+  start: number;
+  /** Unix seconds. */
+  end: number;
+  /** Resolution in seconds; sent as `<step>s`. */
+  step: number;
+}
+
+export class PrometheusClient {
+  private readonly baseURL: string;
+  private readonly timeoutMs: number;
+
+  constructor(config: PrometheusClientConfig) {
+    if (!config.baseURL) {
+      throw new Error("Prometheus base URL is not configured");
+    }
+    this.baseURL = config.baseURL;
+    this.timeoutMs = config.timeoutMs;
+  }
+
+  async rangeQuery(params: RangeQueryParams, externalSignal?: AbortSignal): Promise<PromQLMatrixResponse> {
+    const qs = new URLSearchParams({
+      query: params.query,
+      start: String(Math.floor(params.start)),
+      end: String(Math.floor(params.end)),
+      step: `${params.step}s`,
+    }).toString();
+    return this.fetchJson(`/api/v1/query_range?${qs}`, externalSignal);
+  }
+
+  private async fetchJson(path: string, externalSignal?: AbortSignal): Promise<PromQLMatrixResponse> {
+    const url = `${this.baseURL}${path}`;
+    const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+    const signal = externalSignal ? AbortSignal.any([timeoutSignal, externalSignal]) : timeoutSignal;
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(
+          `Prometheus request failed: ${response.status} ${response.statusText}${text ? `\nResponse: ${text}` : ""}`
+        );
+      }
+
+      const json = await response.json();
+      return promqlMatrixResponseSchema.parse(json);
+    } catch (error) {
+      if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
+        throw new Error(`Prometheus request timed out after ${this.timeoutMs}ms`);
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/trpc/src/routers/index.ts
+++ b/packages/trpc/src/routers/index.ts
@@ -5,6 +5,7 @@ import { configRouter } from "./config/index.js";
 import { dependencyTrackRouter } from "./dependencyTrack/index.js";
 import { gitfusionRouter } from "./gitfusion/index.js";
 import { k8sRouter } from "./k8s/index.js";
+import { prometheusRouter } from "./prometheus/index.js";
 import { sonarqubeRouter } from "./sonarqube/index.js";
 import { tektonResultsRouter } from "./tektonResults/index.js";
 
@@ -14,6 +15,7 @@ export const appRouter = t.router({
   dependencyTrack: dependencyTrackRouter,
   gitfusion: gitfusionRouter,
   k8s: k8sRouter,
+  prometheus: prometheusRouter,
   sonarqube: sonarqubeRouter,
   tektonResults: tektonResultsRouter,
 });

--- a/packages/trpc/src/routers/prometheus/index.ts
+++ b/packages/trpc/src/routers/prometheus/index.ts
@@ -1,0 +1,6 @@
+import { t } from "../../trpc.js";
+import { getDeploymentMetrics } from "./procedures/index.js";
+
+export const prometheusRouter = t.router({
+  getDeploymentMetrics,
+});

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.test.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockedContext } from "../../../../__mocks__/context.js";
+
+const mockListResource = vi.fn();
+const mockRangeQuery = vi.fn();
+
+vi.mock("../../../../clients/k8s/index.js", () => ({
+  K8sClient: vi.fn().mockImplementation(() => ({
+    KubeConfig: {},
+    listResource: mockListResource,
+  })),
+}));
+
+vi.mock("../../../../clients/prometheus/index.js", () => ({
+  createPrometheusClient: () => ({
+    rangeQuery: mockRangeQuery,
+  }),
+}));
+
+async function getCaller() {
+  const { createCaller } = await import("../../../../routers/index.js");
+  return createCaller(createMockedContext());
+}
+
+const validInput = {
+  clusterName: "in-cluster",
+  namespace: "test-namespace",
+  applications: ["test-app"],
+  range: "1h" as const,
+};
+
+const emptyMatrix = {
+  status: "success" as const,
+  data: { resultType: "matrix" as const, result: [] },
+};
+
+describe("prometheus.getDeploymentMetrics", () => {
+  beforeEach(() => {
+    mockRangeQuery.mockResolvedValue(emptyMatrix);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("short-circuits when applications is empty (no K8s, no Prometheus)", async () => {
+    const caller = await getCaller();
+    const result = await caller.prometheus.getDeploymentMetrics({ ...validInput, applications: [] });
+
+    expect(mockListResource).not.toHaveBeenCalled();
+    expect(mockRangeQuery).not.toHaveBeenCalled();
+    expect(result.cpu).toEqual([]);
+    expect(result.memory).toEqual([]);
+    expect(result.restarts).toEqual([]);
+    expect(result.range).toBe("1h");
+    expect(typeof result.queriedAt).toBe("number");
+  });
+
+  it("throws INTERNAL_SERVER_ERROR when K8sClient KubeConfig is uninitialized", async () => {
+    // The shared mock at the top of the file always returns KubeConfig: {}.
+    // For this test, we need a falsy KubeConfig — use vi.mocked() to override the
+    // implementation just for this test.
+    //
+    // NOTE: getCaller() → createMockedContext() → new K8sClient() consumes one
+    // constructor call. We get the caller first, then override the mock so that
+    // the very next new K8sClient() call (inside the procedure) returns null KubeConfig.
+    const caller = await getCaller();
+
+    const k8sClientModule = await import("../../../../clients/k8s/index.js");
+    const K8sClientMock = vi.mocked(k8sClientModule.K8sClient);
+    K8sClientMock.mockImplementationOnce(
+      () =>
+        ({
+          KubeConfig: null,
+          listResource: mockListResource,
+        }) as unknown as InstanceType<typeof k8sClientModule.K8sClient>
+    );
+
+    await expect(caller.prometheus.getDeploymentMetrics(validInput)).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
+    expect(mockListResource).not.toHaveBeenCalled();
+  });
+
+  it("groups pods by app and sends a single combined PromQL pod regex per metric", async () => {
+    mockListResource.mockResolvedValueOnce({
+      items: [
+        { metadata: { name: "frontend-1", labels: { "app.kubernetes.io/instance": "frontend" } } },
+        { metadata: { name: "frontend-2", labels: { "app.kubernetes.io/instance": "frontend" } } },
+        { metadata: { name: "api-1", labels: { "app.kubernetes.io/instance": "api" } } },
+      ],
+    });
+    mockRangeQuery.mockResolvedValue({
+      status: "success",
+      data: {
+        resultType: "matrix",
+        result: [
+          {
+            metric: { pod: "frontend-1" },
+            values: [
+              [100, "1.0"],
+              [110, "2.0"],
+            ],
+          },
+          {
+            metric: { pod: "frontend-2" },
+            values: [[110, "0.5"]],
+          },
+          {
+            metric: { pod: "api-1" },
+            values: [[100, "3.0"]],
+          },
+        ],
+      },
+    });
+
+    const caller = await getCaller();
+    const result = await caller.prometheus.getDeploymentMetrics({
+      ...validInput,
+      applications: ["frontend", "api"],
+    });
+
+    expect(mockRangeQuery).toHaveBeenCalledTimes(3);
+    const firstQuery = mockRangeQuery.mock.calls[0][0].query as string;
+    expect(firstQuery).toContain('namespace="test-namespace"');
+    expect(firstQuery).toContain('pod=~"');
+    expect(firstQuery).toContain("frontend-1");
+    expect(firstQuery).toContain("frontend-2");
+    expect(firstQuery).toContain("api-1");
+
+    const frontend = result.cpu.find((r) => r.app === "frontend");
+    expect(frontend?.series).toEqual([
+      { t: 100, v: 1.0 },
+      { t: 110, v: 2.5 },
+    ]);
+    const api = result.cpu.find((r) => r.app === "api");
+    expect(api?.series).toEqual([{ t: 100, v: 3.0 }]);
+  });
+
+  it("includes apps with zero matched pods in the output as empty series", async () => {
+    mockListResource.mockResolvedValueOnce({
+      items: [{ metadata: { name: "frontend-1", labels: { "app.kubernetes.io/instance": "frontend" } } }],
+    });
+    const caller = await getCaller();
+    const result = await caller.prometheus.getDeploymentMetrics({
+      ...validInput,
+      applications: ["frontend", "missing"],
+    });
+
+    const missing = result.cpu.find((r) => r.app === "missing");
+    expect(missing).toBeDefined();
+    expect(missing?.series).toEqual([]);
+
+    const frontend = result.cpu.find((r) => r.app === "frontend");
+    expect(frontend).toBeDefined();
+    expect(mockRangeQuery).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns empty series per app when zero pods match any requested app (no Prometheus call)", async () => {
+    mockListResource.mockResolvedValueOnce({ items: [] });
+    const caller = await getCaller();
+    const result = await caller.prometheus.getDeploymentMetrics({
+      ...validInput,
+      applications: ["frontend", "api"],
+    });
+
+    expect(mockRangeQuery).not.toHaveBeenCalled();
+    expect(result.cpu.map((r) => r.app)).toEqual(["frontend", "api"]);
+    expect(result.cpu.every((r) => r.series.length === 0)).toBe(true);
+  });
+
+  it("maps Prometheus rejection to BAD_GATEWAY", async () => {
+    mockListResource.mockResolvedValueOnce({
+      items: [{ metadata: { name: "p", labels: { "app.kubernetes.io/instance": "test-app" } } }],
+    });
+    mockRangeQuery.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const caller = await getCaller();
+    await expect(caller.prometheus.getDeploymentMetrics(validInput)).rejects.toMatchObject({
+      code: "BAD_GATEWAY",
+    });
+  });
+
+  it("maps timeout messages to GATEWAY_TIMEOUT", async () => {
+    mockListResource.mockResolvedValueOnce({
+      items: [{ metadata: { name: "p", labels: { "app.kubernetes.io/instance": "test-app" } } }],
+    });
+    mockRangeQuery.mockRejectedValueOnce(new Error("Prometheus request timed out after 10000ms"));
+
+    const caller = await getCaller();
+    await expect(caller.prometheus.getDeploymentMetrics(validInput)).rejects.toMatchObject({
+      code: "GATEWAY_TIMEOUT",
+    });
+  });
+
+  it("Zod rejects bad namespace", async () => {
+    const caller = await getCaller();
+    await expect(
+      caller.prometheus.getDeploymentMetrics({ ...validInput, namespace: "Bad_Namespace!" })
+    ).rejects.toThrow();
+  });
+
+  it("Zod rejects unsupported range", async () => {
+    const caller = await getCaller();
+    await expect(
+      // @ts-expect-error — deliberately invalid
+      caller.prometheus.getDeploymentMetrics({ ...validInput, range: "2h" })
+    ).rejects.toThrow();
+  });
+
+  it("Zod rejects more than 50 applications", async () => {
+    const caller = await getCaller();
+    const apps = Array.from({ length: 51 }, (_, i) => `app-${i}`);
+    await expect(caller.prometheus.getDeploymentMetrics({ ...validInput, applications: apps })).rejects.toThrow();
+  });
+});

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.ts
@@ -1,0 +1,96 @@
+import { TRPCError } from "@trpc/server";
+import {
+  deploymentMetricsInputSchema,
+  deploymentMetricsOutputSchema,
+  k8sPodConfig,
+  STEP_BY_RANGE,
+  PROMETHEUS_TIME_RANGES,
+  type DeploymentMetricsOutput,
+  type MetricSeriesByApp,
+  type PromQLMatrixResponse,
+} from "@my-project/shared";
+import { protectedProcedure } from "../../../../procedures/protected/index.js";
+import { K8sClient } from "../../../../clients/k8s/index.js";
+import { ERROR_K8S_CLIENT_NOT_INITIALIZED } from "../../../k8s/errors/index.js";
+import { createPrometheusClient } from "../../../../clients/prometheus/index.js";
+import { APP_INSTANCE_LABEL, buildPromQLQueries, groupPodsByApp, matrixToSeriesByApp } from "./utils.js";
+
+export const getDeploymentMetricsProcedure = protectedProcedure
+  .input(deploymentMetricsInputSchema)
+  .output(deploymentMetricsOutputSchema)
+  .query(async ({ input, ctx }): Promise<DeploymentMetricsOutput> => {
+    // `clusterName` is part of the input for client-side cache-key stability;
+    // server uses a single PROMETHEUS_URL and resolves the cluster via session.
+    const { namespace, applications, range } = input;
+    const queriedAt = Math.floor(Date.now() / 1000);
+
+    if (applications.length === 0) {
+      return { cpu: [], memory: [], restarts: [], range, queriedAt };
+    }
+
+    const k8sClient = new K8sClient(ctx.session);
+    if (!k8sClient.KubeConfig) {
+      throw new TRPCError(ERROR_K8S_CLIENT_NOT_INITIALIZED);
+    }
+
+    const labelSelector = `${APP_INSTANCE_LABEL} in (${applications.join(",")})`;
+    const podList = await k8sClient.listResource(k8sPodConfig, namespace, labelSelector);
+
+    const podsByApp = groupPodsByApp(
+      (podList.items ?? []) as Array<{ metadata: { name: string; labels?: Record<string, string> } }>,
+      applications
+    );
+
+    const podToApp = new Map<string, string>();
+    const allPodNames: string[] = [];
+    for (const [app, pods] of podsByApp) {
+      for (const podName of pods) {
+        podToApp.set(podName, app);
+        allPodNames.push(podName);
+      }
+    }
+
+    if (allPodNames.length === 0) {
+      const empty: MetricSeriesByApp[] = applications.map((app) => ({ app, series: [] }));
+      return { cpu: empty, memory: empty, restarts: empty, range, queriedAt };
+    }
+
+    const queries = buildPromQLQueries({ namespace, podNames: allPodNames });
+    const end = queriedAt;
+    const start = end - PROMETHEUS_TIME_RANGES[range];
+    const step = STEP_BY_RANGE[range];
+
+    const prometheus = createPrometheusClient();
+    const sharedAbort = new AbortController();
+
+    let cpuMatrix: PromQLMatrixResponse;
+    let memMatrix: PromQLMatrixResponse;
+    let restartsMatrix: PromQLMatrixResponse;
+    try {
+      [cpuMatrix, memMatrix, restartsMatrix] = await Promise.all([
+        prometheus.rangeQuery({ query: queries.cpu, start, end, step }, sharedAbort.signal),
+        prometheus.rangeQuery({ query: queries.memory, start, end, step }, sharedAbort.signal),
+        prometheus.rangeQuery({ query: queries.restarts, start, end, step }, sharedAbort.signal),
+      ]);
+    } catch (error) {
+      sharedAbort.abort();
+      if (error instanceof TRPCError) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      if (/timed out/i.test(message)) {
+        throw new TRPCError({ code: "GATEWAY_TIMEOUT", message, cause: error });
+      }
+      throw new TRPCError({
+        code: "BAD_GATEWAY",
+        message: `Prometheus upstream failure: ${message}`,
+        cause: error,
+      });
+    }
+
+    return {
+      cpu: matrixToSeriesByApp(cpuMatrix, podToApp, applications),
+      memory: matrixToSeriesByApp(memMatrix, podToApp, applications),
+      restarts: matrixToSeriesByApp(restartsMatrix, podToApp, applications),
+      range,
+      queriedAt,
+    };
+  });

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.test.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { escapeRegex, groupPodsByApp, buildPromQLQueries, matrixToSeriesByApp } from "./utils.js";
+
+describe("escapeRegex", () => {
+  it("escapes regex meta-characters", () => {
+    expect(escapeRegex("a.b+c*")).toBe("a\\.b\\+c\\*");
+  });
+  it("leaves RFC-1123-safe pod names unchanged", () => {
+    expect(escapeRegex("test-pod-abc123-xyz")).toBe("test-pod-abc123-xyz");
+  });
+  it("escapes pipe and backslash characters", () => {
+    expect(escapeRegex("a|b")).toBe("a\\|b");
+    expect(escapeRegex("path\\to")).toBe("path\\\\to");
+  });
+});
+
+describe("groupPodsByApp", () => {
+  it("groups pods by app.kubernetes.io/instance label, including apps with zero pods", () => {
+    const pods = [
+      { metadata: { name: "frontend-1", labels: { "app.kubernetes.io/instance": "frontend" } } },
+      { metadata: { name: "frontend-2", labels: { "app.kubernetes.io/instance": "frontend" } } },
+      { metadata: { name: "api-1", labels: { "app.kubernetes.io/instance": "api" } } },
+    ];
+    const result = groupPodsByApp(pods, ["frontend", "api", "worker"]);
+    expect(result.get("frontend")).toEqual(["frontend-1", "frontend-2"]);
+    expect(result.get("api")).toEqual(["api-1"]);
+    expect(result.get("worker")).toEqual([]);
+  });
+  it("ignores pods whose label value is not in the requested apps list", () => {
+    const pods = [{ metadata: { name: "other-1", labels: { "app.kubernetes.io/instance": "other" } } }];
+    const result = groupPodsByApp(pods, ["frontend"]);
+    expect(result.get("frontend")).toEqual([]);
+    expect(result.has("other")).toBe(false);
+  });
+  it("handles pods whose labels object is entirely absent", () => {
+    const pods = [{ metadata: { name: "unlabeled" } }];
+    const result = groupPodsByApp(pods, ["frontend"]);
+    expect(result.get("frontend")).toEqual([]);
+  });
+});
+
+describe("buildPromQLQueries", () => {
+  it("produces three queries with namespace and combined pod regex interpolated", () => {
+    const queries = buildPromQLQueries({
+      namespace: "test-namespace",
+      podNames: ["test-pod-abc123-xyz", "another-pod"],
+    });
+    expect(queries.cpu).toContain('namespace="test-namespace"');
+    expect(queries.cpu).toContain('pod=~"test-pod-abc123-xyz|another-pod"');
+    expect(queries.cpu).toContain("rate(container_cpu_usage_seconds_total");
+    expect(queries.memory).toContain("container_memory_working_set_bytes");
+    expect(queries.restarts).toContain("kube_pod_container_status_restarts_total");
+    expect(queries.restarts).toContain('pod=~"test-pod-abc123-xyz|another-pod"');
+  });
+  it("escapes regex meta-characters in pod names", () => {
+    const queries = buildPromQLQueries({
+      namespace: "ns",
+      podNames: ["good-pod", "weird.pod"],
+    });
+    expect(queries.cpu).toContain('pod=~"good-pod|weird\\.pod"');
+  });
+});
+
+describe("matrixToSeriesByApp", () => {
+  it("maps each pod series to its app and aggregates by summing across the app's pods at each timestamp", () => {
+    const podToApp = new Map<string, string>([
+      ["frontend-1", "frontend"],
+      ["frontend-2", "frontend"],
+      ["api-1", "api"],
+    ]);
+    const matrix = {
+      status: "success" as const,
+      data: {
+        resultType: "matrix" as const,
+        result: [
+          {
+            metric: { pod: "frontend-1" },
+            values: [
+              [100, "1.0"],
+              [110, "2.0"],
+            ] as Array<[number, string]>,
+          },
+          {
+            metric: { pod: "frontend-2" },
+            values: [
+              [100, "0.5"],
+              [110, "0.5"],
+            ] as Array<[number, string]>,
+          },
+          {
+            metric: { pod: "api-1" },
+            values: [[100, "3.0"]] as Array<[number, string]>,
+          },
+        ],
+      },
+    };
+    const known = ["frontend", "api", "worker"];
+    const result = matrixToSeriesByApp(matrix, podToApp, known);
+
+    const frontend = result.find((r) => r.app === "frontend");
+    expect(frontend?.series).toEqual([
+      { t: 100, v: 1.5 },
+      { t: 110, v: 2.5 },
+    ]);
+    const api = result.find((r) => r.app === "api");
+    expect(api?.series).toEqual([{ t: 100, v: 3.0 }]);
+    const worker = result.find((r) => r.app === "worker");
+    expect(worker?.series).toEqual([]);
+  });
+  it("aggregates partial-timestamp coverage (one pod missing a timestamp)", () => {
+    const podToApp = new Map<string, string>([
+      ["frontend-1", "frontend"],
+      ["frontend-2", "frontend"],
+    ]);
+    const matrix = {
+      status: "success" as const,
+      data: {
+        resultType: "matrix" as const,
+        result: [
+          {
+            metric: { pod: "frontend-1" },
+            values: [
+              [100, "1.0"],
+              [110, "2.0"],
+            ] as Array<[number, string]>,
+          },
+          {
+            metric: { pod: "frontend-2" },
+            values: [[100, "0.5"]] as Array<[number, string]>,
+          },
+        ],
+      },
+    };
+    const result = matrixToSeriesByApp(matrix, podToApp, ["frontend"]);
+    expect(result[0]?.series).toEqual([
+      { t: 100, v: 1.5 },
+      { t: 110, v: 2.0 },
+    ]);
+  });
+  it("preserves the order of `known` apps in the output", () => {
+    const result = matrixToSeriesByApp({ status: "success", data: { resultType: "matrix", result: [] } }, new Map(), [
+      "b",
+      "a",
+      "c",
+    ]);
+    expect(result.map((r) => r.app)).toEqual(["b", "a", "c"]);
+  });
+});

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.ts
@@ -1,0 +1,96 @@
+import type { PromQLMatrixResponse, MetricSeriesByApp } from "@my-project/shared";
+
+export const APP_INSTANCE_LABEL = "app.kubernetes.io/instance";
+
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+interface PodLike {
+  metadata: { name: string; labels?: Record<string, string> };
+}
+
+/**
+ * Build a Map<app, podName[]> for every requested app, including apps with zero
+ * matched pods. Pods whose app label is not in the requested list are dropped.
+ */
+export function groupPodsByApp(pods: PodLike[], apps: string[]): Map<string, string[]> {
+  const wanted = new Set(apps);
+  const result = new Map<string, string[]>();
+  for (const app of apps) result.set(app, []);
+  for (const pod of pods) {
+    const label = pod.metadata.labels?.[APP_INSTANCE_LABEL];
+    if (label && wanted.has(label)) {
+      result.get(label)!.push(pod.metadata.name);
+    }
+  }
+  return result;
+}
+
+interface BuildQueriesParams {
+  namespace: string;
+  podNames: string[];
+}
+
+/**
+ * Build the three PromQL queries used by the dashboard. Only `namespace` and
+ * `podNames` are interpolated; everything else is fixed text. `namespace` is
+ * already validated by Zod (RFC-1123). `podNames` are regex-escaped here.
+ *
+ * Precondition: callers must not pass an empty `podNames` array. With no pod
+ * names, the resulting `pod=~""` selector matches nothing, which produces a
+ * structurally-valid but semantically-degenerate query. The procedure handler
+ * short-circuits before calling this util when zero pods match.
+ */
+export function buildPromQLQueries({ namespace, podNames }: BuildQueriesParams): {
+  cpu: string;
+  memory: string;
+  restarts: string;
+} {
+  const podRegex = podNames.map(escapeRegex).join("|");
+  const baseSelector = `namespace="${namespace}", pod=~"${podRegex}"`;
+  const containerSelector = `${baseSelector}, container!="", container!="POD"`;
+  return {
+    cpu: `sum by (pod) (rate(container_cpu_usage_seconds_total{${containerSelector}}[5m]))`,
+    memory: `sum by (pod) (container_memory_working_set_bytes{${containerSelector}})`,
+    restarts: `sum by (pod) (kube_pod_container_status_restarts_total{${baseSelector}})`,
+  };
+}
+
+/**
+ * Convert a Prometheus matrix into per-app aggregated series. For each
+ * timestamp present in any of an app's pod series, sum the values across that
+ * app's pods. Apps with no matched pod series are present in the output with
+ * an empty series array. Output order matches `knownApps`.
+ */
+export function matrixToSeriesByApp(
+  matrix: PromQLMatrixResponse,
+  podToApp: Map<string, string>,
+  knownApps: string[]
+): MetricSeriesByApp[] {
+  const perApp = new Map<string, Map<number, number>>();
+  for (const app of knownApps) perApp.set(app, new Map());
+
+  for (const row of matrix.data.result) {
+    const podName = row.metric.pod;
+    if (!podName) continue;
+    const app = podToApp.get(podName);
+    if (!app) continue;
+    const bucket = perApp.get(app);
+    if (!bucket) continue;
+    for (const [ts, value] of row.values) {
+      const numeric = Number(value);
+      if (Number.isNaN(numeric)) continue;
+      bucket.set(ts, (bucket.get(ts) ?? 0) + numeric);
+    }
+  }
+
+  return knownApps.map((app) => {
+    const bucket = perApp.get(app)!;
+    const sortedTs = [...bucket.keys()].sort((a, b) => a - b);
+    return {
+      app,
+      series: sortedTs.map((t) => ({ t, v: bucket.get(t)! })),
+    };
+  });
+}

--- a/packages/trpc/src/routers/prometheus/procedures/index.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/index.ts
@@ -1,0 +1,1 @@
+export { getDeploymentMetricsProcedure as getDeploymentMetrics } from "./getDeploymentMetrics/index.js";


### PR DESCRIPTION
## Summary

- Replaces the Grafana iframe on the Stage Monitoring tab with native CPU / Memory / Container-restart panels per Application, backed by a new `prometheus.getDeploymentMetrics` tRPC procedure that queries Prometheus directly.
- Phase 1 scope: single `PROMETHEUS_URL` env var; cluster-local Prometheus only. Stages targeting a remote cluster (`stage.spec.clusterName != "in-cluster"`) show a forward-looking notice; no tRPC / K8s / Prometheus calls fire for them.
- Range selector (5m / 15m / 1h / 6h / 24h) + toggleable 30 s auto-refresh. Step resolution scales to keep payloads bounded. On a transient refresh failure, previous charts stay on screen and the toolbar shows a stale indicator.
- 31 new vitest tests + Storybook stories for every visual state. Total project test suite: 2119 / 2119 (no regressions over the prior 2087).

## Architecture

- `packages/shared/src/models/prometheus` — Zod schemas (strict input: RFC-1123 namespace, max 50 apps, range enum), derived types, constants, defensive `promqlMatrixResponseSchema` for upstream responses.
- `packages/trpc/src/clients/prometheus` — `PrometheusClient` with `rangeQuery` using `AbortSignal.any` + `AbortSignal.timeout` for the 10 s per-call timeout. Throws `TRPCError(PRECONDITION_FAILED)` when `PROMETHEUS_URL` is unset.
- `packages/trpc/src/routers/prometheus` — `protectedProcedure` `getDeploymentMetrics`. Lists pods by `app.kubernetes.io/instance` label selector, groups by app, builds a combined `pod=~"..."` regex, runs three parallel range queries under a shared `AbortController`. Error mapping: `GATEWAY_TIMEOUT` for upstream timeouts, `BAD_GATEWAY` otherwise. Pure helpers (`escapeRegex`, `groupPodsByApp`, `buildPromQLQueries`, `matrixToSeriesByApp`) extracted to `utils.ts` for unit testing.
- `apps/client/.../Monitoring` — full rewrite. Composes `Toolbar`, three `MetricChart` panels, and a `RemoteClusterNotice`. The `useDeploymentMetrics` hook wraps tRPC with reactive `refetchInterval`, `staleTime` matched to the refresh window, `placeholderData: keepPreviousData`, `retry: 1`.
- `app.kubernetes.io/instance` is the canonical app label used both by the procedure label-selector and by the existing PodLogs / PodExec dialogs.

## Test plan

- [x] `pnpm tsc:check` — passes
- [x] `pnpm lint:check` — passes
- [x] `pnpm test:coverage` — 2119 / 2119
- [x] `pnpm build` — passes
- [x] Manual: dev server + `kubectl port-forward -n monitoring svc/prom-prometheus 9090:9090` → tab renders 3 panels; range selector switches data; auto-refresh toggle pauses / resumes 30 s ticks; stop / restart port-forward → previous charts stay on screen with stale indicator, then recover; unset `PROMETHEUS_URL` → "metrics not configured" empty state with admin guidance; remote-cluster stage → forward-looking notice without any tRPC roundtrip.

## Out of scope (Phase 2)

- Multi-cluster Prometheus URL resolution (IRSA, single-aggregator Prometheus, or per-cluster URLs).
- Authentication to Prometheus beyond cluster-local reachability.
- Configurable dashboards, alerts, logs, traces.