### PR TITLE
EPMDEDP-16746: feat: Extend Stage Monitoring with network/storate metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ coverage
 .claude/settings.local.json
 .codemie
 .pnpm-store
+.superpowers

--- a/apps/client/src/modules/platform/cdpipelines/dialogs/PodExec/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/dialogs/PodExec/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Dialog, DialogContent, DialogBody, DialogHeader, DialogTitle } from "@/core/components/ui/dialog";
 import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
 import { PodExecTerminal } from "@/core/components/PodExecTerminal";
+import { podLabels } from "@my-project/shared";
 import { usePodWatchList } from "@/k8s/api/groups/Core/Pod";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
@@ -17,7 +18,7 @@ export const PodExecDialog: React.FC<PodExecDialogProps> = ({ props, state }) =>
   const podWatchList = usePodWatchList({
     namespace,
     labels: {
-      "app.kubernetes.io/instance": appName,
+      [podLabels.instance]: appName,
     },
   });
 

--- a/apps/client/src/modules/platform/cdpipelines/dialogs/PodLogs/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/dialogs/PodLogs/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Dialog, DialogContent, DialogBody, DialogHeader, DialogTitle } from "@/core/components/ui/dialog";
 import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
 import { PodLogsTerminal } from "@/core/components/PodLogsTerminal";
+import { podLabels } from "@my-project/shared";
 import { usePodWatchList } from "@/k8s/api/groups/Core/Pod";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
@@ -17,7 +18,7 @@ export const PodLogsDialog: React.FC<PodLogsDialogProps> = ({ props, state }) =>
   const podWatchList = usePodWatchList({
     namespace,
     labels: {
-      "app.kubernetes.io/instance": appName,
+      [podLabels.instance]: appName,
     },
   });
 

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/Monitoring.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/Monitoring.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
 import { MetricChart } from "./components/MetricChart";
 import { Toolbar } from "./components/Toolbar";
-import { RemoteClusterNotice } from "./components/RemoteClusterNotice";
+import { Section } from "./components/Section";
+import { PodPhasePanel } from "./components/PodPhasePanel";
+import { StatPanel } from "./components/StatPanel";
+import { MetricsCursorProvider } from "./hooks/MetricsCursorProvider";
+import { computeUtilization } from "./utils";
 
 const meta: Meta = {
   title: "CDPipelines/StageDetails/Monitoring/Tab",
@@ -17,63 +22,136 @@ const series = (offset: number, scale: number) =>
     v: scale * (1 + Math.sin(i / 4 + offset) * 0.4),
   }));
 
-export const FullTabWithData: StoryObj = {
-  render: () => (
-    <div className="space-y-4">
-      <Toolbar
-        range="1h"
-        onRangeChange={() => {}}
-        autoRefresh
-        onAutoRefreshChange={() => {}}
-        lastUpdatedAt={now}
-        isStale={false}
-      />
-      <MetricChart
-        title="CPU usage"
-        unit="cores"
-        isLoading={false}
-        error={null}
-        data={[
-          { app: "frontend", series: series(0, 0.4) },
-          { app: "api", series: series(1, 0.7) },
-        ]}
-      />
-      <MetricChart
-        title="Memory (working set)"
-        unit="MiB"
-        isLoading={false}
-        error={null}
-        data={[
-          { app: "frontend", series: series(0, 200 * 1024 * 1024) },
-          { app: "api", series: series(1, 350 * 1024 * 1024) },
-        ]}
-      />
-      <MetricChart
-        title="Container restarts"
-        unit="count"
-        isLoading={false}
-        error={null}
-        data={[
-          {
-            app: "frontend",
-            series: [
-              { t: now - 600, v: 0 },
-              { t: now, v: 0 },
-            ],
-          },
-          {
-            app: "api",
-            series: [
-              { t: now - 600, v: 1 },
-              { t: now, v: 2 },
-            ],
-          },
-        ]}
-      />
-    </div>
-  ),
-};
+const apps = ["frontend", "api", "worker"];
 
-export const FullTabRemoteCluster: StoryObj = {
-  render: () => <RemoteClusterNotice />,
-};
+function buildSeries(scale: number) {
+  return apps.map((app, i) => ({ app, series: series(i, scale * (i + 1)) }));
+}
+
+const podPhase = [
+  { app: "frontend", pods: [{ name: "frontend-7c9d4", phase: "Running" as const }] },
+  { app: "api", pods: [{ name: "api-1", phase: "Running" as const }] },
+  { app: "worker", pods: [{ name: "worker-1", phase: "Pending" as const }] },
+];
+
+function FullTab({ selected, emptyQuotas = false }: { selected: string[] | null; emptyQuotas?: boolean }) {
+  const [range, setRange] = React.useState<"5m" | "15m" | "1h" | "6h" | "24h">("1h");
+  const [autoRefresh, setAutoRefresh] = React.useState(true);
+  const [selectedApps, setSelectedApps] = React.useState<string[] | null>(selected);
+  const set = React.useMemo(() => new Set(selectedApps ?? apps), [selectedApps]);
+  const cpuUsage = buildSeries(0.3);
+  const memUsage = buildSeries(64 * 1024 * 1024);
+  const cpuRequests = emptyQuotas ? apps.map((app) => ({ app, series: [] })) : buildSeries(0.5);
+  const cpuLimits = emptyQuotas ? apps.map((app) => ({ app, series: [] })) : buildSeries(1);
+  const memRequests = emptyQuotas ? apps.map((app) => ({ app, series: [] })) : buildSeries(128 * 1024 * 1024);
+  const memLimits = emptyQuotas ? apps.map((app) => ({ app, series: [] })) : buildSeries(256 * 1024 * 1024);
+  const cpuThrottling = apps.map((app, i) => ({
+    app,
+    series: series(i * 2, 5 + i * 12).map((p) => ({ ...p, v: Math.max(0, p.v) })),
+  }));
+  return (
+    <MetricsCursorProvider>
+      <div className="space-y-6">
+        <Toolbar
+          range={range}
+          onRangeChange={setRange}
+          autoRefresh={autoRefresh}
+          onAutoRefreshChange={setAutoRefresh}
+          lastUpdatedAt={now}
+          isStale={false}
+          selectedApps={selectedApps}
+          availableApps={apps}
+          onAppsChange={setSelectedApps}
+          onAppsClear={() => setSelectedApps(null)}
+        />
+        <Section title="Utilisation">
+          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+            <StatPanel
+              title="CPU Utilisation (from requests)"
+              value={computeUtilization(cpuUsage, cpuRequests, set)}
+              isLoading={false}
+              error={null}
+            />
+            <StatPanel
+              title="CPU Utilisation (from limits)"
+              value={computeUtilization(cpuUsage, cpuLimits, set)}
+              isLoading={false}
+              error={null}
+            />
+            <StatPanel
+              title="Memory Utilisation (from requests)"
+              value={computeUtilization(memUsage, memRequests, set)}
+              isLoading={false}
+              error={null}
+            />
+            <StatPanel
+              title="Memory Utilisation (from limits)"
+              value={computeUtilization(memUsage, memLimits, set)}
+              isLoading={false}
+              error={null}
+            />
+          </div>
+        </Section>
+        <Section title="Compute" grid>
+          <MetricChart
+            title="CPU usage"
+            unit="cores"
+            data={cpuUsage}
+            isLoading={false}
+            error={null}
+            selectedApps={set}
+          />
+          <MetricChart
+            title="CPU throttling"
+            unit="percent"
+            data={cpuThrottling}
+            isLoading={false}
+            error={null}
+            selectedApps={set}
+          />
+          <MetricChart
+            title="Memory (working set)"
+            unit="MiB"
+            data={memUsage}
+            isLoading={false}
+            error={null}
+            selectedApps={set}
+          />
+        </Section>
+        <Section title="Network" grid>
+          <MetricChart
+            title="Network receive"
+            unit="bytes/s"
+            data={buildSeries(1024 * 256)}
+            isLoading={false}
+            error={null}
+            selectedApps={set}
+          />
+          <MetricChart
+            title="Network transmit"
+            unit="bytes/s"
+            data={buildSeries(1024 * 96)}
+            isLoading={false}
+            error={null}
+            selectedApps={set}
+          />
+        </Section>
+        <Section title="Health">
+          <MetricChart
+            title="Container restarts"
+            unit="count"
+            data={buildSeries(0).map((s) => ({ ...s, series: s.series.map((p) => ({ ...p, v: 0 })) }))}
+            isLoading={false}
+            error={null}
+            selectedApps={set}
+          />
+          <PodPhasePanel data={podPhase} selectedApps={set} />
+        </Section>
+      </div>
+    </MetricsCursorProvider>
+  );
+}
+
+export const FullTabAllApps: StoryObj = { render: () => <FullTab selected={null} /> };
+export const SingleAppIsolated: StoryObj = { render: () => <FullTab selected={["frontend"]} /> };
+export const UtilisationNoData: StoryObj = { render: () => <FullTab selected={null} emptyQuotas /> };

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/AppMultiSelect/AppMultiSelect.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/AppMultiSelect/AppMultiSelect.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
+import { AppMultiSelect } from "./index";
+
+const meta = {
+  title: "CDPipelines/StageDetails/Monitoring/AppMultiSelect",
+  component: AppMultiSelect,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof AppMultiSelect>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const apps = ["frontend", "api", "worker", "scheduler"];
+
+function Wrap(initial: string[] | null) {
+  return function Component() {
+    const [selected, setSelected] = React.useState<string[] | null>(initial);
+    return (
+      <AppMultiSelect
+        selectedApps={selected}
+        availableApps={apps}
+        onChange={setSelected}
+        onClear={() => setSelected(null)}
+      />
+    );
+  };
+}
+
+export const AllApplications: Story = {
+  args: { selectedApps: null, availableApps: apps, onChange: () => {}, onClear: () => {} },
+  render: Wrap(null),
+};
+export const OneSelected: Story = {
+  args: { selectedApps: ["frontend"], availableApps: apps, onChange: () => {}, onClear: () => {} },
+  render: Wrap(["frontend"]),
+};
+export const SeveralSelected: Story = {
+  args: { selectedApps: ["frontend", "api"], availableApps: apps, onChange: () => {}, onClear: () => {} },
+  render: Wrap(["frontend", "api"]),
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/AppMultiSelect/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/AppMultiSelect/index.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { ComboboxMultipleWithInput } from "@/core/components/ui/combobox-multiple-with-input";
+import type { ComboboxOption } from "@/core/components/ui/combobox";
+import { Button } from "@/core/components/ui/button";
+import { Filter as FilterIcon } from "lucide-react";
+import type { AppMultiSelectProps } from "../../types";
+
+export function AppMultiSelect({ selectedApps, availableApps, onChange, onClear }: AppMultiSelectProps) {
+  const options: ComboboxOption[] = React.useMemo(
+    () => availableApps.map((app) => ({ value: app, label: app })),
+    [availableApps]
+  );
+
+  const isAll = selectedApps === null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {isAll && (
+        <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+          <FilterIcon className="size-3.5" />
+          All applications
+        </span>
+      )}
+      <div className="min-w-[260px]">
+        <ComboboxMultipleWithInput
+          value={selectedApps ?? []}
+          onValueChange={(next) => (next.length === 0 ? onClear() : onChange(next))}
+          options={options}
+          placeholder={isAll ? "Filter applications…" : "Add application…"}
+          emptyText="No applications match"
+          maxShownItems={3}
+        />
+      </div>
+      {!isAll && (
+        <Button variant="ghost" size="sm" onClick={onClear}>
+          Show all
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/MetricChart.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/MetricChart.stories.tsx
@@ -17,44 +17,70 @@ const sampleSeries = (offset: number, scale: number) =>
     v: scale * (1 + Math.sin(i / 4 + offset) * 0.4),
   }));
 
+const sampleData = [
+  { app: "frontend", series: sampleSeries(0, 0.4) },
+  { app: "api", series: sampleSeries(1, 0.2) },
+  { app: "worker", series: sampleSeries(2, 0.3) },
+];
+
 export const WithDataSingleApp: Story = {
   args: {
     title: "CPU usage",
     unit: "cores",
+    data: [{ app: "frontend", series: sampleSeries(0, 0.5) }],
     isLoading: false,
     error: null,
-    data: [{ app: "krci-portal", series: sampleSeries(0, 0.5) }],
   },
 };
 
-export const WithDataMultipleApps: Story = {
+export const WithDataMultiApp: Story = {
   args: {
     title: "CPU usage",
     unit: "cores",
+    data: sampleData,
     isLoading: false,
     error: null,
+  },
+};
+
+export const BytesPerSecond: Story = {
+  args: {
+    title: "Network receive",
+    unit: "bytes/s",
     data: [
-      { app: "frontend", series: sampleSeries(0, 0.4) },
-      { app: "api", series: sampleSeries(1, 0.7) },
-      { app: "worker", series: sampleSeries(2, 0.3) },
+      { app: "frontend", series: sampleSeries(0, 1024 * 1024 * 1.5) },
+      { app: "worker", series: sampleSeries(1, 1024 * 512) },
     ],
+    isLoading: false,
+    error: null,
+  },
+};
+
+export const SelectedAppsFilter: Story = {
+  args: {
+    title: "CPU usage (only frontend)",
+    unit: "cores",
+    data: sampleData,
+    isLoading: false,
+    error: null,
+    selectedApps: new Set(["frontend"]),
   },
 };
 
 export const Loading: Story = {
-  args: { title: "CPU usage", unit: "cores", isLoading: true, error: null, data: [] },
+  args: { title: "CPU usage", unit: "cores", data: [], isLoading: true, error: null },
 };
 
 export const Empty: Story = {
-  args: { title: "CPU usage", unit: "cores", isLoading: false, error: null, data: [] },
+  args: { title: "CPU usage", unit: "cores", data: [], isLoading: false, error: null },
 };
 
 export const ErrorState: Story = {
   args: {
     title: "CPU usage",
     unit: "cores",
-    isLoading: false,
-    error: new globalThis.Error("Metrics query timed out. Try a shorter range."),
     data: [],
+    isLoading: false,
+    error: new Error("Cannot reach Prometheus."),
   },
 };

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/index.tsx
@@ -1,26 +1,26 @@
 import * as React from "react";
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ReferenceLine,
+  ResponsiveContainer,
+} from "recharts";
 import type { MetricChartProps } from "../../types";
 import { Card } from "@/core/components/ui/card";
 import { LoadingSpinner } from "@/core/components/ui/LoadingSpinner";
+import { CHART_PALETTE, CHART_TEXT } from "../../constants";
+import { useMetricsCursor } from "../../hooks/useMetricsCursor";
+import { chartSlug, formatChartTimestamp, formatValue } from "../../utils";
 
-const PALETTE = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#06b6d4", "#a855f7", "#84cc16"];
-
-function formatValue(unit: MetricChartProps["unit"], v: number): string {
-  if (unit === "cores") return v.toFixed(2);
-  if (unit === "MiB") return Math.round(v / (1024 * 1024)).toString();
-  return Math.round(v).toString();
-}
-
-function formatTimestamp(t: number): string {
-  return new Date(t * 1000).toLocaleTimeString();
-}
-
-/**
- * Recharts expects a single data array with one row per timestamp and one
- * column per series. We merge the per-app series into that wide form.
- */
-function toRechartsRows(data: MetricChartProps["data"]): { entries: Array<Record<string, number>>; keys: string[] } {
+function toRechartsRows(data: MetricChartProps["data"]): {
+  entries: Array<Record<string, number>>;
+  keys: string[];
+} {
   const allTs = new Set<number>();
   for (const s of data) for (const p of s.series) allTs.add(p.t);
   const sortedTs = [...allTs].sort((a, b) => a - b);
@@ -34,12 +34,65 @@ function toRechartsRows(data: MetricChartProps["data"]): { entries: Array<Record
   return { entries: [...rowMap.values()], keys: data.map((s) => s.app) };
 }
 
-export const MetricChart: React.FC<MetricChartProps> = ({ title, unit, data, isLoading, error }) => {
-  const { entries, keys } = React.useMemo(() => toRechartsRows(data), [data]);
+export const MetricChart = React.memo(function MetricChart({
+  title,
+  unit,
+  data,
+  isLoading,
+  error,
+  selectedApps,
+  onLegendClick,
+  step,
+}: MetricChartProps) {
+  const { cursorTs, setCursorTs } = useMetricsCursor();
+
+  const filtered = React.useMemo(
+    () => (selectedApps ? data.filter((s) => selectedApps.has(s.app)) : data),
+    [data, selectedApps]
+  );
+
+  const { entries, keys } = React.useMemo(() => toRechartsRows(filtered), [filtered]);
   const isEmpty = !isLoading && !error && entries.length === 0;
 
+  const rafRef = React.useRef<number | null>(null);
+  const handleMouseMove = React.useCallback(
+    (state: { activeLabel?: number | string | null } | null | undefined) => {
+      if (!state || state.activeLabel == null) return;
+      const raw = typeof state.activeLabel === "number" ? state.activeLabel : Number(state.activeLabel);
+      if (Number.isNaN(raw)) return;
+      // Bucket to the nearest step boundary so neighbouring pixels in the same
+      // step short-circuit the store's identity check (no broadcast).
+      const ts = step && step > 0 ? Math.round(raw / step) * step : raw;
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => setCursorTs(ts));
+    },
+    [setCursorTs, step]
+  );
+  const handleMouseLeave = React.useCallback(() => {
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    setCursorTs(null);
+  }, [setCursorTs]);
+
+  React.useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    []
+  );
+
+  const handleLegendClick = React.useCallback(
+    (payload: { value?: string; dataKey?: string }, _index: number, event?: React.MouseEvent) => {
+      if (!onLegendClick) return;
+      const app = payload.value ?? payload.dataKey;
+      if (!app || typeof app !== "string") return;
+      const toggle = !!event && (event.shiftKey || event.metaKey || event.ctrlKey);
+      onLegendClick(app, { toggle });
+    },
+    [onLegendClick]
+  );
+
   return (
-    <Card className="p-4" data-tour={`stage-monitoring-${unit}`}>
+    <Card className="p-4" data-tour={`stage-monitoring-${chartSlug(title)}`}>
       <div className="flex items-baseline justify-between">
         <h4 className="text-foreground text-base font-semibold">{title}</h4>
         <span className="text-muted-foreground text-xs">{unit}</span>
@@ -54,30 +107,64 @@ export const MetricChart: React.FC<MetricChartProps> = ({ title, unit, data, isL
           <div className="text-destructive flex h-full items-center justify-center text-sm">{error.message}</div>
         )}
         {isEmpty && (
-          <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
-            No data in selected time range
+          <div className="text-muted-foreground flex h-full items-center justify-center text-3xl font-light tracking-tight">
+            No data
           </div>
         )}
         {!isLoading && !error && entries.length > 0 && (
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={entries}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="t" tickFormatter={formatTimestamp} minTickGap={32} />
-              <YAxis tickFormatter={(v: number) => formatValue(unit, v)} width={48} />
-              <Tooltip
-                labelFormatter={(t: number) => formatTimestamp(t)}
-                formatter={(v: number | undefined, app: string | undefined) => [
-                  v !== undefined ? formatValue(unit, v) : "",
-                  app ?? "",
-                ]}
+            <LineChart data={entries} onMouseMove={handleMouseMove} onMouseLeave={handleMouseLeave}>
+              <CartesianGrid {...CHART_TEXT.grid} />
+              <XAxis
+                dataKey="t"
+                tickFormatter={formatChartTimestamp}
+                minTickGap={32}
+                tick={CHART_TEXT.axisTick}
+                axisLine={CHART_TEXT.axisLine}
+                tickLine={CHART_TEXT.axisLine}
+                type="number"
+                domain={["dataMin", "dataMax"]}
+                scale="time"
               />
-              <Legend />
+              <YAxis
+                tickFormatter={(v: number) => formatValue(unit, v)}
+                width={unit === "bytes/s" ? 64 : 56}
+                tick={CHART_TEXT.axisTick}
+                axisLine={CHART_TEXT.axisLine}
+                tickLine={CHART_TEXT.axisLine}
+              />
+              {cursorTs !== null && (
+                <ReferenceLine x={cursorTs} stroke="var(--muted-foreground)" strokeDasharray="2 2" />
+              )}
+              <Tooltip
+                wrapperStyle={CHART_TEXT.tooltipWrapper}
+                contentStyle={CHART_TEXT.tooltipContent}
+                labelFormatter={(t: number) => formatChartTimestamp(t)}
+                formatter={(value, name) => {
+                  const v = typeof value === "number" ? value : Number(value);
+                  const app = typeof name === "string" ? name : String(name ?? "");
+                  return [Number.isFinite(v) ? formatValue(unit, v) : "", app];
+                }}
+              />
+              <Legend
+                wrapperStyle={CHART_TEXT.legendWrapper}
+                onClick={
+                  onLegendClick
+                    ? (payload, index, event) =>
+                        handleLegendClick(
+                          payload as { value?: string; dataKey?: string },
+                          index,
+                          event as React.MouseEvent | undefined
+                        )
+                    : undefined
+                }
+              />
               {keys.map((app, i) => (
                 <Line
                   key={app}
                   type="monotone"
                   dataKey={app}
-                  stroke={PALETTE[i % PALETTE.length]}
+                  stroke={CHART_PALETTE[i % CHART_PALETTE.length]}
                   dot={false}
                   isAnimationActive={false}
                 />
@@ -88,4 +175,4 @@ export const MetricChart: React.FC<MetricChartProps> = ({ title, unit, data, isL
       </div>
     </Card>
   );
-};
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/PodPhasePanel/PodPhasePanel.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/PodPhasePanel/PodPhasePanel.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PodPhasePanel } from "./index";
+
+const meta = {
+  title: "CDPipelines/StageDetails/Monitoring/PodPhasePanel",
+  component: PodPhasePanel,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof PodPhasePanel>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Mixed: Story = {
+  args: {
+    data: [
+      {
+        app: "frontend",
+        pods: [
+          { name: "frontend-7c9d4-ab12", phase: "Running" },
+          { name: "frontend-7c9d4-cd34", phase: "Pending" },
+        ],
+      },
+      { app: "worker", pods: [{ name: "worker-1", phase: "Failed" }] },
+    ],
+  },
+};
+
+export const AllRunning: Story = {
+  args: {
+    data: [
+      { app: "frontend", pods: [{ name: "frontend-1", phase: "Running" }] },
+      { app: "worker", pods: [{ name: "worker-1", phase: "Running" }] },
+    ],
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    data: [
+      { app: "frontend", pods: [] },
+      { app: "worker", pods: [] },
+    ],
+  },
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/PodPhasePanel/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/PodPhasePanel/index.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { Badge } from "@/core/components/ui/badge";
+import { Card } from "@/core/components/ui/card";
+import { POD_PHASE_BADGE_VARIANT } from "../../constants";
+import type { PodPhasePanelProps } from "../../types";
+
+export function PodPhasePanel({ data, selectedApps }: PodPhasePanelProps) {
+  const visible = React.useMemo(
+    () => (selectedApps ? data.filter((d) => selectedApps.has(d.app)) : data),
+    [data, selectedApps]
+  );
+  const isEmpty = visible.every((entry) => entry.pods.length === 0);
+
+  return (
+    <Card className="p-4" data-tour="stage-monitoring-pod-phase">
+      <div className="flex items-baseline justify-between">
+        <h4 className="text-foreground text-base font-semibold">Pod status</h4>
+        <span className="text-muted-foreground text-xs">current</span>
+      </div>
+      {isEmpty ? (
+        <div className="text-muted-foreground mt-3 text-sm">No pod status available</div>
+      ) : (
+        <ul className="mt-3 space-y-3">
+          {visible.map((entry) => (
+            <li key={entry.app}>
+              <div className="text-foreground mb-1 text-sm font-medium">{entry.app}</div>
+              {entry.pods.length === 0 ? (
+                <div className="text-muted-foreground text-xs">No pods</div>
+              ) : (
+                <div className="flex flex-wrap gap-1.5">
+                  {entry.pods.map((pod) => (
+                    <Badge
+                      key={pod.name}
+                      variant={POD_PHASE_BADGE_VARIANT[pod.phase]}
+                      title={pod.name}
+                      className="text-[11px]"
+                    >
+                      <span className="max-w-[160px] truncate">{pod.name}</span>
+                      <span className="ml-1.5 opacity-75">{pod.phase}</span>
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Section/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Section/index.tsx
@@ -1,0 +1,11 @@
+import { cn } from "@/core/utils/classname";
+import type { SectionProps } from "../../types";
+
+export function Section({ title, children, grid = false }: SectionProps) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{title}</h3>
+      <div className={cn("grid gap-3", grid ? "md:grid-cols-2" : "grid-cols-1")}>{children}</div>
+    </section>
+  );
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/StatPanel/StatPanel.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/StatPanel/StatPanel.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StatPanel } from "./index";
+
+const meta = {
+  title: "CDPipelines/StageDetails/Monitoring/StatPanel",
+  component: StatPanel,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof StatPanel>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SmallValue: Story = {
+  args: { title: "CPU Utilisation (from requests)", value: 9.18, isLoading: false, error: null },
+};
+
+export const MidValue: Story = {
+  args: { title: "Memory Utilisation (from requests)", value: 52.9, isLoading: false, error: null },
+};
+
+export const Saturated: Story = {
+  args: { title: "CPU Utilisation (from limits)", value: 137, isLoading: false, error: null },
+};
+
+export const NoData: Story = {
+  args: { title: "Memory Utilisation (from limits)", value: null, isLoading: false, error: null },
+};
+
+export const Loading: Story = {
+  args: { title: "CPU Utilisation (from requests)", value: null, isLoading: true, error: null },
+};
+
+export const Errored: Story = {
+  args: {
+    title: "CPU Utilisation (from limits)",
+    value: null,
+    isLoading: false,
+    error: new Error("Cannot reach Prometheus."),
+  },
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/StatPanel/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/StatPanel/index.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { Card } from "@/core/components/ui/card";
+import { LoadingSpinner } from "@/core/components/ui/LoadingSpinner";
+import type { StatPanelProps } from "../../types";
+import { chartSlug, formatPercent } from "../../utils";
+
+export const StatPanel = React.memo(function StatPanel({ title, value, isLoading, error }: StatPanelProps) {
+  return (
+    <Card className="p-4" data-tour={`stage-monitoring-${chartSlug(title)}`}>
+      <h4 className="text-foreground text-sm font-semibold">{title}</h4>
+      <div className="mt-2 flex h-24 items-center justify-center">
+        {isLoading && <LoadingSpinner />}
+        {!isLoading && error && <div className="text-destructive text-sm">{error.message}</div>}
+        {!isLoading && !error && value === null && (
+          <div className="text-muted-foreground text-3xl font-light tracking-tight">No data</div>
+        )}
+        {!isLoading && !error && value !== null && (
+          <div className="text-foreground text-5xl font-light tracking-tight tabular-nums">
+            {formatPercent(value)}
+            <span className="text-muted-foreground ml-1 text-2xl">%</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Toolbar/Toolbar.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Toolbar/Toolbar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
 import { Toolbar } from "./index";
 
 const meta = {
@@ -6,28 +7,60 @@ const meta = {
   component: Toolbar,
   parameters: { layout: "padded" },
   tags: ["autodocs"],
-  args: {
-    range: "1h",
-    onRangeChange: () => {},
-    autoRefresh: true,
-    onAutoRefreshChange: () => {},
-    lastUpdatedAt: Math.floor(Date.now() / 1000),
-    isStale: false,
-  },
 } satisfies Meta<typeof Toolbar>;
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+const apps = ["frontend", "api", "worker"];
+const now = Math.floor(Date.now() / 1000);
 
-export const AutoRefreshOff: Story = {
-  args: { autoRefresh: false },
+function Wrap(initial: {
+  range?: "5m" | "15m" | "1h" | "6h" | "24h";
+  autoRefresh?: boolean;
+  selectedApps?: string[] | null;
+  isStale?: boolean;
+}) {
+  return function Component() {
+    const [range, setRange] = React.useState<"5m" | "15m" | "1h" | "6h" | "24h">(initial.range ?? "1h");
+    const [autoRefresh, setAutoRefresh] = React.useState<boolean>(initial.autoRefresh ?? true);
+    const [selectedApps, setSelectedApps] = React.useState<string[] | null>(initial.selectedApps ?? null);
+    return (
+      <Toolbar
+        range={range}
+        onRangeChange={setRange}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        lastUpdatedAt={now}
+        isStale={!!initial.isStale}
+        selectedApps={selectedApps}
+        availableApps={apps}
+        onAppsChange={setSelectedApps}
+        onAppsClear={() => setSelectedApps(null)}
+      />
+    );
+  };
+}
+
+const defaultArgs = {
+  range: "1h" as const,
+  onRangeChange: () => {},
+  autoRefresh: true,
+  onAutoRefreshChange: () => {},
+  lastUpdatedAt: now,
+  isStale: false,
+  selectedApps: null,
+  availableApps: apps,
+  onAppsChange: () => {},
+  onAppsClear: () => {},
 };
 
-export const Stale: Story = {
-  args: { isStale: true },
+export const AllAppsDefault: Story = { args: defaultArgs, render: Wrap({}) };
+export const FilteredOneApp: Story = {
+  args: { ...defaultArgs, selectedApps: ["frontend"] },
+  render: Wrap({ selectedApps: ["frontend"] }),
 };
-
-export const NeverFetched: Story = {
-  args: { lastUpdatedAt: undefined },
+export const StaleRefresh: Story = { args: { ...defaultArgs, isStale: true }, render: Wrap({ isStale: true }) };
+export const ManualRefresh: Story = {
+  args: { ...defaultArgs, autoRefresh: false },
+  render: Wrap({ autoRefresh: false }),
 };

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Toolbar/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/Toolbar/index.tsx
@@ -1,46 +1,55 @@
-import * as React from "react";
 import { Clock, RefreshCw, AlertTriangle } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/core/components/ui/select";
 import { Switch } from "@/core/components/ui/switch";
 import { Label } from "@/core/components/ui/label";
 import type { ToolbarProps } from "../../types";
 import { RANGE_OPTIONS } from "../../constants";
+import { formatChartTimestamp } from "../../utils";
+import { AppMultiSelect } from "../AppMultiSelect";
 
-function formatTimestamp(t: number): string {
-  return new Date(t * 1000).toLocaleTimeString();
-}
-
-export const Toolbar: React.FC<ToolbarProps> = ({
+export function Toolbar({
   range,
   onRangeChange,
   autoRefresh,
   onAutoRefreshChange,
   lastUpdatedAt,
   isStale,
-}) => {
+  selectedApps,
+  availableApps,
+  onAppsChange,
+  onAppsClear,
+}: ToolbarProps) {
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 pb-3">
-      <div className="flex items-center gap-2">
-        <Clock className="text-muted-foreground size-4" />
-        <Select value={range} onValueChange={(v) => onRangeChange(v as ToolbarProps["range"])}>
-          <SelectTrigger className="w-44" aria-label="Select time range">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {RANGE_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className="flex flex-wrap items-center gap-3">
+        <AppMultiSelect
+          selectedApps={selectedApps}
+          availableApps={availableApps}
+          onChange={onAppsChange}
+          onClear={onAppsClear}
+        />
+        <div className="flex items-center gap-2">
+          <Clock className="text-muted-foreground size-4" />
+          <Select value={range} onValueChange={(v) => onRangeChange(v as ToolbarProps["range"])}>
+            <SelectTrigger className="w-44" aria-label="Select time range">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {RANGE_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
 
       <div className="text-muted-foreground flex items-center gap-3 text-xs">
         {lastUpdatedAt !== undefined && (
           <span className="flex items-center gap-1">
             {isStale && <AlertTriangle className="size-3.5 text-amber-500" aria-label="Refresh failed" />}
-            Last updated {formatTimestamp(lastUpdatedAt)}
+            Last updated {formatChartTimestamp(lastUpdatedAt)}
           </span>
         )}
         <Label className="flex items-center gap-2">
@@ -51,4 +60,4 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       </div>
     </div>
   );
-};
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/constants.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/constants.ts
@@ -1,4 +1,5 @@
-import { type MetricRange } from "@my-project/shared";
+import type * as React from "react";
+import { type MetricRange, type PodPhase } from "@my-project/shared";
 
 export const RANGE_OPTIONS: ReadonlyArray<{ value: MetricRange; label: string }> = [
   { value: "5m", label: "Last 5 minutes" },
@@ -11,3 +12,45 @@ export const RANGE_OPTIONS: ReadonlyArray<{ value: MetricRange; label: string }>
 export const DEFAULT_RANGE: MetricRange = "1h";
 export const DEFAULT_AUTO_REFRESH = true;
 export const REFRESH_INTERVAL_MS = 30_000;
+
+/** Tailwind-700 palette; cycles when there are more apps than colors. */
+export const CHART_PALETTE = [
+  "#3b82f6",
+  "#10b981",
+  "#f59e0b",
+  "#ef4444",
+  "#8b5cf6",
+  "#06b6d4",
+  "#a855f7",
+  "#84cc16",
+] as const;
+
+/**
+ * Standardised text styling for every chart. Recharts defaults render axis
+ * ticks and legend at the SVG default (~14 px), which dwarfs the surrounding
+ * Card chrome. These overrides bring chart text into line with the portal.
+ */
+export const CHART_TEXT = {
+  axisTick: { fontSize: 11, fill: "var(--muted-foreground)" },
+  axisLine: { stroke: "var(--border)" },
+  legendWrapper: { fontSize: 12, color: "var(--foreground)" },
+  tooltipWrapper: { fontSize: 12 },
+  tooltipContent: {
+    background: "var(--card)",
+    border: "1px solid var(--border)",
+    borderRadius: 6,
+    padding: "6px 8px",
+    color: "var(--foreground)",
+  } as React.CSSProperties,
+  grid: { stroke: "var(--border)", strokeDasharray: "3 3", opacity: 0.5 },
+} as const;
+
+import type { BadgeProps } from "@/core/components/ui/badge";
+
+export const POD_PHASE_BADGE_VARIANT: Record<PodPhase, NonNullable<BadgeProps["variant"]>> = {
+  Running: "success",
+  Pending: "warning",
+  Succeeded: "info",
+  Failed: "error",
+  Unknown: "neutral",
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/MetricsCursorProvider.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/MetricsCursorProvider.tsx
@@ -1,0 +1,7 @@
+import * as React from "react";
+import { CursorStore, CursorStoreContext } from "./useMetricsCursor";
+
+export function MetricsCursorProvider({ children }: { children: React.ReactNode }) {
+  const [store] = React.useState(() => new CursorStore());
+  return <CursorStoreContext.Provider value={store}>{children}</CursorStoreContext.Provider>;
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useDeploymentMetrics.test.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useDeploymentMetrics.test.tsx
@@ -16,9 +16,11 @@ vi.mock("@/core/providers/trpc", () => ({
 }));
 
 const okResponse: DeploymentMetricsOutput = {
-  cpu: [],
-  memory: [],
-  restarts: [],
+  compute: { cpu: [], memory: [], memoryRss: [], memoryCache: [], cpuThrottling: [] },
+  network: { rx: [], tx: [] },
+  storage: { readBytes: [], writeBytes: [] },
+  health: { restarts: [], oomEvents: [], podPhase: [] },
+  quotas: { cpuRequests: [], cpuLimits: [], memoryRequests: [], memoryLimits: [] },
   range: "1h",
   queriedAt: 1700000000,
 };

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMetricsCursor.test.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMetricsCursor.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { render, renderHook, act } from "@testing-library/react";
+import { useMetricsCursor } from "./useMetricsCursor";
+import { MetricsCursorProvider } from "./MetricsCursorProvider";
+
+describe("useMetricsCursor", () => {
+  it("returns null cursorTs by default", () => {
+    const { result } = renderHook(() => useMetricsCursor(), {
+      wrapper: ({ children }) => <MetricsCursorProvider>{children}</MetricsCursorProvider>,
+    });
+    expect(result.current.cursorTs).toBeNull();
+  });
+
+  it("setCursorTs notifies subscribers", () => {
+    const { result } = renderHook(() => useMetricsCursor(), {
+      wrapper: ({ children }) => <MetricsCursorProvider>{children}</MetricsCursorProvider>,
+    });
+    act(() => result.current.setCursorTs(1700000000));
+    expect(result.current.cursorTs).toBe(1700000000);
+    act(() => result.current.setCursorTs(null));
+    expect(result.current.cursorTs).toBeNull();
+  });
+
+  it("setting the same value does not re-render (identity check)", () => {
+    let renders = 0;
+    function Probe() {
+      const { cursorTs, setCursorTs } = useMetricsCursor();
+      renders++;
+      return <button onClick={() => setCursorTs(42)}>{String(cursorTs)}</button>;
+    }
+    const { getByRole } = render(
+      <MetricsCursorProvider>
+        <Probe />
+      </MetricsCursorProvider>
+    );
+    const initial = renders;
+    act(() => getByRole("button").click());
+    const afterFirst = renders;
+    act(() => getByRole("button").click());
+    expect(renders).toBe(afterFirst); // second click sets same value, no re-render
+    expect(afterFirst).toBeGreaterThan(initial);
+  });
+
+  it("returns null cursor and no-op setter outside the provider", () => {
+    const { result } = renderHook(() => useMetricsCursor());
+    expect(result.current.cursorTs).toBeNull();
+    expect(() => act(() => result.current.setCursorTs(42))).not.toThrow();
+    // Setter is a no-op, so cursorTs stays null after a "set".
+    expect(result.current.cursorTs).toBeNull();
+  });
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMetricsCursor.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMetricsCursor.ts
@@ -1,0 +1,47 @@
+import * as React from "react";
+
+type Listener = () => void;
+
+export class CursorStore {
+  private value: number | null = null;
+  private listeners = new Set<Listener>();
+
+  get = (): number | null => this.value;
+
+  set = (next: number | null): void => {
+    if (this.value === next) return;
+    this.value = next;
+    this.listeners.forEach((l) => l());
+  };
+
+  subscribe = (l: Listener): (() => void) => {
+    this.listeners.add(l);
+    return () => {
+      this.listeners.delete(l);
+    };
+  };
+}
+
+export const CursorStoreContext = React.createContext<CursorStore | null>(null);
+
+export interface UseMetricsCursorResult {
+  cursorTs: number | null;
+  setCursorTs: (next: number | null) => void;
+}
+
+// Stable no-op handles for callers used outside a MetricsCursorProvider
+// (Storybook, isolated tests). Defined at module scope so identity stays
+// stable across renders.
+const NOOP_SUBSCRIBE = () => () => {};
+const NOOP_GET = (): number | null => null;
+const NOOP_SET = (): void => {};
+
+export function useMetricsCursor(): UseMetricsCursorResult {
+  const store = React.useContext(CursorStoreContext);
+  const cursorTs = React.useSyncExternalStore(
+    store ? store.subscribe : NOOP_SUBSCRIBE,
+    store ? store.get : NOOP_GET,
+    store ? store.get : NOOP_GET
+  );
+  return { cursorTs, setCursorTs: store ? store.set : NOOP_SET };
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMonitoringSearch.test.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMonitoringSearch.test.tsx
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const mockUseSearch = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/modules/platform/cdpipelines/pages/stage-details/route", () => ({
+  routeStageDetails: {
+    fullPath: "/_layout/c/$clusterName/cdpipelines/$namespace/$cdPipeline/stages/$stage",
+    useSearch: () => mockUseSearch(),
+  },
+}));
+
+import { useMonitoringSearch } from "./useMonitoringSearch";
+
+function lastNavigateCall(): { replace?: boolean; search: Record<string, unknown> } {
+  const calls = mockNavigate.mock.calls;
+  const arg = calls[calls.length - 1]?.[0];
+  const search = typeof arg.search === "function" ? arg.search({}) : arg.search;
+  return { replace: arg.replace, search };
+}
+
+function lastNavigateSearch(): Record<string, unknown> {
+  return lastNavigateCall().search;
+}
+
+describe("useMonitoringSearch", () => {
+  beforeEach(() => {
+    mockUseSearch.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it("returns null apps when ?apps is absent", () => {
+    mockUseSearch.mockReturnValue({});
+    const { result } = renderHook(() => useMonitoringSearch());
+    expect(result.current.apps).toBeNull();
+    expect(result.current.range).toBe("1h");
+    expect(result.current.autoRefresh).toBe(true);
+  });
+
+  it("returns null apps when ?apps is empty string", () => {
+    mockUseSearch.mockReturnValue({ apps: "" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    expect(result.current.apps).toBeNull();
+  });
+
+  it("parses comma-separated ?apps", () => {
+    mockUseSearch.mockReturnValue({ apps: "frontend,api" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    expect(result.current.apps).toEqual(["frontend", "api"]);
+  });
+
+  it("setRange writes ?range as a deliberate navigation (replace:false)", () => {
+    mockUseSearch.mockReturnValue({});
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.setRange("6h"));
+    expect(lastNavigateCall().replace).toBe(false);
+    expect(lastNavigateSearch()).toMatchObject({ range: "6h" });
+  });
+
+  it("setAutoRefresh uses replace:true to keep history clean", () => {
+    mockUseSearch.mockReturnValue({});
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.setAutoRefresh(false));
+    expect(lastNavigateCall().replace).toBe(true);
+    expect(lastNavigateSearch()).toMatchObject({ autoRefresh: false });
+  });
+
+  it("setApps and isolateApp do not use replace:true", () => {
+    mockUseSearch.mockReturnValue({ apps: "a,b" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.setApps(["a"]));
+    expect(lastNavigateCall().replace).toBe(false);
+    act(() => result.current.isolateApp("b"));
+    expect(lastNavigateCall().replace).toBe(false);
+  });
+
+  it.each([
+    ["leading/trailing whitespace", "  a  , b ", ["a", "b"]],
+    ["only commas", ",,,", null],
+    ["only whitespace", "   ", null],
+  ])("parseApps handles %s", (_label, raw, expected) => {
+    mockUseSearch.mockReturnValue({ apps: raw });
+    const { result } = renderHook(() => useMonitoringSearch());
+    expect(result.current.apps).toEqual(expected);
+  });
+
+  it("setApps([]) clears the URL key", () => {
+    mockUseSearch.mockReturnValue({ apps: "frontend" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.setApps([]));
+    expect(lastNavigateSearch()).toMatchObject({ apps: undefined });
+  });
+
+  it("clearApps resets the URL key without going through serializeApps", () => {
+    mockUseSearch.mockReturnValue({ apps: "a,b" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.clearApps());
+    expect(lastNavigateCall().replace).toBe(false);
+    expect(lastNavigateSearch()).toMatchObject({ apps: undefined });
+  });
+
+  it("setApps(['a','b']) joins with commas", () => {
+    mockUseSearch.mockReturnValue({});
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.setApps(["a", "b"]));
+    expect(lastNavigateSearch()).toMatchObject({ apps: "a,b" });
+  });
+
+  it("toggleApp adds when not present", () => {
+    mockUseSearch.mockReturnValue({ apps: "a" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.toggleApp("b"));
+    expect(lastNavigateSearch()).toMatchObject({ apps: "a,b" });
+  });
+
+  it("toggleApp removes when present", () => {
+    mockUseSearch.mockReturnValue({ apps: "a,b" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.toggleApp("a"));
+    expect(lastNavigateSearch()).toMatchObject({ apps: "b" });
+  });
+
+  it("toggleApp on the last selected app resets to all (apps undefined)", () => {
+    mockUseSearch.mockReturnValue({ apps: "a" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.toggleApp("a"));
+    expect(lastNavigateSearch()).toMatchObject({ apps: undefined });
+  });
+
+  it("isolateApp sets apps to just that app", () => {
+    mockUseSearch.mockReturnValue({ apps: "a,b,c" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.isolateApp("b"));
+    expect(lastNavigateSearch()).toMatchObject({ apps: "b" });
+  });
+
+  it("isolateApp on the already-isolated app resets to all", () => {
+    mockUseSearch.mockReturnValue({ apps: "b" });
+    const { result } = renderHook(() => useMonitoringSearch());
+    act(() => result.current.isolateApp("b"));
+    expect(lastNavigateSearch()).toMatchObject({ apps: undefined });
+  });
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMonitoringSearch.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMonitoringSearch.ts
@@ -1,0 +1,79 @@
+import { useNavigate } from "@tanstack/react-router";
+import * as React from "react";
+import type { MetricRange } from "@my-project/shared";
+import { routeStageDetails } from "@/modules/platform/cdpipelines/pages/stage-details/route";
+import { DEFAULT_AUTO_REFRESH, DEFAULT_RANGE } from "../constants";
+
+interface UseMonitoringSearchResult {
+  /** null means "all known apps" (no filter active). */
+  apps: string[] | null;
+  range: MetricRange;
+  autoRefresh: boolean;
+  setApps: (next: string[]) => void;
+  clearApps: () => void;
+  setRange: (next: MetricRange) => void;
+  setAutoRefresh: (next: boolean) => void;
+  toggleApp: (app: string) => void;
+  isolateApp: (app: string) => void;
+}
+
+type SearchPatch = Partial<{ apps: string | undefined; range: MetricRange; autoRefresh: boolean }>;
+
+function parseApps(raw: string | undefined): string[] | null {
+  if (!raw) return null;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.length === 0 ? null : list;
+}
+
+function serializeApps(list: string[]): string | undefined {
+  return list.length === 0 ? undefined : list.join(",");
+}
+
+export function useMonitoringSearch(): UseMonitoringSearchResult {
+  const search = routeStageDetails.useSearch();
+  const navigate = useNavigate();
+
+  const apps = React.useMemo(() => parseApps(search.apps), [search.apps]);
+  const range: MetricRange = search.range ?? DEFAULT_RANGE;
+  const autoRefresh = search.autoRefresh ?? DEFAULT_AUTO_REFRESH;
+
+  // `replace: false` (the default) for deliberate navigations the user may want
+  // to undo with browser-back; `replace: true` only for the autoRefresh
+  // preference toggle which shouldn't pollute history.
+  const update = React.useCallback(
+    (patch: SearchPatch, replace = false) => {
+      void navigate({
+        replace,
+        search: ((prev: Record<string, unknown>) => ({ ...prev, ...patch })) as never,
+      });
+    },
+    [navigate]
+  );
+
+  const setApps = React.useCallback((next: string[]) => update({ apps: serializeApps(next) }), [update]);
+  const clearApps = React.useCallback(() => update({ apps: undefined }), [update]);
+  const setRange = React.useCallback((next: MetricRange) => update({ range: next }), [update]);
+  const setAutoRefresh = React.useCallback((next: boolean) => update({ autoRefresh: next }, true), [update]);
+
+  const toggleApp = React.useCallback(
+    (app: string) => {
+      const current = apps ?? [];
+      const next = current.includes(app) ? current.filter((a) => a !== app) : [...current, app];
+      update({ apps: serializeApps(next) });
+    },
+    [apps, update]
+  );
+
+  const isolateApp = React.useCallback(
+    (app: string) => {
+      const alreadyIsolated = apps?.length === 1 && apps[0] === app;
+      update({ apps: alreadyIsolated ? undefined : serializeApps([app]) });
+    },
+    [apps, update]
+  );
+
+  return { apps, range, autoRefresh, setApps, clearApps, setRange, setAutoRefresh, toggleApp, isolateApp };
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/index.tsx
@@ -1,41 +1,142 @@
 import * as React from "react";
-import { inClusterName } from "@my-project/shared";
+import { inClusterName, STEP_BY_RANGE, type DeploymentMetricsOutput, type MetricSeriesByApp } from "@my-project/shared";
 import { Card } from "@/core/components/ui/card";
 import { useStageWatch, usePipelineAppCodebasesWatch } from "@/modules/platform/cdpipelines/pages/stage-details/hooks";
 import { routeStageDetails } from "@/modules/platform/cdpipelines/pages/stage-details/route";
 import { Toolbar } from "./components/Toolbar";
 import { MetricChart } from "./components/MetricChart";
 import { RemoteClusterNotice } from "./components/RemoteClusterNotice";
+import { Section } from "./components/Section";
+import { PodPhasePanel } from "./components/PodPhasePanel";
+import { StatPanel } from "./components/StatPanel";
 import { useDeploymentMetrics } from "./hooks/useDeploymentMetrics";
-import { DEFAULT_AUTO_REFRESH, DEFAULT_RANGE } from "./constants";
-import type { MetricRange } from "@my-project/shared";
+import { useMonitoringSearch } from "./hooks/useMonitoringSearch";
+import { MetricsCursorProvider } from "./hooks/MetricsCursorProvider";
+import type { MetricUnit } from "./types";
+import { computeUtilization } from "./utils";
 
-export const Monitoring: React.FC = () => {
+type ChartDef = {
+  title: string;
+  unit: MetricUnit;
+  pick: (data: DeploymentMetricsOutput) => MetricSeriesByApp[];
+};
+
+type UtilisationDef = {
+  title: string;
+  usage: (data: DeploymentMetricsOutput) => MetricSeriesByApp[];
+  capacity: (data: DeploymentMetricsOutput) => MetricSeriesByApp[];
+};
+
+const COMPUTE_CHARTS: ChartDef[] = [
+  { title: "CPU usage", unit: "cores", pick: (d) => d.compute.cpu },
+  { title: "CPU throttling", unit: "percent", pick: (d) => d.compute.cpuThrottling },
+  { title: "Memory (working set)", unit: "MiB", pick: (d) => d.compute.memory },
+  { title: "Memory RSS", unit: "MiB", pick: (d) => d.compute.memoryRss },
+  { title: "Memory cache", unit: "MiB", pick: (d) => d.compute.memoryCache },
+];
+const NETWORK_CHARTS: ChartDef[] = [
+  { title: "Network receive", unit: "bytes/s", pick: (d) => d.network.rx },
+  { title: "Network transmit", unit: "bytes/s", pick: (d) => d.network.tx },
+];
+const STORAGE_CHARTS: ChartDef[] = [
+  { title: "Disk read", unit: "bytes/s", pick: (d) => d.storage.readBytes },
+  { title: "Disk write", unit: "bytes/s", pick: (d) => d.storage.writeBytes },
+];
+const HEALTH_CHARTS: ChartDef[] = [
+  { title: "Container restarts", unit: "events", pick: (d) => d.health.restarts },
+  { title: "OOM events", unit: "events", pick: (d) => d.health.oomEvents },
+];
+const UTILISATION_PANELS: UtilisationDef[] = [
+  {
+    title: "CPU Utilisation (from requests)",
+    usage: (d) => d.compute.cpu,
+    capacity: (d) => d.quotas.cpuRequests,
+  },
+  {
+    title: "CPU Utilisation (from limits)",
+    usage: (d) => d.compute.cpu,
+    capacity: (d) => d.quotas.cpuLimits,
+  },
+  {
+    title: "Memory Utilisation (from requests)",
+    usage: (d) => d.compute.memory,
+    capacity: (d) => d.quotas.memoryRequests,
+  },
+  {
+    title: "Memory Utilisation (from limits)",
+    usage: (d) => d.compute.memory,
+    capacity: (d) => d.quotas.memoryLimits,
+  },
+];
+
+export function Monitoring() {
   const params = routeStageDetails.useParams();
   const stageWatch = useStageWatch();
   const stage = stageWatch.query.data;
   const appCodebasesWatch = usePipelineAppCodebasesWatch();
+  const {
+    apps: filterApps,
+    range,
+    autoRefresh,
+    setRange,
+    setAutoRefresh,
+    setApps,
+    clearApps,
+    toggleApp,
+    isolateApp,
+  } = useMonitoringSearch();
 
   const isRemoteCluster = stage !== undefined && stage.spec.clusterName !== inClusterName;
 
-  const [range, setRange] = React.useState<MetricRange>(DEFAULT_RANGE);
-  const [autoRefresh, setAutoRefresh] = React.useState<boolean>(DEFAULT_AUTO_REFRESH);
-
-  const applications = React.useMemo(
+  const availableApps = React.useMemo(
     () => appCodebasesWatch.data.map((c) => c.metadata.name),
     [appCodebasesWatch.data]
   );
+
+  // Resolved apps = filter intersected with available; null means "all available".
+  const resolvedApps = React.useMemo(() => {
+    if (filterApps === null) return availableApps;
+    const set = new Set(availableApps);
+    return filterApps.filter((a) => set.has(a));
+  }, [filterApps, availableApps]);
+
+  const selectedAppsSet = React.useMemo(() => new Set(resolvedApps), [resolvedApps]);
 
   const namespace = stage?.spec.namespace;
 
   const metrics = useDeploymentMetrics({
     clusterName: params.clusterName,
     namespace: namespace ?? "",
-    applications,
+    applications: resolvedApps,
     range,
     autoRefresh,
-    enabled: !!namespace && !isRemoteCluster && !appCodebasesWatch.isLoading,
+    enabled: !!namespace && !isRemoteCluster && !appCodebasesWatch.isLoading && resolvedApps.length > 0,
   });
+
+  const onLegendClick = React.useCallback(
+    (app: string, modifiers: { toggle: boolean }) => {
+      if (modifiers.toggle) toggleApp(app);
+      else isolateApp(app);
+    },
+    [toggleApp, isolateApp]
+  );
+
+  // Memoised so MetricChart's React.memo isn't defeated by a fresh Error
+  // reference on every render.
+  const error = React.useMemo<Error | null>(() => {
+    const errorObj = metrics.error as (Error & { data?: { code?: string } }) | null;
+    if (!errorObj || metrics.data) return null;
+    switch (errorObj.data?.code) {
+      case "PRECONDITION_FAILED":
+        return new Error("Metrics are not configured. Set PROMETHEUS_URL on the server.");
+      case "GATEWAY_TIMEOUT":
+        return new Error("Metrics query timed out. Try a shorter range.");
+      case "BAD_GATEWAY":
+        return new Error("Cannot reach Prometheus. Check that the metrics service is running.");
+      default:
+        return new Error(errorObj.message);
+    }
+  }, [metrics.error, metrics.data]);
 
   if (stageWatch.query.isLoading) {
     return (
@@ -54,31 +155,11 @@ export const Monitoring: React.FC = () => {
     );
   }
 
-  const errorObj = metrics.error as (Error & { data?: { code?: string } }) | null;
-  const errorCode = errorObj?.data?.code;
-  const errorMessage = (() => {
-    if (!errorObj) return null;
-    switch (errorCode) {
-      case "PRECONDITION_FAILED":
-        return "Metrics are not configured. Set PROMETHEUS_URL on the server.";
-      case "GATEWAY_TIMEOUT":
-        return "Metrics query timed out. Try a shorter range.";
-      case "BAD_GATEWAY":
-        return "Cannot reach Prometheus. Check that the metrics service is running.";
-      default:
-        return errorObj.message;
-    }
-  })();
-
   const data = metrics.data;
   const isLoading = metrics.isLoading;
-
-  // Suppress error in charts while keepPreviousData keeps the last successful
-  // payload visible; the Toolbar's stale indicator communicates the failure.
-  const error = errorMessage && !data ? new Error(errorMessage) : null;
   const isStale = data !== undefined && metrics.isError;
 
-  if (!isLoading && !appCodebasesWatch.isLoading && applications.length === 0) {
+  if (!isLoading && !appCodebasesWatch.isLoading && availableApps.length === 0) {
     return (
       <Card className="p-6" data-tour="stage-monitoring">
         <h3 className="text-foreground mb-4 text-xl font-semibold">Monitoring</h3>
@@ -87,31 +168,66 @@ export const Monitoring: React.FC = () => {
     );
   }
 
-  return (
-    <div className="space-y-4" data-tour="stage-monitoring">
-      <Toolbar
-        range={range}
-        onRangeChange={setRange}
-        autoRefresh={autoRefresh}
-        onAutoRefreshChange={setAutoRefresh}
-        lastUpdatedAt={data?.queriedAt}
-        isStale={isStale}
-      />
-      <MetricChart title="CPU usage" unit="cores" data={data?.cpu ?? []} isLoading={isLoading} error={error} />
-      <MetricChart
-        title="Memory (working set)"
-        unit="MiB"
-        data={data?.memory ?? []}
-        isLoading={isLoading}
-        error={error}
-      />
-      <MetricChart
-        title="Container restarts"
-        unit="count"
-        data={data?.restarts ?? []}
-        isLoading={isLoading}
-        error={error}
-      />
-    </div>
+  const step = STEP_BY_RANGE[range];
+  const renderChart = (def: ChartDef) => (
+    <MetricChart
+      key={def.title}
+      title={def.title}
+      unit={def.unit}
+      data={data ? def.pick(data) : []}
+      isLoading={isLoading}
+      error={error}
+      onLegendClick={onLegendClick}
+      step={step}
+    />
   );
-};
+  const renderStat = (def: UtilisationDef) => (
+    <StatPanel
+      key={def.title}
+      title={def.title}
+      value={data ? computeUtilization(def.usage(data), def.capacity(data), selectedAppsSet) : null}
+      isLoading={isLoading}
+      error={error}
+    />
+  );
+
+  return (
+    <MetricsCursorProvider>
+      <div className="space-y-6" data-tour="stage-monitoring">
+        <Toolbar
+          range={range}
+          onRangeChange={setRange}
+          autoRefresh={autoRefresh}
+          onAutoRefreshChange={setAutoRefresh}
+          lastUpdatedAt={data?.queriedAt}
+          isStale={isStale}
+          selectedApps={filterApps}
+          availableApps={availableApps}
+          onAppsChange={setApps}
+          onAppsClear={clearApps}
+        />
+
+        <Section title="Utilisation">
+          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">{UTILISATION_PANELS.map(renderStat)}</div>
+        </Section>
+
+        <Section title="Compute" grid>
+          {COMPUTE_CHARTS.map(renderChart)}
+        </Section>
+
+        <Section title="Network" grid>
+          {NETWORK_CHARTS.map(renderChart)}
+        </Section>
+
+        <Section title="Storage" grid>
+          {STORAGE_CHARTS.map(renderChart)}
+        </Section>
+
+        <Section title="Health">
+          <div className="grid gap-3 md:grid-cols-2">{HEALTH_CHARTS.map(renderChart)}</div>
+          <PodPhasePanel data={data?.health.podPhase ?? []} selectedApps={selectedAppsSet} />
+        </Section>
+      </div>
+    </MetricsCursorProvider>
+  );
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/types.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/types.ts
@@ -1,13 +1,32 @@
-import type { MetricRange, MetricSeriesByApp } from "@my-project/shared";
+import type * as React from "react";
+import type { MetricRange, MetricSeriesByApp, PodPhaseByApp } from "@my-project/shared";
 
-export type MetricKind = "cpu" | "memory" | "restarts";
+export type MetricUnit = "cores" | "MiB" | "bytes/s" | "count" | "events" | "percent";
 
 export interface MetricChartProps {
   title: string;
-  unit: "cores" | "MiB" | "count";
+  unit: MetricUnit;
   data: MetricSeriesByApp[];
   isLoading: boolean;
   error: Error | null;
+  /**
+   * Optional client-side filter for callers that pass a superset of the apps
+   * to render (e.g. storybook stories with static data). Production passes
+   * data already scoped to the selected apps via the metrics query, so this
+   * prop is left unset there.
+   */
+  selectedApps?: ReadonlySet<string>;
+  /**
+   * Click handler for a legend entry.
+   * `modifiers.toggle` is true when the user held shift or cmd/ctrl while clicking.
+   */
+  onLegendClick?: (app: string, modifiers: { toggle: boolean }) => void;
+  /**
+   * Resolution of the time series in seconds. Used to bucket cursor timestamps
+   * so neighbouring pixels in the same step short-circuit the cross-chart
+   * cursor broadcast.
+   */
+  step?: number;
 }
 
 export interface ToolbarProps {
@@ -17,4 +36,38 @@ export interface ToolbarProps {
   onAutoRefreshChange: (next: boolean) => void;
   lastUpdatedAt: number | undefined;
   isStale: boolean;
+  /** Apps the user has selected; null means "all". */
+  selectedApps: string[] | null;
+  /** Apps available to select (resolved from usePipelineAppCodebasesWatch). */
+  availableApps: string[];
+  onAppsChange: (next: string[]) => void;
+  /** Reset the filter to "all applications" (clears the URL param). */
+  onAppsClear: () => void;
+}
+
+export interface AppMultiSelectProps {
+  selectedApps: string[] | null;
+  availableApps: string[];
+  onChange: (next: string[]) => void;
+  onClear: () => void;
+}
+
+export interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+  /** Render children in a 2-column grid where the viewport allows. */
+  grid?: boolean;
+}
+
+export interface PodPhasePanelProps {
+  data: PodPhaseByApp[];
+  selectedApps?: ReadonlySet<string>;
+}
+
+export interface StatPanelProps {
+  title: string;
+  /** Percentage value to display, or `null` for the "No data" empty state. */
+  value: number | null;
+  isLoading: boolean;
+  error: Error | null;
 }

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/utils.test.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/utils.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import type { MetricSeriesByApp } from "@my-project/shared";
+import {
+  chartSlug,
+  computeUtilization,
+  formatChartTimestamp,
+  formatPercent,
+  formatValue,
+  humanBytes,
+  latestSumByApp,
+} from "./utils";
+
+const series = (app: string, values: number[]): MetricSeriesByApp => ({
+  app,
+  series: values.map((v, i) => ({ t: 1700000000 + i * 60, v })),
+});
+
+describe("humanBytes", () => {
+  it("returns '0' for non-finite input or values <= 0", () => {
+    expect(humanBytes(0)).toBe("0");
+    expect(humanBytes(-1)).toBe("0");
+    expect(humanBytes(NaN)).toBe("0");
+    expect(humanBytes(Infinity)).toBe("0");
+  });
+
+  it("renders sub-1-byte values in B without 'undefined' unit (regression for Math.log < 0)", () => {
+    // Regression: a previous version computed Math.floor(Math.log(v) / Math.log(1024))
+    // without clamping, yielding -1 for 0 < v < 1 and rendering "0.5 undefined".
+    expect(humanBytes(0.5)).toBe("1 B");
+    expect(humanBytes(0.999)).toBe("1 B");
+  });
+
+  it("uses no decimals for whole-byte values", () => {
+    expect(humanBytes(1)).toBe("1 B");
+    expect(humanBytes(512)).toBe("512 B");
+    expect(humanBytes(1023)).toBe("1023 B");
+  });
+
+  it("scales to KiB / MiB / GiB / TiB with one decimal", () => {
+    expect(humanBytes(1024)).toBe("1.0 KiB");
+    expect(humanBytes(1536)).toBe("1.5 KiB");
+    expect(humanBytes(1024 * 1024)).toBe("1.0 MiB");
+    expect(humanBytes(1024 * 1024 * 1024)).toBe("1.0 GiB");
+    expect(humanBytes(1024 ** 4)).toBe("1.0 TiB");
+  });
+
+  it("clamps to TiB for values larger than the largest unit", () => {
+    expect(humanBytes(1024 ** 5)).toBe("1024.0 TiB");
+  });
+});
+
+describe("formatValue", () => {
+  it("renders cores with two decimals", () => {
+    expect(formatValue("cores", 0)).toBe("0.00");
+    expect(formatValue("cores", 1.2345)).toBe("1.23");
+  });
+
+  it("renders MiB by dividing bytes and rounding", () => {
+    expect(formatValue("MiB", 0)).toBe("0");
+    expect(formatValue("MiB", 1024 * 1024)).toBe("1");
+    expect(formatValue("MiB", 1.5 * 1024 * 1024)).toBe("2");
+  });
+
+  it("renders bytes/s using humanBytes with a /s suffix", () => {
+    expect(formatValue("bytes/s", 0)).toBe("0/s");
+    expect(formatValue("bytes/s", 1024)).toBe("1.0 KiB/s");
+    expect(formatValue("bytes/s", 0.5)).toBe("1 B/s");
+  });
+
+  it("rounds count and events to integers", () => {
+    expect(formatValue("count", 1.4)).toBe("1");
+    expect(formatValue("count", 1.6)).toBe("2");
+    expect(formatValue("events", 0)).toBe("0");
+    expect(formatValue("events", 3.9)).toBe("4");
+  });
+
+  it("renders percent values with formatPercent precision tiers and a % suffix", () => {
+    expect(formatValue("percent", 0)).toBe("0.00%");
+    expect(formatValue("percent", 9.18)).toBe("9.18%");
+    expect(formatValue("percent", 52.9)).toBe("52.9%");
+    expect(formatValue("percent", 100)).toBe("100%");
+    expect(formatValue("percent", 137)).toBe("137%");
+  });
+});
+
+describe("formatChartTimestamp", () => {
+  it("formats unix-seconds via toLocaleTimeString", () => {
+    const result = formatChartTimestamp(1700000000);
+    // Output is locale/timezone-dependent; assert it's a non-empty time-like string.
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toBe(new Date(1700000000 * 1000).toLocaleTimeString());
+  });
+});
+
+describe("latestSumByApp", () => {
+  it("sums the last point of every selected app's series", () => {
+    const data = [series("a", [1, 2, 3]), series("b", [10, 20]), series("c", [100])];
+    expect(latestSumByApp(data, new Set(["a", "b", "c"]))).toBe(123);
+  });
+
+  it("skips apps not in the selection", () => {
+    const data = [series("a", [1, 2, 3]), series("b", [10, 20])];
+    expect(latestSumByApp(data, new Set(["a"]))).toBe(3);
+  });
+
+  it("treats apps with empty series as zero contribution", () => {
+    const data = [series("a", [3]), { app: "b", series: [] }];
+    expect(latestSumByApp(data, new Set(["a", "b"]))).toBe(3);
+  });
+
+  it("returns 0 when nothing matches", () => {
+    expect(latestSumByApp([], new Set(["a"]))).toBe(0);
+    expect(latestSumByApp([series("a", [1])], new Set())).toBe(0);
+  });
+});
+
+describe("computeUtilization", () => {
+  const apps = new Set(["a", "b"]);
+
+  it("returns Grafana-style percentage (sum usage / sum capacity * 100)", () => {
+    const usage = [series("a", [0.3]), series("b", [0.6])];
+    const capacity = [series("a", [1]), series("b", [2])];
+    // (0.3 + 0.6) / (1 + 2) * 100 = 30
+    expect(computeUtilization(usage, capacity, apps)).toBe(30);
+  });
+
+  it("returns null when no selected app has capacity configured", () => {
+    const usage = [series("a", [0.5]), series("b", [0.5])];
+    const capacity = [
+      { app: "a", series: [] },
+      { app: "b", series: [] },
+    ];
+    expect(computeUtilization(usage, capacity, apps)).toBeNull();
+  });
+
+  it("returns null when capacity sums to zero", () => {
+    const usage = [series("a", [0.5])];
+    const capacity = [series("a", [0])];
+    expect(computeUtilization(usage, capacity, apps)).toBeNull();
+  });
+
+  it("only counts capacity from apps in the selection", () => {
+    const usage = [series("a", [1]), series("b", [1])];
+    const capacity = [series("a", [4]), series("b", [4])];
+    expect(computeUtilization(usage, capacity, new Set(["a"]))).toBe(25);
+  });
+
+  it("can exceed 100% when usage outpaces configured capacity", () => {
+    const usage = [series("a", [3])];
+    const capacity = [series("a", [2])];
+    expect(computeUtilization(usage, capacity, apps)).toBe(150);
+  });
+});
+
+describe("formatPercent", () => {
+  it("uses two decimals below 10", () => {
+    expect(formatPercent(0)).toBe("0.00");
+    expect(formatPercent(9.18)).toBe("9.18");
+  });
+
+  it("uses one decimal between 10 and 100", () => {
+    expect(formatPercent(52.9)).toBe("52.9");
+    expect(formatPercent(99.95)).toBe("100.0");
+  });
+
+  it("uses zero decimals at or above 100", () => {
+    expect(formatPercent(100)).toBe("100");
+    expect(formatPercent(250.7)).toBe("251");
+  });
+
+  it("falls back to '0' for non-finite input", () => {
+    expect(formatPercent(NaN)).toBe("0");
+    expect(formatPercent(Infinity)).toBe("0");
+  });
+});
+
+describe("chartSlug", () => {
+  it("lowercases and replaces non-alphanumerics with single hyphens", () => {
+    expect(chartSlug("CPU usage")).toBe("cpu-usage");
+    expect(chartSlug("Memory (working set)")).toBe("memory-working-set");
+    expect(chartSlug("Disk I/O Bytes")).toBe("disk-i-o-bytes");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(chartSlug("  Hello  ")).toBe("hello");
+    expect(chartSlug("__title__")).toBe("title");
+  });
+
+  it("handles already-slug-friendly input unchanged", () => {
+    expect(chartSlug("oom-events")).toBe("oom-events");
+  });
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/utils.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/utils.ts
@@ -1,0 +1,80 @@
+import type { MetricSeriesByApp } from "@my-project/shared";
+import type { MetricUnit } from "./types";
+
+const BYTE_UNITS = ["B", "KiB", "MiB", "GiB", "TiB"] as const;
+
+export function humanBytes(v: number): string {
+  if (!Number.isFinite(v) || v <= 0) return "0";
+  const raw = Math.floor(Math.log(v) / Math.log(1024));
+  const i = Math.min(BYTE_UNITS.length - 1, Math.max(0, raw));
+  return `${(v / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${BYTE_UNITS[i]}`;
+}
+
+export function formatValue(unit: MetricUnit, v: number): string {
+  if (unit === "cores") return v.toFixed(2);
+  if (unit === "MiB") return Math.round(v / (1024 * 1024)).toString();
+  if (unit === "bytes/s") return `${humanBytes(v)}/s`;
+  if (unit === "percent") return `${formatPercent(v)}%`;
+  return Math.round(v).toString();
+}
+
+/** Format a unix-seconds timestamp as a locale time string. */
+export function formatChartTimestamp(t: number): string {
+  return new Date(t * 1000).toLocaleTimeString();
+}
+
+/** Slugify a chart title for use in stable data-tour attributes. */
+export function chartSlug(title: string): string {
+  const collapsed = title.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const start = collapsed.startsWith("-") ? 1 : 0;
+  const end = collapsed.endsWith("-") ? collapsed.length - 1 : collapsed.length;
+  return start >= end ? "" : collapsed.slice(start, end);
+}
+
+/**
+ * Sum the latest sample of every selected app's series. Apps with empty series
+ * are skipped (kube-state-metrics omits a series entirely when the resource
+ * isn't configured, so empty == not set).
+ */
+export function latestSumByApp(series: MetricSeriesByApp[], apps: ReadonlySet<string>): number {
+  let total = 0;
+  for (const s of series) {
+    if (!apps.has(s.app) || s.series.length === 0) continue;
+    total += s.series[s.series.length - 1].v;
+  }
+  return total;
+}
+
+/**
+ * Compute utilisation percentage matching Grafana's
+ * `sum(usage) / sum(capacity)` semantic. Returns `null` when no selected app
+ * has capacity configured (so the panel can render "No data" instead of a
+ * misleading 0% or division-by-zero infinity).
+ */
+export function computeUtilization(
+  usage: MetricSeriesByApp[],
+  capacity: MetricSeriesByApp[],
+  apps: ReadonlySet<string>
+): number | null {
+  let totalCapacity = 0;
+  let hasCapacity = false;
+  for (const s of capacity) {
+    if (!apps.has(s.app) || s.series.length === 0) continue;
+    totalCapacity += s.series[s.series.length - 1].v;
+    hasCapacity = true;
+  }
+  if (!hasCapacity || totalCapacity <= 0) return null;
+  return (latestSumByApp(usage, apps) / totalCapacity) * 100;
+}
+
+/**
+ * Grafana-style percent formatting: more precision at small magnitudes so
+ * single-digit utilisation reads as "9.18", not "9".
+ */
+export function formatPercent(v: number): string {
+  if (!Number.isFinite(v)) return "0";
+  const abs = Math.abs(v);
+  if (abs >= 100) return v.toFixed(0);
+  if (abs >= 10) return v.toFixed(1);
+  return v.toFixed(2);
+}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/route.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/route.ts
@@ -1,4 +1,5 @@
 import { routeCluster } from "@/core/router/routes";
+import { METRIC_RANGE_VALUES, type MetricRange } from "@my-project/shared";
 import { createRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
@@ -23,6 +24,10 @@ export interface Search {
   applicationsMode?: ApplicationsMode;
   page?: number;
   rowsPerPage?: number;
+  // Monitoring tab:
+  apps?: string; // comma-separated app names; absent or "" means "all"
+  range?: MetricRange;
+  autoRefresh?: boolean;
 }
 
 export const routeStageDetails = createRoute({
@@ -35,6 +40,9 @@ export const routeStageDetails = createRoute({
         applicationsMode: applicationsModeSchema.optional(),
         page: z.number().optional(),
         rowsPerPage: z.number().optional(),
+        apps: z.string().optional(),
+        range: z.enum(METRIC_RANGE_VALUES).optional(),
+        autoRefresh: z.coerce.boolean().optional(),
       })
       .parse(search);
 

--- a/apps/client/src/modules/platform/cdpipelines/tours.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/tours.tsx
@@ -456,8 +456,8 @@ export const CDPIPELINE_TOURS = {
         content: (
           <TourStepContent title="Monitoring Dashboard">
             <p>
-              An embedded Grafana monitoring dashboard for this environment. View real-time metrics, resource usage, and
-              application performance directly within the portal.
+              A monitoring dashboard for this environment. View real-time metrics, resource usage, and application
+              performance directly within the portal.
             </p>
           </TourStepContent>
         ),

--- a/packages/shared/src/models/k8s/groups/Core/Pod/labels.ts
+++ b/packages/shared/src/models/k8s/groups/Core/Pod/labels.ts
@@ -1,3 +1,4 @@
 export const podLabels = {
   taskRun: "tekton.dev/taskRun",
+  instance: "app.kubernetes.io/instance",
 } as const;

--- a/packages/shared/src/models/prometheus/schemas.ts
+++ b/packages/shared/src/models/prometheus/schemas.ts
@@ -1,25 +1,27 @@
 import { z } from "zod";
 import { METRIC_RANGE_VALUES, MAX_APPLICATIONS } from "./constants.js";
 
-// namespace must match RFC-1123 to be safe inside the templated PromQL.
+const RFC_1123_LABEL_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+const RFC_1123_LABEL_MESSAGE =
+  "must match RFC-1123 DNS label (lowercase alphanumeric, optional hyphens, max 63 chars, must start and end with alphanumeric)";
+
+// namespace and application names are interpolated into PromQL and K8s label
+// selectors; constraining them to RFC-1123 at the schema boundary is the
+// single source of truth for that invariant.
 export const deploymentMetricsInputSchema = z
   .object({
     clusterName: z.string().min(1),
-    namespace: z
-      .string()
-      .min(1)
-      .regex(
-        /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/,
-        "namespace must match RFC-1123 DNS label (lowercase alphanumeric, optional hyphens, max 63 chars, must start and end with alphanumeric)"
-      ),
-    applications: z.array(z.string().min(1)).max(MAX_APPLICATIONS),
+    namespace: z.string().min(1).regex(RFC_1123_LABEL_REGEX, `namespace ${RFC_1123_LABEL_MESSAGE}`),
+    applications: z
+      .array(z.string().min(1).regex(RFC_1123_LABEL_REGEX, `application name ${RFC_1123_LABEL_MESSAGE}`))
+      .max(MAX_APPLICATIONS),
     range: z.enum(METRIC_RANGE_VALUES),
   })
   .strict();
 
 export const metricSeriesPointSchema = z.object({
-  t: z.number(), // unix seconds
-  v: z.number(),
+  t: z.number().int().nonnegative(), // unix seconds
+  v: z.number().finite(),
 });
 
 export const metricSeriesByAppSchema = z.object({
@@ -27,12 +29,47 @@ export const metricSeriesByAppSchema = z.object({
   series: z.array(metricSeriesPointSchema),
 });
 
+export const podPhaseSchema = z.enum(["Pending", "Running", "Succeeded", "Failed", "Unknown"]);
+
+export const podPhaseByAppSchema = z.object({
+  app: z.string(),
+  pods: z.array(
+    z.object({
+      name: z.string(),
+      phase: podPhaseSchema,
+    })
+  ),
+});
+
 export const deploymentMetricsOutputSchema = z.object({
-  cpu: z.array(metricSeriesByAppSchema),
-  memory: z.array(metricSeriesByAppSchema),
-  restarts: z.array(metricSeriesByAppSchema),
+  compute: z.object({
+    cpu: z.array(metricSeriesByAppSchema), // cores
+    memory: z.array(metricSeriesByAppSchema), // bytes (working set)
+    memoryRss: z.array(metricSeriesByAppSchema), // bytes
+    memoryCache: z.array(metricSeriesByAppSchema), // bytes
+    cpuThrottling: z.array(metricSeriesByAppSchema), // percent (0-100): sum throttled / sum periods × 100
+  }),
+  network: z.object({
+    rx: z.array(metricSeriesByAppSchema), // bytes/s
+    tx: z.array(metricSeriesByAppSchema), // bytes/s
+  }),
+  storage: z.object({
+    readBytes: z.array(metricSeriesByAppSchema), // bytes/s
+    writeBytes: z.array(metricSeriesByAppSchema), // bytes/s
+  }),
+  health: z.object({
+    restarts: z.array(metricSeriesByAppSchema), // events in selected range (increase)
+    oomEvents: z.array(metricSeriesByAppSchema), // events in selected range (increase)
+    podPhase: z.array(podPhaseByAppSchema),
+  }),
+  quotas: z.object({
+    cpuRequests: z.array(metricSeriesByAppSchema), // cores
+    cpuLimits: z.array(metricSeriesByAppSchema), // cores
+    memoryRequests: z.array(metricSeriesByAppSchema), // bytes
+    memoryLimits: z.array(metricSeriesByAppSchema), // bytes
+  }),
   range: z.enum(METRIC_RANGE_VALUES),
-  queriedAt: z.number(),
+  queriedAt: z.number().int().nonnegative(),
 });
 
 // Minimal subset of Prometheus query_range matrix shape used for response validation.
@@ -44,6 +81,20 @@ export const promqlMatrixResponseSchema = z.object({
       z.object({
         metric: z.record(z.string(), z.string()),
         values: z.array(z.tuple([z.number(), z.string()])),
+      })
+    ),
+  }),
+});
+
+// Minimal subset of Prometheus instant-query vector shape.
+export const promqlVectorResponseSchema = z.object({
+  status: z.literal("success"),
+  data: z.object({
+    resultType: z.literal("vector"),
+    result: z.array(
+      z.object({
+        metric: z.record(z.string(), z.string()),
+        value: z.tuple([z.number(), z.string()]),
       })
     ),
   }),

--- a/packages/shared/src/models/prometheus/types.ts
+++ b/packages/shared/src/models/prometheus/types.ts
@@ -3,14 +3,20 @@ import type {
   deploymentMetricsInputSchema,
   deploymentMetricsOutputSchema,
   promqlMatrixResponseSchema,
+  promqlVectorResponseSchema,
   metricSeriesPointSchema,
   metricSeriesByAppSchema,
+  podPhaseSchema,
+  podPhaseByAppSchema,
 } from "./schemas.js";
 import type { METRIC_RANGE_VALUES } from "./constants.js";
 
 export type DeploymentMetricsInput = z.infer<typeof deploymentMetricsInputSchema>;
 export type DeploymentMetricsOutput = z.infer<typeof deploymentMetricsOutputSchema>;
 export type PromQLMatrixResponse = z.infer<typeof promqlMatrixResponseSchema>;
+export type PromQLVectorResponse = z.infer<typeof promqlVectorResponseSchema>;
 export type MetricRange = (typeof METRIC_RANGE_VALUES)[number];
 export type MetricSeriesPoint = z.infer<typeof metricSeriesPointSchema>;
 export type MetricSeriesByApp = z.infer<typeof metricSeriesByAppSchema>;
+export type PodPhase = z.infer<typeof podPhaseSchema>;
+export type PodPhaseByApp = z.infer<typeof podPhaseByAppSchema>;

--- a/packages/trpc/src/clients/prometheus/index.test.ts
+++ b/packages/trpc/src/clients/prometheus/index.test.ts
@@ -147,4 +147,86 @@ describe("PrometheusClient timeout & errors", () => {
     const client = new PrometheusClient({ baseURL: "http://x", timeoutMs: 500 });
     await expect(client.rangeQuery({ query: "x", start: 0, end: 1, step: 1 })).rejects.toThrow(/400 Bad Request/);
   });
+
+  it("instantQuery rejects with timeout message when fetch hangs past timeoutMs", async () => {
+    globalThis.fetch = vi.fn(
+      (_url: string, init: { signal?: AbortSignal } = {}) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        })
+    ) as unknown as typeof globalThis.fetch;
+
+    const { PrometheusClient } = await import("./index.js");
+    const client = new PrometheusClient({ baseURL: "http://x", timeoutMs: 10 });
+    await expect(client.instantQuery({ query: "x" })).rejects.toThrow(/timed out/i);
+  });
+});
+
+describe("PrometheusClient.instantQuery URL shape", () => {
+  const BASE = "http://prom.example:9090";
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: { resultType: "vector", result: [] },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  async function newClient() {
+    const { PrometheusClient } = await import("./index.js");
+    return new PrometheusClient({ baseURL: BASE, timeoutMs: 500 });
+  }
+
+  function capturedUrl(): string {
+    const firstCall = fetchMock.mock.calls[0];
+    return String(firstCall[0]);
+  }
+
+  it("instantQuery hits /api/v1/query with the encoded query", async () => {
+    const client = await newClient();
+    await client.instantQuery({ query: 'up{namespace="foo"}' });
+    const url = capturedUrl();
+    expect(url).toContain("/api/v1/query?");
+    expect(url).toContain("query=up%7Bnamespace%3D%22foo%22%7D");
+    expect(url).not.toContain("start=");
+    expect(url).not.toContain("step=");
+  });
+
+  it("instantQuery happy path parses vector shape", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: {
+            resultType: "vector",
+            result: [{ metric: { pod: "p1", phase: "Running" }, value: [1700000000, "1"] }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    const client = await newClient();
+    const result = await client.instantQuery({ query: "x" });
+    expect(result.data.result[0]?.metric.pod).toBe("p1");
+    expect(result.data.result[0]?.metric.phase).toBe("Running");
+    expect(result.data.result[0]?.value[1]).toBe("1");
+  });
 });

--- a/packages/trpc/src/clients/prometheus/index.ts
+++ b/packages/trpc/src/clients/prometheus/index.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
-import { promqlMatrixResponseSchema, PROMETHEUS_TIMEOUT_MS } from "@my-project/shared";
-import type { PromQLMatrixResponse } from "@my-project/shared";
+import { promqlMatrixResponseSchema, promqlVectorResponseSchema, PROMETHEUS_TIMEOUT_MS } from "@my-project/shared";
+import type { PromQLMatrixResponse, PromQLVectorResponse } from "@my-project/shared";
+import type { ZodType } from "zod";
 
 export interface PrometheusClientConfig {
   baseURL: string;
@@ -39,6 +40,10 @@ export interface RangeQueryParams {
   step: number;
 }
 
+export interface InstantQueryParams {
+  query: string;
+}
+
 export class PrometheusClient {
   private readonly baseURL: string;
   private readonly timeoutMs: number;
@@ -58,10 +63,15 @@ export class PrometheusClient {
       end: String(Math.floor(params.end)),
       step: `${params.step}s`,
     }).toString();
-    return this.fetchJson(`/api/v1/query_range?${qs}`, externalSignal);
+    return this.fetchJson(`/api/v1/query_range?${qs}`, promqlMatrixResponseSchema, externalSignal);
   }
 
-  private async fetchJson(path: string, externalSignal?: AbortSignal): Promise<PromQLMatrixResponse> {
+  async instantQuery(params: InstantQueryParams, externalSignal?: AbortSignal): Promise<PromQLVectorResponse> {
+    const qs = new URLSearchParams({ query: params.query }).toString();
+    return this.fetchJson(`/api/v1/query?${qs}`, promqlVectorResponseSchema, externalSignal);
+  }
+
+  private async fetchJson<T>(path: string, schema: ZodType<T>, externalSignal?: AbortSignal): Promise<T> {
     const url = `${this.baseURL}${path}`;
     const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
     const signal = externalSignal ? AbortSignal.any([timeoutSignal, externalSignal]) : timeoutSignal;
@@ -81,7 +91,7 @@ export class PrometheusClient {
       }
 
       const json = await response.json();
-      return promqlMatrixResponseSchema.parse(json);
+      return schema.parse(json);
     } catch (error) {
       if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
         throw new Error(`Prometheus request timed out after ${this.timeoutMs}ms`);

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.test.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.test.ts
@@ -3,6 +3,7 @@ import { createMockedContext } from "../../../../__mocks__/context.js";
 
 const mockListResource = vi.fn();
 const mockRangeQuery = vi.fn();
+const mockInstantQuery = vi.fn();
 
 vi.mock("../../../../clients/k8s/index.js", () => ({
   K8sClient: vi.fn().mockImplementation(() => ({
@@ -14,6 +15,7 @@ vi.mock("../../../../clients/k8s/index.js", () => ({
 vi.mock("../../../../clients/prometheus/index.js", () => ({
   createPrometheusClient: () => ({
     rangeQuery: mockRangeQuery,
+    instantQuery: mockInstantQuery,
   }),
 }));
 
@@ -34,9 +36,15 @@ const emptyMatrix = {
   data: { resultType: "matrix" as const, result: [] },
 };
 
+const emptyVector = {
+  status: "success" as const,
+  data: { resultType: "vector" as const, result: [] },
+};
+
 describe("prometheus.getDeploymentMetrics", () => {
   beforeEach(() => {
     mockRangeQuery.mockResolvedValue(emptyMatrix);
+    mockInstantQuery.mockResolvedValue(emptyVector);
   });
 
   afterEach(() => {
@@ -49,21 +57,17 @@ describe("prometheus.getDeploymentMetrics", () => {
 
     expect(mockListResource).not.toHaveBeenCalled();
     expect(mockRangeQuery).not.toHaveBeenCalled();
-    expect(result.cpu).toEqual([]);
-    expect(result.memory).toEqual([]);
-    expect(result.restarts).toEqual([]);
+    expect(mockInstantQuery).not.toHaveBeenCalled();
+    expect(result.compute.cpu).toEqual([]);
+    expect(result.compute.memoryRss).toEqual([]);
+    expect(result.network.rx).toEqual([]);
+    expect(result.health.podPhase).toEqual([]);
+    expect(result.quotas.cpuLimits).toEqual([]);
     expect(result.range).toBe("1h");
     expect(typeof result.queriedAt).toBe("number");
   });
 
   it("throws INTERNAL_SERVER_ERROR when K8sClient KubeConfig is uninitialized", async () => {
-    // The shared mock at the top of the file always returns KubeConfig: {}.
-    // For this test, we need a falsy KubeConfig — use vi.mocked() to override the
-    // implementation just for this test.
-    //
-    // NOTE: getCaller() → createMockedContext() → new K8sClient() consumes one
-    // constructor call. We get the caller first, then override the mock so that
-    // the very next new K8sClient() call (inside the procedure) returns null KubeConfig.
     const caller = await getCaller();
 
     const k8sClientModule = await import("../../../../clients/k8s/index.js");
@@ -82,7 +86,7 @@ describe("prometheus.getDeploymentMetrics", () => {
     expect(mockListResource).not.toHaveBeenCalled();
   });
 
-  it("groups pods by app and sends a single combined PromQL pod regex per metric", async () => {
+  it("fans out 16 range queries + 1 instant query and groups output by section", async () => {
     mockListResource.mockResolvedValueOnce({
       items: [
         { metadata: { name: "frontend-1", labels: { "app.kubernetes.io/instance": "frontend" } } },
@@ -102,14 +106,19 @@ describe("prometheus.getDeploymentMetrics", () => {
               [110, "2.0"],
             ],
           },
-          {
-            metric: { pod: "frontend-2" },
-            values: [[110, "0.5"]],
-          },
-          {
-            metric: { pod: "api-1" },
-            values: [[100, "3.0"]],
-          },
+          { metric: { pod: "frontend-2" }, values: [[110, "0.5"]] },
+          { metric: { pod: "api-1" }, values: [[100, "3.0"]] },
+        ],
+      },
+    });
+    mockInstantQuery.mockResolvedValueOnce({
+      status: "success",
+      data: {
+        resultType: "vector",
+        result: [
+          { metric: { pod: "frontend-1", phase: "Running" }, value: [100, "1"] },
+          { metric: { pod: "frontend-2", phase: "Pending" }, value: [100, "1"] },
+          { metric: { pod: "api-1", phase: "Running" }, value: [100, "1"] },
         ],
       },
     });
@@ -120,24 +129,42 @@ describe("prometheus.getDeploymentMetrics", () => {
       applications: ["frontend", "api"],
     });
 
-    expect(mockRangeQuery).toHaveBeenCalledTimes(3);
-    const firstQuery = mockRangeQuery.mock.calls[0][0].query as string;
-    expect(firstQuery).toContain('namespace="test-namespace"');
-    expect(firstQuery).toContain('pod=~"');
-    expect(firstQuery).toContain("frontend-1");
-    expect(firstQuery).toContain("frontend-2");
-    expect(firstQuery).toContain("api-1");
+    expect(mockRangeQuery).toHaveBeenCalledTimes(16);
+    expect(mockInstantQuery).toHaveBeenCalledTimes(1);
+    const cpuCall = mockRangeQuery.mock.calls.find(([q]) => q.query.includes("container_cpu_usage_seconds_total"));
+    expect(cpuCall?.[0].query).toContain('namespace="test-namespace"');
+    expect(cpuCall?.[0].query).toContain("frontend-1");
+    expect(cpuCall?.[0].query).toContain("api-1");
 
-    const frontend = result.cpu.find((r) => r.app === "frontend");
-    expect(frontend?.series).toEqual([
+    const cpuFrontend = result.compute.cpu.find((r) => r.app === "frontend");
+    expect(cpuFrontend?.series).toEqual([
       { t: 100, v: 1.0 },
       { t: 110, v: 2.5 },
     ]);
-    const api = result.cpu.find((r) => r.app === "api");
-    expect(api?.series).toEqual([{ t: 100, v: 3.0 }]);
+    const phaseFrontend = result.health.podPhase.find((r) => r.app === "frontend");
+    expect(phaseFrontend?.pods).toEqual([
+      { name: "frontend-1", phase: "Running" },
+      { name: "frontend-2", phase: "Pending" },
+    ]);
+    expect(result.network.rx.find((r) => r.app === "api")?.series).toEqual([{ t: 100, v: 3.0 }]);
   });
 
-  it("includes apps with zero matched pods in the output as empty series", async () => {
+  it("returns empty grouped series per app when zero pods match (no Prometheus call)", async () => {
+    mockListResource.mockResolvedValueOnce({ items: [] });
+    const caller = await getCaller();
+    const result = await caller.prometheus.getDeploymentMetrics({
+      ...validInput,
+      applications: ["frontend", "api"],
+    });
+
+    expect(mockRangeQuery).not.toHaveBeenCalled();
+    expect(mockInstantQuery).not.toHaveBeenCalled();
+    expect(result.compute.cpu.map((r) => r.app)).toEqual(["frontend", "api"]);
+    expect(result.compute.cpu.every((r) => r.series.length === 0)).toBe(true);
+    expect(result.health.podPhase.every((r) => r.pods.length === 0)).toBe(true);
+  });
+
+  it("includes an app with no pods as empty series alongside apps that do have pods", async () => {
     mockListResource.mockResolvedValueOnce({
       items: [{ metadata: { name: "frontend-1", labels: { "app.kubernetes.io/instance": "frontend" } } }],
     });
@@ -147,26 +174,14 @@ describe("prometheus.getDeploymentMetrics", () => {
       applications: ["frontend", "missing"],
     });
 
-    const missing = result.cpu.find((r) => r.app === "missing");
+    expect(mockRangeQuery).toHaveBeenCalledTimes(16);
+    const missing = result.compute.cpu.find((r) => r.app === "missing");
     expect(missing).toBeDefined();
     expect(missing?.series).toEqual([]);
-
-    const frontend = result.cpu.find((r) => r.app === "frontend");
+    const frontend = result.compute.cpu.find((r) => r.app === "frontend");
     expect(frontend).toBeDefined();
-    expect(mockRangeQuery).toHaveBeenCalledTimes(3);
-  });
-
-  it("returns empty series per app when zero pods match any requested app (no Prometheus call)", async () => {
-    mockListResource.mockResolvedValueOnce({ items: [] });
-    const caller = await getCaller();
-    const result = await caller.prometheus.getDeploymentMetrics({
-      ...validInput,
-      applications: ["frontend", "api"],
-    });
-
-    expect(mockRangeQuery).not.toHaveBeenCalled();
-    expect(result.cpu.map((r) => r.app)).toEqual(["frontend", "api"]);
-    expect(result.cpu.every((r) => r.series.length === 0)).toBe(true);
+    const missingPhase = result.health.podPhase.find((r) => r.app === "missing");
+    expect(missingPhase?.pods).toEqual([]);
   });
 
   it("maps Prometheus rejection to BAD_GATEWAY", async () => {
@@ -212,5 +227,61 @@ describe("prometheus.getDeploymentMetrics", () => {
     const caller = await getCaller();
     const apps = Array.from({ length: 51 }, (_, i) => `app-${i}`);
     await expect(caller.prometheus.getDeploymentMetrics({ ...validInput, applications: apps })).rejects.toThrow();
+  });
+
+  it.each([
+    ["uppercase letters", "MyApp"],
+    ["underscore", "my_app"],
+    ["leading hyphen", "-my-app"],
+    ["trailing hyphen", "my-app-"],
+    ["dot", "my.app"],
+  ])("Zod rejects application name with %s (%s)", async (_label, badApp) => {
+    const caller = await getCaller();
+    await expect(caller.prometheus.getDeploymentMetrics({ ...validInput, applications: [badApp] })).rejects.toThrow();
+  });
+
+  it("computes start = end - 86400 and step = 300 for range 24h", async () => {
+    mockListResource.mockResolvedValueOnce({
+      items: [{ metadata: { name: "p", labels: { "app.kubernetes.io/instance": "test-app" } } }],
+    });
+    const caller = await getCaller();
+    await caller.prometheus.getDeploymentMetrics({ ...validInput, range: "24h" });
+    const firstCall = mockRangeQuery.mock.calls[0]?.[0];
+    expect(firstCall).toBeDefined();
+    expect(firstCall.end - firstCall.start).toBe(86400);
+    expect(firstCall.step).toBe(300);
+  });
+
+  it("aborts in-flight queries via the shared signal when one query rejects", async () => {
+    mockListResource.mockResolvedValueOnce({
+      items: [{ metadata: { name: "p", labels: { "app.kubernetes.io/instance": "test-app" } } }],
+    });
+    const seenSignals: AbortSignal[] = [];
+    mockRangeQuery.mockImplementation((_params: unknown, signal: AbortSignal) => {
+      seenSignals.push(signal);
+      return new Promise((_res, reject) => {
+        signal.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    });
+    // First call rejects synchronously; remaining calls hang until aborted.
+    mockRangeQuery.mockImplementationOnce((_params: unknown, signal: AbortSignal) => {
+      seenSignals.push(signal);
+      return Promise.reject(new Error("ECONNREFUSED"));
+    });
+
+    const caller = await getCaller();
+    await expect(caller.prometheus.getDeploymentMetrics(validInput)).rejects.toMatchObject({
+      code: "BAD_GATEWAY",
+    });
+
+    expect(seenSignals.length).toBeGreaterThan(1);
+    // All non-rejecting signals must have been aborted by sharedAbort.
+    for (const signal of seenSignals.slice(1)) {
+      expect(signal.aborted).toBe(true);
+    }
   });
 });

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.ts
@@ -3,17 +3,64 @@ import {
   deploymentMetricsInputSchema,
   deploymentMetricsOutputSchema,
   k8sPodConfig,
+  podLabels,
   STEP_BY_RANGE,
   PROMETHEUS_TIME_RANGES,
   type DeploymentMetricsOutput,
   type MetricSeriesByApp,
+  type PodPhaseByApp,
   type PromQLMatrixResponse,
+  type PromQLVectorResponse,
 } from "@my-project/shared";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { K8sClient } from "../../../../clients/k8s/index.js";
 import { ERROR_K8S_CLIENT_NOT_INITIALIZED } from "../../../k8s/errors/index.js";
 import { createPrometheusClient } from "../../../../clients/prometheus/index.js";
-import { APP_INSTANCE_LABEL, buildPromQLQueries, groupPodsByApp, matrixToSeriesByApp } from "./utils.js";
+import {
+  buildPodPhaseQuery,
+  buildPromQLQueries,
+  combineRatioSeriesByApp,
+  deriveRateWindow,
+  groupPodsByApp,
+  matrixToSeriesByApp,
+  RANGE_METRIC_KEYS,
+  vectorToPodPhaseByApp,
+  type RangeMetricKey,
+} from "./utils.js";
+
+// Wall-clock deadline for the entire range+instant query bundle. Above
+// PROMETHEUS_TIMEOUT_MS (10 s) so a single slow query can still fail per-query
+// while the bundle as a whole has bounded latency.
+const PROMETHEUS_BUDGET_MS = 15_000;
+
+function emptyOutput(
+  range: DeploymentMetricsOutput["range"],
+  queriedAt: number,
+  apps: string[]
+): DeploymentMetricsOutput {
+  const empty = (): MetricSeriesByApp[] => apps.map((app) => ({ app, series: [] }));
+  const emptyPhase = (): PodPhaseByApp[] => apps.map((app) => ({ app, pods: [] }));
+  return {
+    compute: {
+      cpu: empty(),
+      memory: empty(),
+      memoryRss: empty(),
+      memoryCache: empty(),
+      cpuThrottling: empty(),
+    },
+    network: { rx: empty(), tx: empty() },
+    storage: { readBytes: empty(), writeBytes: empty() },
+    health: { restarts: empty(), oomEvents: empty(), podPhase: emptyPhase() },
+    quotas: {
+      cpuRequests: empty(),
+      cpuLimits: empty(),
+      memoryRequests: empty(),
+      memoryLimits: empty(),
+    },
+    range,
+    queriedAt,
+  };
+}
 
 export const getDeploymentMetricsProcedure = protectedProcedure
   .input(deploymentMetricsInputSchema)
@@ -25,7 +72,7 @@ export const getDeploymentMetricsProcedure = protectedProcedure
     const queriedAt = Math.floor(Date.now() / 1000);
 
     if (applications.length === 0) {
-      return { cpu: [], memory: [], restarts: [], range, queriedAt };
+      return emptyOutput(range, queriedAt, []);
     }
 
     const k8sClient = new K8sClient(ctx.session);
@@ -33,7 +80,7 @@ export const getDeploymentMetricsProcedure = protectedProcedure
       throw new TRPCError(ERROR_K8S_CLIENT_NOT_INITIALIZED);
     }
 
-    const labelSelector = `${APP_INSTANCE_LABEL} in (${applications.join(",")})`;
+    const labelSelector = `${podLabels.instance} in (${applications.join(",")})`;
     const podList = await k8sClient.listResource(k8sPodConfig, namespace, labelSelector);
 
     const podsByApp = groupPodsByApp(
@@ -51,27 +98,39 @@ export const getDeploymentMetricsProcedure = protectedProcedure
     }
 
     if (allPodNames.length === 0) {
-      const empty: MetricSeriesByApp[] = applications.map((app) => ({ app, series: [] }));
-      return { cpu: empty, memory: empty, restarts: empty, range, queriedAt };
+      return emptyOutput(range, queriedAt, applications);
     }
 
-    const queries = buildPromQLQueries({ namespace, podNames: allPodNames });
     const end = queriedAt;
-    const start = end - PROMETHEUS_TIME_RANGES[range];
     const step = STEP_BY_RANGE[range];
+    const rangeSeconds = PROMETHEUS_TIME_RANGES[range];
+    const start = end - rangeSeconds;
+    const queries = buildPromQLQueries({
+      namespace,
+      podNames: allPodNames,
+      lookbackWindow: deriveRateWindow(step),
+    });
+    const phaseQuery = buildPodPhaseQuery({ namespace, podNames: allPodNames });
 
     const prometheus = createPrometheusClient();
     const sharedAbort = new AbortController();
+    // Wall-clock deadline for the whole bundle. Combined with the per-query
+    // timeout inside fetchJson via AbortSignal.any, so a single slow query is
+    // bounded by min(PROMETHEUS_TIMEOUT_MS, remaining budget).
+    const budgetSignal = AbortSignal.timeout(PROMETHEUS_BUDGET_MS);
+    const combinedSignal = AbortSignal.any([sharedAbort.signal, budgetSignal]);
+    const procedureStart = Date.now();
 
-    let cpuMatrix: PromQLMatrixResponse;
-    let memMatrix: PromQLMatrixResponse;
-    let restartsMatrix: PromQLMatrixResponse;
+    let rangeResults: PromQLMatrixResponse[];
+    let phaseVector: PromQLVectorResponse;
     try {
-      [cpuMatrix, memMatrix, restartsMatrix] = await Promise.all([
-        prometheus.rangeQuery({ query: queries.cpu, start, end, step }, sharedAbort.signal),
-        prometheus.rangeQuery({ query: queries.memory, start, end, step }, sharedAbort.signal),
-        prometheus.rangeQuery({ query: queries.restarts, start, end, step }, sharedAbort.signal),
-      ]);
+      // TODO(M-6): consider Promise.allSettled so partial section failures
+      // surface per section instead of failing the whole bundle.
+      const rangePromises = RANGE_METRIC_KEYS.map((key) =>
+        prometheus.rangeQuery({ query: queries[key], start, end, step }, combinedSignal)
+      );
+      const phasePromise = prometheus.instantQuery({ query: phaseQuery }, combinedSignal);
+      [rangeResults, phaseVector] = await Promise.all([Promise.all(rangePromises), phasePromise]);
     } catch (error) {
       sharedAbort.abort();
       if (error instanceof TRPCError) throw error;
@@ -84,12 +143,45 @@ export const getDeploymentMetricsProcedure = protectedProcedure
         message: `Prometheus upstream failure: ${message}`,
         cause: error,
       });
+    } finally {
+      console.info(
+        `[prometheus.getDeploymentMetrics] range=${range} apps=${applications.length} pods=${allPodNames.length} durationMs=${Date.now() - procedureStart}`
+      );
     }
 
+    const resultByKey = new Map<RangeMetricKey, PromQLMatrixResponse>(
+      RANGE_METRIC_KEYS.map((key, idx) => [key, rangeResults[idx]!])
+    );
+    const seriesFor = (key: RangeMetricKey): MetricSeriesByApp[] =>
+      matrixToSeriesByApp(resultByKey.get(key)!, podToApp, applications);
+
     return {
-      cpu: matrixToSeriesByApp(cpuMatrix, podToApp, applications),
-      memory: matrixToSeriesByApp(memMatrix, podToApp, applications),
-      restarts: matrixToSeriesByApp(restartsMatrix, podToApp, applications),
+      compute: {
+        cpu: seriesFor("cpu"),
+        memory: seriesFor("memory"),
+        memoryRss: seriesFor("memoryRss"),
+        memoryCache: seriesFor("memoryCache"),
+        cpuThrottling: combineRatioSeriesByApp(seriesFor("cpuThrottledPeriods"), seriesFor("cpuPeriods")),
+      },
+      network: {
+        rx: seriesFor("networkRx"),
+        tx: seriesFor("networkTx"),
+      },
+      storage: {
+        readBytes: seriesFor("diskReadBytes"),
+        writeBytes: seriesFor("diskWriteBytes"),
+      },
+      health: {
+        restarts: seriesFor("restarts"),
+        oomEvents: seriesFor("oomEvents"),
+        podPhase: vectorToPodPhaseByApp(phaseVector, podToApp, applications),
+      },
+      quotas: {
+        cpuRequests: seriesFor("cpuRequests"),
+        cpuLimits: seriesFor("cpuLimits"),
+        memoryRequests: seriesFor("memoryRequests"),
+        memoryLimits: seriesFor("memoryLimits"),
+      },
       range,
       queriedAt,
     };

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.test.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { escapeRegex, groupPodsByApp, buildPromQLQueries, matrixToSeriesByApp } from "./utils.js";
+import {
+  escapeRegex,
+  groupPodsByApp,
+  buildPromQLQueries,
+  buildPodPhaseQuery,
+  combineRatioSeriesByApp,
+  deriveRateWindow,
+  matrixToSeriesByApp,
+  vectorToPodPhaseByApp,
+} from "./utils.js";
+
+const DEFAULT_BUILD_PARAMS = { lookbackWindow: "300s" } as const;
 
 describe("escapeRegex", () => {
   it("escapes regex meta-characters", () => {
@@ -39,25 +50,124 @@ describe("groupPodsByApp", () => {
   });
 });
 
-describe("buildPromQLQueries", () => {
-  it("produces three queries with namespace and combined pod regex interpolated", () => {
-    const queries = buildPromQLQueries({
-      namespace: "test-namespace",
-      podNames: ["test-pod-abc123-xyz", "another-pod"],
-    });
-    expect(queries.cpu).toContain('namespace="test-namespace"');
-    expect(queries.cpu).toContain('pod=~"test-pod-abc123-xyz|another-pod"');
-    expect(queries.cpu).toContain("rate(container_cpu_usage_seconds_total");
-    expect(queries.memory).toContain("container_memory_working_set_bytes");
-    expect(queries.restarts).toContain("kube_pod_container_status_restarts_total");
-    expect(queries.restarts).toContain('pod=~"test-pod-abc123-xyz|another-pod"');
+describe("deriveRateWindow", () => {
+  it("clamps to 300s when 4*step is below the floor", () => {
+    expect(deriveRateWindow(15)).toBe("300s"); // 4*15=60
+    expect(deriveRateWindow(75)).toBe("300s"); // 4*75=300
   });
+  it("uses 4*step when above the floor", () => {
+    expect(deriveRateWindow(120)).toBe("480s");
+    expect(deriveRateWindow(300)).toBe("1200s");
+  });
+});
+
+describe("buildPromQLQueries", () => {
+  const queries = buildPromQLQueries({ namespace: "ns", podNames: ["pod-a", "pod-b"], ...DEFAULT_BUILD_PARAMS });
+
+  it.each([
+    [
+      "cpu",
+      'rate(container_cpu_usage_seconds_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
+    ],
+    [
+      "memory",
+      'container_memory_working_set_bytes{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}',
+    ],
+    ["memoryRss", 'container_memory_rss{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}'],
+    ["memoryCache", 'container_memory_cache{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}'],
+    ["restarts", 'increase(kube_pod_container_status_restarts_total{namespace="ns", pod=~"^(pod-a|pod-b)$"}[300s])'],
+    ["networkRx", 'rate(container_network_receive_bytes_total{namespace="ns", pod=~"^(pod-a|pod-b)$"}[300s])'],
+    ["networkTx", 'rate(container_network_transmit_bytes_total{namespace="ns", pod=~"^(pod-a|pod-b)$"}[300s])'],
+    [
+      "diskReadBytes",
+      'rate(container_fs_reads_bytes_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
+    ],
+    [
+      "diskWriteBytes",
+      'rate(container_fs_writes_bytes_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
+    ],
+    ["oomEvents", 'increase(container_oom_events_total{namespace="ns", pod=~"^(pod-a|pod-b)$"}[300s])'],
+    ["cpuRequests", 'kube_pod_container_resource_requests{namespace="ns", pod=~"^(pod-a|pod-b)$", resource="cpu"}'],
+    ["cpuLimits", 'kube_pod_container_resource_limits{namespace="ns", pod=~"^(pod-a|pod-b)$", resource="cpu"}'],
+    [
+      "memoryRequests",
+      'kube_pod_container_resource_requests{namespace="ns", pod=~"^(pod-a|pod-b)$", resource="memory"}',
+    ],
+    ["memoryLimits", 'kube_pod_container_resource_limits{namespace="ns", pod=~"^(pod-a|pod-b)$", resource="memory"}'],
+    [
+      "cpuThrottledPeriods",
+      'rate(container_cpu_cfs_throttled_periods_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
+    ],
+    [
+      "cpuPeriods",
+      'rate(container_cpu_cfs_periods_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
+    ],
+  ])("emits the expected PromQL fragment for %s", (key, fragment) => {
+    expect(queries[key as keyof typeof queries]).toContain(fragment);
+  });
+
   it("escapes regex meta-characters in pod names", () => {
-    const queries = buildPromQLQueries({
+    const q = buildPromQLQueries({
       namespace: "ns",
       podNames: ["good-pod", "weird.pod"],
+      ...DEFAULT_BUILD_PARAMS,
     });
-    expect(queries.cpu).toContain('pod=~"good-pod|weird\\.pod"');
+    expect(q.cpu).toContain('pod=~"^(good-pod|weird\\.pod)$"');
+  });
+
+  it("anchors the pod regex to prevent prefix-match ambiguity", () => {
+    const q = buildPromQLQueries({ namespace: "ns", podNames: ["web"], ...DEFAULT_BUILD_PARAMS });
+    expect(q.cpu).toContain('pod=~"^(web)$"');
+  });
+
+  it("wraps every metric in `sum by (pod) (...)` (regression guard for aggregation)", () => {
+    const all = buildPromQLQueries({ namespace: "ns", podNames: ["pod-a"], ...DEFAULT_BUILD_PARAMS });
+    for (const [key, value] of Object.entries(all)) {
+      expect(value, `query ${key}`).toMatch(/^sum by \(pod\) \(/);
+      expect(value, `query ${key}`).toMatch(/\)$/);
+    }
+  });
+
+  it("scales rate window with the requested step", () => {
+    const fast = buildPromQLQueries({
+      namespace: "ns",
+      podNames: ["p"],
+      lookbackWindow: deriveRateWindow(15),
+    });
+    expect(fast.cpu).toContain("[300s]");
+    const slow = buildPromQLQueries({
+      namespace: "ns",
+      podNames: ["p"],
+      lookbackWindow: deriveRateWindow(300),
+    });
+    expect(slow.cpu).toContain("[1200s]");
+  });
+
+  it("uses increase() with the rate window (bounded trailing interval, not the full range)", () => {
+    // Regression: a previous version evaluated increase() over the full
+    // selected range, so every datapoint counted events from t=start to T.
+    // A single restart then appeared as a rising plateau across the chart.
+    // Using the rate window keeps each datapoint's lookback bounded.
+    const q = buildPromQLQueries({
+      namespace: "ns",
+      podNames: ["p"],
+      lookbackWindow: "1200s",
+    });
+    expect(q.restarts).toContain("increase(");
+    expect(q.restarts).toContain("[1200s]");
+    expect(q.oomEvents).toContain("increase(");
+    expect(q.oomEvents).toContain("[1200s]");
+  });
+});
+
+describe("buildPodPhaseQuery", () => {
+  it("emits the instant-query selector with == 1", () => {
+    const q = buildPodPhaseQuery({ namespace: "ns", podNames: ["pod-a"] });
+    expect(q).toBe('kube_pod_status_phase{namespace="ns", pod=~"^(pod-a)$"} == 1');
+  });
+  it("escapes regex meta-characters in pod names", () => {
+    const q = buildPodPhaseQuery({ namespace: "ns", podNames: ["weird.pod"] });
+    expect(q).toContain('pod=~"^(weird\\.pod)$"');
   });
 });
 
@@ -87,27 +197,21 @@ describe("matrixToSeriesByApp", () => {
               [110, "0.5"],
             ] as Array<[number, string]>,
           },
-          {
-            metric: { pod: "api-1" },
-            values: [[100, "3.0"]] as Array<[number, string]>,
-          },
+          { metric: { pod: "api-1" }, values: [[100, "3.0"]] as Array<[number, string]> },
         ],
       },
     };
     const known = ["frontend", "api", "worker"];
     const result = matrixToSeriesByApp(matrix, podToApp, known);
 
-    const frontend = result.find((r) => r.app === "frontend");
-    expect(frontend?.series).toEqual([
+    expect(result.find((r) => r.app === "frontend")?.series).toEqual([
       { t: 100, v: 1.5 },
       { t: 110, v: 2.5 },
     ]);
-    const api = result.find((r) => r.app === "api");
-    expect(api?.series).toEqual([{ t: 100, v: 3.0 }]);
-    const worker = result.find((r) => r.app === "worker");
-    expect(worker?.series).toEqual([]);
+    expect(result.find((r) => r.app === "api")?.series).toEqual([{ t: 100, v: 3.0 }]);
+    expect(result.find((r) => r.app === "worker")?.series).toEqual([]);
   });
-  it("aggregates partial-timestamp coverage (one pod missing a timestamp)", () => {
+  it("aggregates partial-timestamp coverage", () => {
     const podToApp = new Map<string, string>([
       ["frontend-1", "frontend"],
       ["frontend-2", "frontend"],
@@ -124,10 +228,7 @@ describe("matrixToSeriesByApp", () => {
               [110, "2.0"],
             ] as Array<[number, string]>,
           },
-          {
-            metric: { pod: "frontend-2" },
-            values: [[100, "0.5"]] as Array<[number, string]>,
-          },
+          { metric: { pod: "frontend-2" }, values: [[100, "0.5"]] as Array<[number, string]> },
         ],
       },
     };
@@ -137,6 +238,31 @@ describe("matrixToSeriesByApp", () => {
       { t: 110, v: 2.0 },
     ]);
   });
+  it("drops NaN and empty string values silently", () => {
+    const podToApp = new Map<string, string>([["p1", "app"]]);
+    const matrix = {
+      status: "success" as const,
+      data: {
+        resultType: "matrix" as const,
+        result: [
+          {
+            metric: { pod: "p1" },
+            values: [
+              [100, "NaN"],
+              [110, "1.0"],
+              [120, ""],
+              [130, "2.5"],
+            ] as Array<[number, string]>,
+          },
+        ],
+      },
+    };
+    const result = matrixToSeriesByApp(matrix, podToApp, ["app"]);
+    expect(result[0]?.series).toEqual([
+      { t: 110, v: 1.0 },
+      { t: 130, v: 2.5 },
+    ]);
+  });
   it("preserves the order of `known` apps in the output", () => {
     const result = matrixToSeriesByApp({ status: "success", data: { resultType: "matrix", result: [] } }, new Map(), [
       "b",
@@ -144,5 +270,154 @@ describe("matrixToSeriesByApp", () => {
       "c",
     ]);
     expect(result.map((r) => r.app)).toEqual(["b", "a", "c"]);
+  });
+});
+
+describe("vectorToPodPhaseByApp", () => {
+  it("groups pods by app and uses the phase label", () => {
+    const podToApp = new Map<string, string>([
+      ["frontend-1", "frontend"],
+      ["frontend-2", "frontend"],
+      ["api-1", "api"],
+    ]);
+    const vector = {
+      status: "success" as const,
+      data: {
+        resultType: "vector" as const,
+        result: [
+          { metric: { pod: "frontend-1", phase: "Running" }, value: [100, "1"] as [number, string] },
+          { metric: { pod: "frontend-2", phase: "Pending" }, value: [100, "1"] as [number, string] },
+          { metric: { pod: "api-1", phase: "Running" }, value: [100, "1"] as [number, string] },
+        ],
+      },
+    };
+    const result = vectorToPodPhaseByApp(vector, podToApp, ["frontend", "api", "worker"]);
+    expect(result.find((r) => r.app === "frontend")?.pods).toEqual([
+      { name: "frontend-1", phase: "Running" },
+      { name: "frontend-2", phase: "Pending" },
+    ]);
+    expect(result.find((r) => r.app === "api")?.pods).toEqual([{ name: "api-1", phase: "Running" }]);
+    expect(result.find((r) => r.app === "worker")?.pods).toEqual([]);
+  });
+  it("falls back to Unknown when the phase label is missing or unrecognised", () => {
+    const podToApp = new Map<string, string>([["p1", "app"]]);
+    const vector = {
+      status: "success" as const,
+      data: {
+        resultType: "vector" as const,
+        result: [{ metric: { pod: "p1", phase: "Weird" }, value: [100, "1"] as [number, string] }],
+      },
+    };
+    const result = vectorToPodPhaseByApp(vector, podToApp, ["app"]);
+    expect(result[0]?.pods).toEqual([{ name: "p1", phase: "Unknown" }]);
+  });
+  it("ignores pods not present in podToApp", () => {
+    const result = vectorToPodPhaseByApp(
+      {
+        status: "success",
+        data: {
+          resultType: "vector",
+          result: [{ metric: { pod: "stranger", phase: "Running" }, value: [100, "1"] }],
+        },
+      },
+      new Map(),
+      ["app"]
+    );
+    expect(result[0]?.pods).toEqual([]);
+  });
+
+  it("preserves the order of `knownApps` in the output", () => {
+    const result = vectorToPodPhaseByApp({ status: "success", data: { resultType: "vector", result: [] } }, new Map(), [
+      "b",
+      "a",
+      "c",
+    ]);
+    expect(result.map((r) => r.app)).toEqual(["b", "a", "c"]);
+  });
+});
+
+describe("combineRatioSeriesByApp", () => {
+  const series = (app: string, points: Array<[number, number]>) => ({
+    app,
+    series: points.map(([t, v]) => ({ t, v })),
+  });
+
+  it("emits 100 * num/den at every timestamp where both have a finite, positive denominator", () => {
+    const num = [series("a", [[100, 2]]), series("b", [[100, 1]])];
+    const den = [series("a", [[100, 10]]), series("b", [[100, 4]])];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result.find((r) => r.app === "a")?.series).toEqual([{ t: 100, v: 20 }]);
+    expect(result.find((r) => r.app === "b")?.series).toEqual([{ t: 100, v: 25 }]);
+  });
+
+  it("drops timestamps where the denominator is zero or negative (avoids div-by-zero / nonsense ratios)", () => {
+    const num = [
+      series("a", [
+        [100, 1],
+        [110, 2],
+        [120, 3],
+      ]),
+    ];
+    const den = [
+      series("a", [
+        [100, 0],
+        [110, 5],
+        [120, -1],
+      ]),
+    ];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result[0]?.series).toEqual([{ t: 110, v: 40 }]);
+  });
+
+  it("returns an empty series when the denominator series for an app is empty", () => {
+    const num = [series("a", [[100, 1]])];
+    const den = [{ app: "a", series: [] }];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result[0]?.series).toEqual([]);
+  });
+
+  it("drops numerator timestamps that have no matching denominator timestamp", () => {
+    const num = [
+      series("a", [
+        [100, 1],
+        [110, 2],
+      ]),
+    ];
+    const den = [series("a", [[110, 5]])];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result[0]?.series).toEqual([{ t: 110, v: 40 }]);
+  });
+
+  it("returns an empty series when an app is missing from the denominator entirely", () => {
+    const num = [series("a", [[100, 1]]), series("b", [[100, 2]])];
+    const den = [series("a", [[100, 4]])];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result.find((r) => r.app === "b")?.series).toEqual([]);
+  });
+
+  it("drops points with non-finite numerator or denominator values", () => {
+    const num = [
+      series("a", [
+        [100, NaN],
+        [110, Infinity],
+        [120, 3],
+      ]),
+    ];
+    const den = [
+      series("a", [
+        [100, 2],
+        [110, 4],
+        [120, 6],
+      ]),
+    ];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result[0]?.series).toEqual([{ t: 120, v: 50 }]);
+  });
+
+  it("preserves the order of `numerator`'s apps in the output", () => {
+    const num = [series("c", [[100, 1]]), series("a", [[100, 1]]), series("b", [[100, 1]])];
+    const den = [series("a", [[100, 2]]), series("b", [[100, 2]]), series("c", [[100, 2]])];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result.map((r) => r.app)).toEqual(["c", "a", "b"]);
   });
 });

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.ts
@@ -1,6 +1,21 @@
-import type { PromQLMatrixResponse, MetricSeriesByApp } from "@my-project/shared";
+import {
+  podLabels,
+  podPhaseSchema,
+  type PromQLMatrixResponse,
+  type PromQLVectorResponse,
+  type MetricSeriesByApp,
+  type PodPhaseByApp,
+  type PodPhase,
+} from "@my-project/shared";
 
-export const APP_INSTANCE_LABEL = "app.kubernetes.io/instance";
+/**
+ * Rate window scaled to the resolution step. Prometheus recommends a window of
+ * at least 4× the scrape/step interval; we floor at 5m so short ranges still
+ * have enough samples for a smooth rate.
+ */
+export function deriveRateWindow(stepSeconds: number): string {
+  return `${Math.max(4 * stepSeconds, 300)}s`;
+}
 
 export function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -19,7 +34,7 @@ export function groupPodsByApp(pods: PodLike[], apps: string[]): Map<string, str
   const result = new Map<string, string[]>();
   for (const app of apps) result.set(app, []);
   for (const pod of pods) {
-    const label = pod.metadata.labels?.[APP_INSTANCE_LABEL];
+    const label = pod.metadata.labels?.[podLabels.instance];
     if (label && wanted.has(label)) {
       result.get(label)!.push(pod.metadata.name);
     }
@@ -32,29 +47,85 @@ interface BuildQueriesParams {
   podNames: string[];
 }
 
+interface BuildRangeQueriesParams extends BuildQueriesParams {
+  /**
+   * Range-vector window for both `rate()` and `increase()` queries, e.g.
+   * "300s". Derive from `deriveRateWindow(step)`. Restart/OOM `increase()`
+   * uses the same window so each datapoint reflects events in a bounded
+   * trailing interval rather than the full selected range (which would
+   * produce a rising plateau across the whole chart).
+   */
+  lookbackWindow: string;
+}
+
+export const RANGE_METRIC_KEYS = [
+  "cpu",
+  "memory",
+  "memoryRss",
+  "memoryCache",
+  "restarts",
+  "networkRx",
+  "networkTx",
+  "diskReadBytes",
+  "diskWriteBytes",
+  "oomEvents",
+  "cpuRequests",
+  "cpuLimits",
+  "memoryRequests",
+  "memoryLimits",
+  "cpuThrottledPeriods",
+  "cpuPeriods",
+] as const;
+
+export type RangeMetricKey = (typeof RANGE_METRIC_KEYS)[number];
+
+function buildPodRegex(podNames: string[]): string {
+  return `^(${podNames.map(escapeRegex).join("|")})$`;
+}
+
 /**
- * Build the three PromQL queries used by the dashboard. Only `namespace` and
- * `podNames` are interpolated; everything else is fixed text. `namespace` is
- * already validated by Zod (RFC-1123). `podNames` are regex-escaped here.
+ * Build every range-query PromQL string the dashboard needs. Only `namespace`
+ * and `podNames` are interpolated; everything else is fixed text. `namespace`
+ * is already validated by Zod (RFC-1123). `podNames` are regex-escaped and
+ * anchored here.
  *
- * Precondition: callers must not pass an empty `podNames` array. With no pod
- * names, the resulting `pod=~""` selector matches nothing, which produces a
- * structurally-valid but semantically-degenerate query. The procedure handler
- * short-circuits before calling this util when zero pods match.
+ * Precondition: callers must not pass an empty `podNames` array (the resulting
+ * `pod=~""` selector matches nothing). The procedure handler short-circuits
+ * before calling this util when zero pods match.
  */
-export function buildPromQLQueries({ namespace, podNames }: BuildQueriesParams): {
-  cpu: string;
-  memory: string;
-  restarts: string;
-} {
-  const podRegex = podNames.map(escapeRegex).join("|");
-  const baseSelector = `namespace="${namespace}", pod=~"${podRegex}"`;
-  const containerSelector = `${baseSelector}, container!="", container!="POD"`;
+export function buildPromQLQueries({
+  namespace,
+  podNames,
+  lookbackWindow,
+}: BuildRangeQueriesParams): Record<RangeMetricKey, string> {
+  const podRegex = buildPodRegex(podNames);
+  const base = `namespace="${namespace}", pod=~"${podRegex}"`;
+  const sel = `${base}, container!="", container!="POD"`;
+
   return {
-    cpu: `sum by (pod) (rate(container_cpu_usage_seconds_total{${containerSelector}}[5m]))`,
-    memory: `sum by (pod) (container_memory_working_set_bytes{${containerSelector}})`,
-    restarts: `sum by (pod) (kube_pod_container_status_restarts_total{${baseSelector}})`,
+    cpu: `sum by (pod) (rate(container_cpu_usage_seconds_total{${sel}}[${lookbackWindow}]))`,
+    memory: `sum by (pod) (container_memory_working_set_bytes{${sel}})`,
+    memoryRss: `sum by (pod) (container_memory_rss{${sel}})`,
+    memoryCache: `sum by (pod) (container_memory_cache{${sel}})`,
+    restarts: `sum by (pod) (increase(kube_pod_container_status_restarts_total{${base}}[${lookbackWindow}]))`,
+    networkRx: `sum by (pod) (rate(container_network_receive_bytes_total{${base}}[${lookbackWindow}]))`,
+    networkTx: `sum by (pod) (rate(container_network_transmit_bytes_total{${base}}[${lookbackWindow}]))`,
+    diskReadBytes: `sum by (pod) (rate(container_fs_reads_bytes_total{${sel}}[${lookbackWindow}]))`,
+    diskWriteBytes: `sum by (pod) (rate(container_fs_writes_bytes_total{${sel}}[${lookbackWindow}]))`,
+    oomEvents: `sum by (pod) (increase(container_oom_events_total{${base}}[${lookbackWindow}]))`,
+    cpuRequests: `sum by (pod) (kube_pod_container_resource_requests{${base}, resource="cpu"})`,
+    cpuLimits: `sum by (pod) (kube_pod_container_resource_limits{${base}, resource="cpu"})`,
+    memoryRequests: `sum by (pod) (kube_pod_container_resource_requests{${base}, resource="memory"})`,
+    memoryLimits: `sum by (pod) (kube_pod_container_resource_limits{${base}, resource="memory"})`,
+    cpuThrottledPeriods: `sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{${sel}}[${lookbackWindow}]))`,
+    cpuPeriods: `sum by (pod) (rate(container_cpu_cfs_periods_total{${sel}}[${lookbackWindow}]))`,
   };
+}
+
+/** Build the single instant-query string for current pod phase. */
+export function buildPodPhaseQuery({ namespace, podNames }: BuildQueriesParams): string {
+  const podRegex = buildPodRegex(podNames);
+  return `kube_pod_status_phase{namespace="${namespace}", pod=~"${podRegex}"} == 1`;
 }
 
 /**
@@ -79,8 +150,9 @@ export function matrixToSeriesByApp(
     const bucket = perApp.get(app);
     if (!bucket) continue;
     for (const [ts, value] of row.values) {
+      if (value === "") continue;
       const numeric = Number(value);
-      if (Number.isNaN(numeric)) continue;
+      if (!Number.isFinite(numeric)) continue;
       bucket.set(ts, (bucket.get(ts) ?? 0) + numeric);
     }
   }
@@ -93,4 +165,75 @@ export function matrixToSeriesByApp(
       series: sortedTs.map((t) => ({ t, v: bucket.get(t)! })),
     };
   });
+}
+
+const KNOWN_PHASES: ReadonlySet<PodPhase> = new Set(podPhaseSchema.options);
+
+function coercePhase(value: string | undefined): PodPhase {
+  return value && KNOWN_PHASES.has(value as PodPhase) ? (value as PodPhase) : "Unknown";
+}
+
+/**
+ * Convert a `kube_pod_status_phase{...} == 1` vector into per-app pod-phase
+ * lists. Each series has labels `pod` and `phase`; we group by app via the
+ * shared podToApp map. Pods present in podToApp but missing from the vector
+ * are not added (Prometheus only emits the matching phase).
+ */
+/**
+ * Combine two per-app series into a per-app ratio series, expressed as a
+ * percentage (`100 * num / den`). Designed for "saturation"-style metrics like
+ * CPU throttling where summing the underlying counters then dividing is the
+ * mathematically correct rollup (you cannot meaningfully average ratios).
+ *
+ * Output preserves `numerator`'s app order. For each app, the result series
+ * contains a point only at timestamps where both numerator and denominator
+ * have a finite value AND the denominator is strictly positive. Apps absent
+ * from the denominator emit an empty series — mirrors the "no capacity
+ * configured → no data" semantic used by the client-side `computeUtilization`
+ * helper for stat panels.
+ */
+export function combineRatioSeriesByApp(
+  numerator: MetricSeriesByApp[],
+  denominator: MetricSeriesByApp[]
+): MetricSeriesByApp[] {
+  const denByApp = new Map<string, Map<number, number>>();
+  for (const entry of denominator) {
+    const points = new Map<number, number>();
+    for (const point of entry.series) points.set(point.t, point.v);
+    denByApp.set(entry.app, points);
+  }
+
+  return numerator.map(({ app, series }) => {
+    const denPoints = denByApp.get(app);
+    if (!denPoints || denPoints.size === 0) return { app, series: [] };
+    const points: { t: number; v: number }[] = [];
+    for (const { t, v } of series) {
+      const den = denPoints.get(t);
+      if (den === undefined) continue;
+      if (!Number.isFinite(v) || !Number.isFinite(den) || den <= 0) continue;
+      points.push({ t, v: (100 * v) / den });
+    }
+    return { app, series: points };
+  });
+}
+
+export function vectorToPodPhaseByApp(
+  vector: PromQLVectorResponse,
+  podToApp: Map<string, string>,
+  knownApps: string[]
+): PodPhaseByApp[] {
+  const perApp = new Map<string, { name: string; phase: PodPhase }[]>();
+  for (const app of knownApps) perApp.set(app, []);
+
+  for (const row of vector.data.result) {
+    const podName = row.metric.pod;
+    if (!podName) continue;
+    const app = podToApp.get(podName);
+    if (!app) continue;
+    const bucket = perApp.get(app);
+    if (!bucket) continue;
+    bucket.push({ name: podName, phase: coercePhase(row.metric.phase) });
+  }
+
+  return knownApps.map((app) => ({ app, pods: perApp.get(app)! }));
 }


### PR DESCRIPTION
Replace the three-panel CPU / Memory / Restarts dashboard with a section-grouped Compute / Network / Storage / Health / Quotas layout, add a global Application multi-select with click-to-isolate legend behaviour, sync the cursor across every panel, persist toolbar state in URL search params, and bring chart typography into line with the portal's Card chrome.

