### PR TITLE
EPMDEDP-16746: feat: Per-pod, history-aware Stage Monitoring

### DIFF
--- a/apps/client/src/core/utils/sortByName/index.ts
+++ b/apps/client/src/core/utils/sortByName/index.ts
@@ -1,15 +1,1 @@
-export const sortByName = (a?: string, b?: string): number => {
-  if (a && b) {
-    return a.localeCompare(b, undefined, { sensitivity: "accent" });
-  }
-
-  if (a && !b) {
-    return -1;
-  }
-
-  if (!a && b) {
-    return 1;
-  }
-
-  return 0;
-};
+export { sortByName } from "@my-project/shared";

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/Monitoring.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/Monitoring.stories.tsx
@@ -25,7 +25,21 @@ const series = (offset: number, scale: number) =>
 const apps = ["frontend", "api", "worker"];
 
 function buildSeries(scale: number) {
-  return apps.map((app, i) => ({ app, series: series(i, scale * (i + 1)) }));
+  return apps.map((app, i) => ({
+    app,
+    pods: [{ pod: `${app}-1`, series: series(i, scale * (i + 1)) }],
+  }));
+}
+
+function emptyForEachApp() {
+  return apps.map((app) => ({ app, pods: [] }));
+}
+
+function zeroSeries(base: ReturnType<typeof buildSeries>) {
+  return base.map((entry) => ({
+    app: entry.app,
+    pods: entry.pods.map((p) => ({ pod: p.pod, series: p.series.map((point) => ({ ...point, v: 0 })) })),
+  }));
 }
 
 const podPhase = [
@@ -41,13 +55,18 @@ function FullTab({ selected, emptyQuotas = false }: { selected: string[] | null;
   const set = React.useMemo(() => new Set(selectedApps ?? apps), [selectedApps]);
   const cpuUsage = buildSeries(0.3);
   const memUsage = buildSeries(64 * 1024 * 1024);
-  const cpuRequests = emptyQuotas ? apps.map((app) => ({ app, series: [] })) : buildSeries(0.5);
-  const cpuLimits = emptyQuotas ? apps.map((app) => ({ app, series: [] })) : buildSeries(1);
-  const memRequests = emptyQuotas ? apps.map((app) => ({ app, series: [] })) : buildSeries(128 * 1024 * 1024);
-  const memLimits = emptyQuotas ? apps.map((app) => ({ app, series: [] })) : buildSeries(256 * 1024 * 1024);
+  const cpuRequests = emptyQuotas ? emptyForEachApp() : buildSeries(0.5);
+  const cpuLimits = emptyQuotas ? emptyForEachApp() : buildSeries(1);
+  const memRequests = emptyQuotas ? emptyForEachApp() : buildSeries(128 * 1024 * 1024);
+  const memLimits = emptyQuotas ? emptyForEachApp() : buildSeries(256 * 1024 * 1024);
   const cpuThrottling = apps.map((app, i) => ({
     app,
-    series: series(i * 2, 5 + i * 12).map((p) => ({ ...p, v: Math.max(0, p.v) })),
+    pods: [
+      {
+        pod: `${app}-1`,
+        series: series(i * 2, 5 + i * 12).map((p) => ({ ...p, v: Math.max(0, p.v) })),
+      },
+    ],
   }));
   return (
     <MetricsCursorProvider>
@@ -140,7 +159,7 @@ function FullTab({ selected, emptyQuotas = false }: { selected: string[] | null;
           <MetricChart
             title="Container restarts"
             unit="count"
-            data={buildSeries(0).map((s) => ({ ...s, series: s.series.map((p) => ({ ...p, v: 0 })) }))}
+            data={zeroSeries(buildSeries(0))}
             isLoading={false}
             error={null}
             selectedApps={set}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/MetricChart.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/MetricChart.stories.tsx
@@ -11,33 +11,55 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const now = Math.floor(Date.now() / 1000);
-const sampleSeries = (offset: number, scale: number) =>
+const samplePoints = (offset: number, scale: number) =>
   Array.from({ length: 30 }, (_, i) => ({
     t: now - (29 - i) * 60,
     v: scale * (1 + Math.sin(i / 4 + offset) * 0.4),
   }));
 
-const sampleData = [
-  { app: "frontend", series: sampleSeries(0, 0.4) },
-  { app: "api", series: sampleSeries(1, 0.2) },
-  { app: "worker", series: sampleSeries(2, 0.3) },
+const sampleApp = (app: string, pods: Array<{ pod: string; offset: number; scale: number }>) => ({
+  app,
+  pods: pods.map(({ pod, offset, scale }) => ({ pod, series: samplePoints(offset, scale) })),
+});
+
+const singlePodApp = sampleApp("frontend", [{ pod: "frontend-5b799844b-7qr6x", offset: 0, scale: 0.5 }]);
+
+const multiPodSingleApp = sampleApp("frontend", [
+  { pod: "frontend-5b799844b-7qr6x", offset: 0, scale: 0.5 },
+  { pod: "frontend-75b7875569-nf9cp", offset: 1.2, scale: 0.3 },
+]);
+
+const multiAppData = [
+  sampleApp("frontend", [{ pod: "frontend-1", offset: 0, scale: 0.4 }]),
+  sampleApp("api", [{ pod: "api-1", offset: 1, scale: 0.2 }]),
+  sampleApp("worker", [{ pod: "worker-1", offset: 2, scale: 0.3 }]),
 ];
 
-export const WithDataSingleApp: Story = {
+export const SinglePod: Story = {
   args: {
     title: "CPU usage",
     unit: "cores",
-    data: [{ app: "frontend", series: sampleSeries(0, 0.5) }],
+    data: [singlePodApp],
     isLoading: false,
     error: null,
   },
 };
 
-export const WithDataMultiApp: Story = {
+export const MultiPodSingleApp: Story = {
+  args: {
+    title: "CPU usage (rolling deployment)",
+    unit: "cores",
+    data: [multiPodSingleApp],
+    isLoading: false,
+    error: null,
+  },
+};
+
+export const MultiApp: Story = {
   args: {
     title: "CPU usage",
     unit: "cores",
-    data: sampleData,
+    data: multiAppData,
     isLoading: false,
     error: null,
   },
@@ -48,8 +70,8 @@ export const BytesPerSecond: Story = {
     title: "Network receive",
     unit: "bytes/s",
     data: [
-      { app: "frontend", series: sampleSeries(0, 1024 * 1024 * 1.5) },
-      { app: "worker", series: sampleSeries(1, 1024 * 512) },
+      sampleApp("frontend", [{ pod: "frontend-1", offset: 0, scale: 1024 * 1024 * 1.5 }]),
+      sampleApp("worker", [{ pod: "worker-1", offset: 1, scale: 1024 * 512 }]),
     ],
     isLoading: false,
     error: null,
@@ -60,7 +82,7 @@ export const SelectedAppsFilter: Story = {
   args: {
     title: "CPU usage (only frontend)",
     unit: "cores",
-    data: sampleData,
+    data: multiAppData,
     isLoading: false,
     error: null,
     selectedApps: new Set(["frontend"]),

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/MetricChart/index.tsx
@@ -17,21 +17,38 @@ import { CHART_PALETTE, CHART_TEXT } from "../../constants";
 import { useMetricsCursor } from "../../hooks/useMetricsCursor";
 import { chartSlug, formatChartTimestamp, formatValue } from "../../utils";
 
-function toRechartsRows(data: MetricChartProps["data"]): {
+type FlattenedSeries = {
+  key: string; // pod name (chart line dataKey + legend label)
+  app: string;
+  points: Array<{ t: number; v: number }>;
+};
+
+function flatten(data: MetricChartProps["data"], selectedApps?: ReadonlySet<string>): FlattenedSeries[] {
+  const out: FlattenedSeries[] = [];
+  for (const entry of data) {
+    if (selectedApps && !selectedApps.has(entry.app)) continue;
+    for (const pod of entry.pods) {
+      out.push({ key: pod.pod, app: entry.app, points: pod.series });
+    }
+  }
+  return out;
+}
+
+function toRechartsRows(flat: FlattenedSeries[]): {
   entries: Array<Record<string, number>>;
   keys: string[];
 } {
   const allTs = new Set<number>();
-  for (const s of data) for (const p of s.series) allTs.add(p.t);
+  for (const s of flat) for (const p of s.points) allTs.add(p.t);
   const sortedTs = [...allTs].sort((a, b) => a - b);
   const rowMap = new Map<number, Record<string, number>>();
   for (const t of sortedTs) rowMap.set(t, { t });
-  for (const s of data) {
-    for (const p of s.series) {
-      rowMap.get(p.t)![s.app] = p.v;
+  for (const s of flat) {
+    for (const p of s.points) {
+      rowMap.get(p.t)![s.key] = p.v;
     }
   }
-  return { entries: [...rowMap.values()], keys: data.map((s) => s.app) };
+  return { entries: [...rowMap.values()], keys: flat.map((s) => s.key) };
 }
 
 export const MetricChart = React.memo(function MetricChart({
@@ -41,17 +58,36 @@ export const MetricChart = React.memo(function MetricChart({
   isLoading,
   error,
   selectedApps,
-  onLegendClick,
   step,
+  domain,
 }: MetricChartProps) {
   const { cursorTs, setCursorTs } = useMetricsCursor();
 
-  const filtered = React.useMemo(
-    () => (selectedApps ? data.filter((s) => selectedApps.has(s.app)) : data),
-    [data, selectedApps]
+  const flat = React.useMemo(() => flatten(data, selectedApps), [data, selectedApps]);
+
+  // Stable identity for the current pod set; reset chart-local visibility
+  // whenever the underlying pod set changes (e.g. app filter changed) so a
+  // previously hidden pod doesn't ghost-suppress a newly arrived pod that
+  // happens to share its name.
+  const podKey = React.useMemo(
+    () =>
+      flat
+        .map((s) => s.key)
+        .sort()
+        .join("|"),
+    [flat]
+  );
+  const [hiddenPods, setHiddenPods] = React.useState<ReadonlySet<string>>(() => new Set());
+  React.useEffect(() => {
+    setHiddenPods(new Set());
+  }, [podKey]);
+
+  const visible = React.useMemo(
+    () => (hiddenPods.size === 0 ? flat : flat.filter((s) => !hiddenPods.has(s.key))),
+    [flat, hiddenPods]
   );
 
-  const { entries, keys } = React.useMemo(() => toRechartsRows(filtered), [filtered]);
+  const { entries, keys } = React.useMemo(() => toRechartsRows(visible), [visible]);
   const isEmpty = !isLoading && !error && entries.length === 0;
 
   const rafRef = React.useRef<number | null>(null);
@@ -80,15 +116,40 @@ export const MetricChart = React.memo(function MetricChart({
     []
   );
 
+  // Colour assignment is computed across ALL pods (regardless of current
+  // visibility) so colours stay stable when a pod is hidden via the legend.
+  const podColorMap = React.useMemo(() => {
+    const map = new Map<string, string>();
+    flat.forEach((s, idx) => {
+      map.set(s.key, CHART_PALETTE[idx % CHART_PALETTE.length]);
+    });
+    return map;
+  }, [flat]);
+
   const handleLegendClick = React.useCallback(
     (payload: { value?: string; dataKey?: string }, _index: number, event?: React.MouseEvent) => {
-      if (!onLegendClick) return;
-      const app = payload.value ?? payload.dataKey;
-      if (!app || typeof app !== "string") return;
-      const toggle = !!event && (event.shiftKey || event.metaKey || event.ctrlKey);
-      onLegendClick(app, { toggle });
+      const pod = payload.value ?? payload.dataKey;
+      if (!pod || typeof pod !== "string") return;
+      const isolate = !!event && (event.shiftKey || event.metaKey || event.ctrlKey);
+      setHiddenPods((prev) => {
+        if (isolate) {
+          const podKeys = flat.map((s) => s.key);
+          // Nothing to isolate when only one pod exists — leave state
+          // unchanged so the click is a documented no-op rather than
+          // creating a phantom new Set instance that thrashes referential
+          // equality downstream.
+          if (podKeys.length <= 1) return prev;
+          const onlyThisIsVisible = prev.size === podKeys.length - 1 && !prev.has(pod);
+          if (onlyThisIsVisible) return new Set(); // already isolated → unisolate
+          return new Set(podKeys.filter((p) => p !== pod));
+        }
+        const next = new Set(prev);
+        if (next.has(pod)) next.delete(pod);
+        else next.add(pod);
+        return next;
+      });
     },
-    [onLegendClick]
+    [flat]
   );
 
   return (
@@ -123,7 +184,8 @@ export const MetricChart = React.memo(function MetricChart({
                 axisLine={CHART_TEXT.axisLine}
                 tickLine={CHART_TEXT.axisLine}
                 type="number"
-                domain={["dataMin", "dataMax"]}
+                domain={domain ?? ["dataMin", "dataMax"]}
+                allowDataOverflow={domain !== undefined}
                 scale="time"
               />
               <YAxis
@@ -142,29 +204,26 @@ export const MetricChart = React.memo(function MetricChart({
                 labelFormatter={(t: number) => formatChartTimestamp(t)}
                 formatter={(value, name) => {
                   const v = typeof value === "number" ? value : Number(value);
-                  const app = typeof name === "string" ? name : String(name ?? "");
-                  return [Number.isFinite(v) ? formatValue(unit, v) : "", app];
+                  const pod = typeof name === "string" ? name : String(name ?? "");
+                  return [Number.isFinite(v) ? formatValue(unit, v) : "", pod];
                 }}
               />
               <Legend
                 wrapperStyle={CHART_TEXT.legendWrapper}
-                onClick={
-                  onLegendClick
-                    ? (payload, index, event) =>
-                        handleLegendClick(
-                          payload as { value?: string; dataKey?: string },
-                          index,
-                          event as React.MouseEvent | undefined
-                        )
-                    : undefined
+                onClick={(payload, index, event) =>
+                  handleLegendClick(
+                    payload as { value?: string; dataKey?: string },
+                    index,
+                    event as React.MouseEvent | undefined
+                  )
                 }
               />
-              {keys.map((app, i) => (
+              {keys.map((pod) => (
                 <Line
-                  key={app}
+                  key={pod}
                   type="monotone"
-                  dataKey={app}
-                  stroke={CHART_PALETTE[i % CHART_PALETTE.length]}
+                  dataKey={pod}
+                  stroke={podColorMap.get(pod) ?? CHART_PALETTE[0]}
                   dot={false}
                   isAnimationActive={false}
                 />

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useDeploymentMetrics.test.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useDeploymentMetrics.test.tsx
@@ -15,8 +15,17 @@ vi.mock("@/core/providers/trpc", () => ({
   }),
 }));
 
+// At least one populated app entry exercises the per-pod nesting so a
+// future regression that flattens the shape back to `{ app, series }` is
+// caught by hook-level tests, not only by the trpc-level Zod validator.
 const okResponse: DeploymentMetricsOutput = {
-  compute: { cpu: [], memory: [], memoryRss: [], memoryCache: [], cpuThrottling: [] },
+  compute: {
+    cpu: [{ app: "test-app", pods: [{ pod: "test-app-abc", series: [{ t: 1700000000, v: 0.5 }] }] }],
+    memory: [],
+    memoryRss: [],
+    memoryCache: [],
+    cpuThrottling: [],
+  },
   network: { rx: [], tx: [] },
   storage: { readBytes: [], writeBytes: [] },
   health: { restarts: [], oomEvents: [], podPhase: [] },

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMonitoringSearch.test.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMonitoringSearch.test.tsx
@@ -70,12 +70,10 @@ describe("useMonitoringSearch", () => {
     expect(lastNavigateSearch()).toMatchObject({ autoRefresh: false });
   });
 
-  it("setApps and isolateApp do not use replace:true", () => {
+  it("setApps does not use replace:true", () => {
     mockUseSearch.mockReturnValue({ apps: "a,b" });
     const { result } = renderHook(() => useMonitoringSearch());
     act(() => result.current.setApps(["a"]));
-    expect(lastNavigateCall().replace).toBe(false);
-    act(() => result.current.isolateApp("b"));
     expect(lastNavigateCall().replace).toBe(false);
   });
 
@@ -109,40 +107,5 @@ describe("useMonitoringSearch", () => {
     const { result } = renderHook(() => useMonitoringSearch());
     act(() => result.current.setApps(["a", "b"]));
     expect(lastNavigateSearch()).toMatchObject({ apps: "a,b" });
-  });
-
-  it("toggleApp adds when not present", () => {
-    mockUseSearch.mockReturnValue({ apps: "a" });
-    const { result } = renderHook(() => useMonitoringSearch());
-    act(() => result.current.toggleApp("b"));
-    expect(lastNavigateSearch()).toMatchObject({ apps: "a,b" });
-  });
-
-  it("toggleApp removes when present", () => {
-    mockUseSearch.mockReturnValue({ apps: "a,b" });
-    const { result } = renderHook(() => useMonitoringSearch());
-    act(() => result.current.toggleApp("a"));
-    expect(lastNavigateSearch()).toMatchObject({ apps: "b" });
-  });
-
-  it("toggleApp on the last selected app resets to all (apps undefined)", () => {
-    mockUseSearch.mockReturnValue({ apps: "a" });
-    const { result } = renderHook(() => useMonitoringSearch());
-    act(() => result.current.toggleApp("a"));
-    expect(lastNavigateSearch()).toMatchObject({ apps: undefined });
-  });
-
-  it("isolateApp sets apps to just that app", () => {
-    mockUseSearch.mockReturnValue({ apps: "a,b,c" });
-    const { result } = renderHook(() => useMonitoringSearch());
-    act(() => result.current.isolateApp("b"));
-    expect(lastNavigateSearch()).toMatchObject({ apps: "b" });
-  });
-
-  it("isolateApp on the already-isolated app resets to all", () => {
-    mockUseSearch.mockReturnValue({ apps: "b" });
-    const { result } = renderHook(() => useMonitoringSearch());
-    act(() => result.current.isolateApp("b"));
-    expect(lastNavigateSearch()).toMatchObject({ apps: undefined });
   });
 });

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMonitoringSearch.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/hooks/useMonitoringSearch.ts
@@ -13,8 +13,6 @@ interface UseMonitoringSearchResult {
   clearApps: () => void;
   setRange: (next: MetricRange) => void;
   setAutoRefresh: (next: boolean) => void;
-  toggleApp: (app: string) => void;
-  isolateApp: (app: string) => void;
 }
 
 type SearchPatch = Partial<{ apps: string | undefined; range: MetricRange; autoRefresh: boolean }>;
@@ -58,22 +56,5 @@ export function useMonitoringSearch(): UseMonitoringSearchResult {
   const setRange = React.useCallback((next: MetricRange) => update({ range: next }), [update]);
   const setAutoRefresh = React.useCallback((next: boolean) => update({ autoRefresh: next }, true), [update]);
 
-  const toggleApp = React.useCallback(
-    (app: string) => {
-      const current = apps ?? [];
-      const next = current.includes(app) ? current.filter((a) => a !== app) : [...current, app];
-      update({ apps: serializeApps(next) });
-    },
-    [apps, update]
-  );
-
-  const isolateApp = React.useCallback(
-    (app: string) => {
-      const alreadyIsolated = apps?.length === 1 && apps[0] === app;
-      update({ apps: alreadyIsolated ? undefined : serializeApps([app]) });
-    },
-    [apps, update]
-  );
-
-  return { apps, range, autoRefresh, setApps, clearApps, setRange, setAutoRefresh, toggleApp, isolateApp };
+  return { apps, range, autoRefresh, setApps, clearApps, setRange, setAutoRefresh };
 }

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/index.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { inClusterName, STEP_BY_RANGE, type DeploymentMetricsOutput, type MetricSeriesByApp } from "@my-project/shared";
+import {
+  inClusterName,
+  PROMETHEUS_TIME_RANGES,
+  STEP_BY_RANGE,
+  type DeploymentMetricsOutput,
+  type MetricSeriesByApp,
+} from "@my-project/shared";
 import { Card } from "@/core/components/ui/card";
 import { useStageWatch, usePipelineAppCodebasesWatch } from "@/modules/platform/cdpipelines/pages/stage-details/hooks";
 import { routeStageDetails } from "@/modules/platform/cdpipelines/pages/stage-details/route";
@@ -74,17 +80,7 @@ export function Monitoring() {
   const stageWatch = useStageWatch();
   const stage = stageWatch.query.data;
   const appCodebasesWatch = usePipelineAppCodebasesWatch();
-  const {
-    apps: filterApps,
-    range,
-    autoRefresh,
-    setRange,
-    setAutoRefresh,
-    setApps,
-    clearApps,
-    toggleApp,
-    isolateApp,
-  } = useMonitoringSearch();
+  const { apps: filterApps, range, autoRefresh, setRange, setAutoRefresh, setApps, clearApps } = useMonitoringSearch();
 
   const isRemoteCluster = stage !== undefined && stage.spec.clusterName !== inClusterName;
 
@@ -112,14 +108,6 @@ export function Monitoring() {
     autoRefresh,
     enabled: !!namespace && !isRemoteCluster && !appCodebasesWatch.isLoading && resolvedApps.length > 0,
   });
-
-  const onLegendClick = React.useCallback(
-    (app: string, modifiers: { toggle: boolean }) => {
-      if (modifiers.toggle) toggleApp(app);
-      else isolateApp(app);
-    },
-    [toggleApp, isolateApp]
-  );
 
   // Memoised so MetricChart's React.memo isn't defeated by a fresh Error
   // reference on every render.
@@ -169,6 +157,14 @@ export function Monitoring() {
   }
 
   const step = STEP_BY_RANGE[range];
+  // Pin the X axis to the time window the server actually queried
+  // (`data.range` echoes the request). Otherwise Recharts auto-fits to
+  // `dataMin..dataMax`, which collapses a "Last 24 hours" selection down to
+  // however much history the pod actually has — making the range filter
+  // appear ignored in the UI.
+  const domain: [number, number] | undefined = data
+    ? [data.queriedAt - PROMETHEUS_TIME_RANGES[data.range], data.queriedAt]
+    : undefined;
   const renderChart = (def: ChartDef) => (
     <MetricChart
       key={def.title}
@@ -177,8 +173,8 @@ export function Monitoring() {
       data={data ? def.pick(data) : []}
       isLoading={isLoading}
       error={error}
-      onLegendClick={onLegendClick}
       step={step}
+      domain={domain}
     />
   );
   const renderStat = (def: UtilisationDef) => (

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/types.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/types.ts
@@ -17,16 +17,19 @@ export interface MetricChartProps {
    */
   selectedApps?: ReadonlySet<string>;
   /**
-   * Click handler for a legend entry.
-   * `modifiers.toggle` is true when the user held shift or cmd/ctrl while clicking.
-   */
-  onLegendClick?: (app: string, modifiers: { toggle: boolean }) => void;
-  /**
    * Resolution of the time series in seconds. Used to bucket cursor timestamps
    * so neighbouring pixels in the same step short-circuit the cross-chart
    * cursor broadcast.
    */
   step?: number;
+  /**
+   * Explicit `[startSec, endSec]` bounds for the X axis (unix seconds). When
+   * set, the chart spans the full selected time range even if data only
+   * exists for part of it — so a 24h selection always reads as 24h, with
+   * empty space where Prometheus has no samples (e.g. before the pod
+   * started). Falls back to data-fitted axis when omitted.
+   */
+  domain?: [number, number];
 }
 
 export interface ToolbarProps {

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/utils.test.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/utils.test.ts
@@ -12,7 +12,20 @@ import {
 
 const series = (app: string, values: number[]): MetricSeriesByApp => ({
   app,
-  series: values.map((v, i) => ({ t: 1700000000 + i * 60, v })),
+  pods: [
+    {
+      pod: `${app}-1`,
+      series: values.map((v, i) => ({ t: 1700000000 + i * 60, v })),
+    },
+  ],
+});
+
+const multiPod = (app: string, perPod: number[][]): MetricSeriesByApp => ({
+  app,
+  pods: perPod.map((values, idx) => ({
+    pod: `${app}-${idx + 1}`,
+    series: values.map((v, i) => ({ t: 1700000000 + i * 60, v })),
+  })),
 });
 
 describe("humanBytes", () => {
@@ -105,13 +118,29 @@ describe("latestSumByApp", () => {
   });
 
   it("treats apps with empty series as zero contribution", () => {
-    const data = [series("a", [3]), { app: "b", series: [] }];
+    const data = [series("a", [3]), { app: "b", pods: [] }];
     expect(latestSumByApp(data, new Set(["a", "b"]))).toBe(3);
   });
 
   it("returns 0 when nothing matches", () => {
     expect(latestSumByApp([], new Set(["a"]))).toBe(0);
     expect(latestSumByApp([series("a", [1])], new Set())).toBe(0);
+  });
+
+  it("sums the latest sample of every pod under each selected app", () => {
+    const data = [
+      multiPod("a", [
+        [1, 2, 3], // a-1 latest = 3
+        [10, 20], // a-2 latest = 20
+      ]),
+      series("b", [100]),
+    ];
+    expect(latestSumByApp(data, new Set(["a", "b"]))).toBe(123);
+  });
+
+  it("ignores pods within an app when the app is not selected", () => {
+    const data = [multiPod("a", [[1], [2]]), multiPod("b", [[3]])];
+    expect(latestSumByApp(data, new Set(["a"]))).toBe(3);
   });
 });
 
@@ -128,8 +157,8 @@ describe("computeUtilization", () => {
   it("returns null when no selected app has capacity configured", () => {
     const usage = [series("a", [0.5]), series("b", [0.5])];
     const capacity = [
-      { app: "a", series: [] },
-      { app: "b", series: [] },
+      { app: "a", pods: [] },
+      { app: "b", pods: [] },
     ];
     expect(computeUtilization(usage, capacity, apps)).toBeNull();
   });
@@ -150,6 +179,12 @@ describe("computeUtilization", () => {
     const usage = [series("a", [3])];
     const capacity = [series("a", [2])];
     expect(computeUtilization(usage, capacity, apps)).toBe(150);
+  });
+
+  it("rolls up multi-pod usage and capacity by summing all pods of selected apps", () => {
+    const usage = [multiPod("a", [[0.2], [0.3]])]; // total 0.5
+    const capacity = [multiPod("a", [[1], [1]])]; // total 2
+    expect(computeUtilization(usage, capacity, new Set(["a"]))).toBe(25);
   });
 });
 

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/utils.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/utils.ts
@@ -32,24 +32,28 @@ export function chartSlug(title: string): string {
 }
 
 /**
- * Sum the latest sample of every selected app's series. Apps with empty series
- * are skipped (kube-state-metrics omits a series entirely when the resource
- * isn't configured, so empty == not set).
+ * Sum the latest sample of every pod under every selected app. Apps with
+ * no pods, or pods with empty series (kube-state-metrics omits a series
+ * entirely when the resource isn't configured, so empty == not set), are
+ * skipped.
  */
 export function latestSumByApp(series: MetricSeriesByApp[], apps: ReadonlySet<string>): number {
   let total = 0;
-  for (const s of series) {
-    if (!apps.has(s.app) || s.series.length === 0) continue;
-    total += s.series[s.series.length - 1].v;
+  for (const entry of series) {
+    if (!apps.has(entry.app)) continue;
+    for (const pod of entry.pods) {
+      if (pod.series.length === 0) continue;
+      total += pod.series[pod.series.length - 1].v;
+    }
   }
   return total;
 }
 
 /**
  * Compute utilisation percentage matching Grafana's
- * `sum(usage) / sum(capacity)` semantic. Returns `null` when no selected app
- * has capacity configured (so the panel can render "No data" instead of a
- * misleading 0% or division-by-zero infinity).
+ * `sum(usage) / sum(capacity)` semantic, summing across every pod of
+ * every selected app on both sides. Returns `null` when no selected app
+ * has any pod with capacity configured.
  */
 export function computeUtilization(
   usage: MetricSeriesByApp[],
@@ -58,10 +62,13 @@ export function computeUtilization(
 ): number | null {
   let totalCapacity = 0;
   let hasCapacity = false;
-  for (const s of capacity) {
-    if (!apps.has(s.app) || s.series.length === 0) continue;
-    totalCapacity += s.series[s.series.length - 1].v;
-    hasCapacity = true;
+  for (const entry of capacity) {
+    if (!apps.has(entry.app)) continue;
+    for (const pod of entry.pods) {
+      if (pod.series.length === 0) continue;
+      totalCapacity += pod.series[pod.series.length - 1].v;
+      hasCapacity = true;
+    }
   }
   if (!hasCapacity || totalCapacity <= 0) return null;
   return (latestSumByApp(usage, apps) / totalCapacity) * 100;

--- a/apps/client/src/modules/platform/security/pages/trivy-overview/hooks/useDiscoverTrivyNamespaces/index.ts
+++ b/apps/client/src/modules/platform/security/pages/trivy-overview/hooks/useDiscoverTrivyNamespaces/index.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useVulnerabilityReportWatchList } from "@/k8s/api/groups/Trivy/VulnerabilityReport/hooks";
 import { useClusterStore } from "@/k8s/store";
+import { sortByName } from "@/core/utils/sortByName";
 import { useShallow } from "zustand/react/shallow";
 
 export interface UseDiscoverTrivyNamespacesResult {
@@ -76,7 +77,7 @@ export function useDiscoverTrivyNamespaces(): UseDiscoverTrivyNamespacesResult {
           .map((report) => report.metadata?.namespace)
           .filter((ns): ns is string => Boolean(ns))
       ),
-    ].sort((a, b) => a.localeCompare(b));
+    ].sort(sortByName);
 
     // If we discovered namespaces, use them; otherwise fall back to configured
     return discoveredNamespaces.length > 0 ? discoveredNamespaces : allowedNamespaces;

--- a/packages/shared/src/models/prometheus/constants.ts
+++ b/packages/shared/src/models/prometheus/constants.ts
@@ -20,3 +20,11 @@ export const STEP_BY_RANGE = {
 export const MAX_APPLICATIONS = 50;
 
 export const PROMETHEUS_TIMEOUT_MS = 10_000;
+
+/**
+ * Prometheus label name emitted by `kube-state-metrics` for the
+ * `app.kubernetes.io/instance` Kubernetes label, after KSM's
+ * `label_` prefix and `_`-for-`/`/`.` munging. Used as the join
+ * key for vector matching pod metrics with `kube_pod_labels`.
+ */
+export const POD_LABEL_APP_INSTANCE = "label_app_kubernetes_io_instance";

--- a/packages/shared/src/models/prometheus/schemas.ts
+++ b/packages/shared/src/models/prometheus/schemas.ts
@@ -24,9 +24,14 @@ export const metricSeriesPointSchema = z.object({
   v: z.number().finite(),
 });
 
+export const metricSeriesByPodSchema = z.object({
+  pod: z.string(),
+  series: z.array(metricSeriesPointSchema),
+});
+
 export const metricSeriesByAppSchema = z.object({
   app: z.string(),
-  series: z.array(metricSeriesPointSchema),
+  pods: z.array(metricSeriesByPodSchema),
 });
 
 export const podPhaseSchema = z.enum(["Pending", "Running", "Succeeded", "Failed", "Unknown"]);

--- a/packages/shared/src/models/prometheus/types.ts
+++ b/packages/shared/src/models/prometheus/types.ts
@@ -6,6 +6,7 @@ import type {
   promqlVectorResponseSchema,
   metricSeriesPointSchema,
   metricSeriesByAppSchema,
+  metricSeriesByPodSchema,
   podPhaseSchema,
   podPhaseByAppSchema,
 } from "./schemas.js";
@@ -18,5 +19,6 @@ export type PromQLVectorResponse = z.infer<typeof promqlVectorResponseSchema>;
 export type MetricRange = (typeof METRIC_RANGE_VALUES)[number];
 export type MetricSeriesPoint = z.infer<typeof metricSeriesPointSchema>;
 export type MetricSeriesByApp = z.infer<typeof metricSeriesByAppSchema>;
+export type MetricSeriesByPod = z.infer<typeof metricSeriesByPodSchema>;
 export type PodPhase = z.infer<typeof podPhaseSchema>;
 export type PodPhaseByApp = z.infer<typeof podPhaseByAppSchema>;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from "./truncateName.js";
 export * from "./versioning.js";
 export * from "./stripLeadingSlash.js";
 export * from "./tryParseJsonArray.js";
+export * from "./sortByName.js";

--- a/packages/shared/src/utils/sortByName.ts
+++ b/packages/shared/src/utils/sortByName.ts
@@ -1,0 +1,15 @@
+export const sortByName = (a?: string, b?: string): number => {
+  if (a && b) {
+    return a.localeCompare(b, undefined, { sensitivity: "accent" });
+  }
+
+  if (a && !b) {
+    return -1;
+  }
+
+  if (!a && b) {
+    return 1;
+  }
+
+  return 0;
+};

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.test.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.test.ts
@@ -86,7 +86,7 @@ describe("prometheus.getDeploymentMetrics", () => {
     expect(mockListResource).not.toHaveBeenCalled();
   });
 
-  it("fans out 16 range queries + 1 instant query and groups output by section", async () => {
+  it("fans out 16 range queries + 2 instant queries (probe + pod phase) and groups output by section", async () => {
     mockListResource.mockResolvedValueOnce({
       items: [
         { metadata: { name: "frontend-1", labels: { "app.kubernetes.io/instance": "frontend" } } },
@@ -100,17 +100,29 @@ describe("prometheus.getDeploymentMetrics", () => {
         resultType: "matrix",
         result: [
           {
-            metric: { pod: "frontend-1" },
+            metric: { pod: "frontend-1", label_app_kubernetes_io_instance: "frontend" },
             values: [
               [100, "1.0"],
               [110, "2.0"],
             ],
           },
-          { metric: { pod: "frontend-2" }, values: [[110, "0.5"]] },
-          { metric: { pod: "api-1" }, values: [[100, "3.0"]] },
+          {
+            metric: { pod: "frontend-2", label_app_kubernetes_io_instance: "frontend" },
+            values: [[110, "0.5"]],
+          },
+          {
+            metric: { pod: "api-1", label_app_kubernetes_io_instance: "api" },
+            values: [[100, "3.0"]],
+          },
         ],
       },
     });
+    // First instant call: kube_pod_labels probe → confirms KSM has labels
+    mockInstantQuery.mockResolvedValueOnce({
+      status: "success",
+      data: { resultType: "vector", result: [{ metric: {}, value: [100, "3"] }] },
+    });
+    // Second instant call: pod phase
     mockInstantQuery.mockResolvedValueOnce({
       status: "success",
       data: {
@@ -130,43 +142,73 @@ describe("prometheus.getDeploymentMetrics", () => {
     });
 
     expect(mockRangeQuery).toHaveBeenCalledTimes(16);
-    expect(mockInstantQuery).toHaveBeenCalledTimes(1);
+    expect(mockInstantQuery).toHaveBeenCalledTimes(2); // probe + pod phase
+
     const cpuCall = mockRangeQuery.mock.calls.find(([q]) => q.query.includes("container_cpu_usage_seconds_total"));
     expect(cpuCall?.[0].query).toContain('namespace="test-namespace"');
-    expect(cpuCall?.[0].query).toContain("frontend-1");
-    expect(cpuCall?.[0].query).toContain("api-1");
+    expect(cpuCall?.[0].query).toContain('label_app_kubernetes_io_instance=~"^(frontend|api)$"');
+    expect(cpuCall?.[0].query).not.toContain("frontend-1"); // pod names are no longer interpolated
 
     const cpuFrontend = result.compute.cpu.find((r) => r.app === "frontend");
-    expect(cpuFrontend?.series).toEqual([
-      { t: 100, v: 1.0 },
-      { t: 110, v: 2.5 },
+    expect(cpuFrontend?.pods).toEqual([
+      {
+        pod: "frontend-1",
+        series: [
+          { t: 100, v: 1.0 },
+          { t: 110, v: 2.0 },
+        ],
+      },
+      { pod: "frontend-2", series: [{ t: 110, v: 0.5 }] },
     ]);
     const phaseFrontend = result.health.podPhase.find((r) => r.app === "frontend");
     expect(phaseFrontend?.pods).toEqual([
       { name: "frontend-1", phase: "Running" },
       { name: "frontend-2", phase: "Pending" },
     ]);
-    expect(result.network.rx.find((r) => r.app === "api")?.series).toEqual([{ t: 100, v: 3.0 }]);
+    expect(result.network.rx.find((r) => r.app === "api")?.pods).toEqual([
+      { pod: "api-1", series: [{ t: 100, v: 3.0 }] },
+    ]);
   });
 
-  it("returns empty grouped series per app when zero pods match (no Prometheus call)", async () => {
+  it("returns empty grouped series per app when zero pods match (range queries still fire for history)", async () => {
     mockListResource.mockResolvedValueOnce({ items: [] });
+    // Probe confirms kube_pod_labels is available so range queries fire for historical pods.
+    mockInstantQuery.mockResolvedValueOnce({
+      status: "success",
+      data: { resultType: "vector", result: [{ metric: {}, value: [100, "2"] }] },
+    });
     const caller = await getCaller();
     const result = await caller.prometheus.getDeploymentMetrics({
       ...validInput,
       applications: ["frontend", "api"],
     });
 
-    expect(mockRangeQuery).not.toHaveBeenCalled();
-    expect(mockInstantQuery).not.toHaveBeenCalled();
+    // Range queries still fire — they may return historical pod data
+    // even when no pods are currently alive. The instant podPhase query
+    // is short-circuited because there are no live pods to match.
+    expect(mockRangeQuery).toHaveBeenCalledTimes(16);
+    // Only the kube_pod_labels probe fires; podPhase is skipped (no live pods).
+    expect(mockInstantQuery).toHaveBeenCalledTimes(1);
     expect(result.compute.cpu.map((r) => r.app)).toEqual(["frontend", "api"]);
-    expect(result.compute.cpu.every((r) => r.series.length === 0)).toBe(true);
+    expect(result.compute.cpu.every((r) => r.pods.length === 0)).toBe(true);
     expect(result.health.podPhase.every((r) => r.pods.length === 0)).toBe(true);
   });
 
   it("includes an app with no pods as empty series alongside apps that do have pods", async () => {
     mockListResource.mockResolvedValueOnce({
       items: [{ metadata: { name: "frontend-1", labels: { "app.kubernetes.io/instance": "frontend" } } }],
+    });
+    mockRangeQuery.mockResolvedValue({
+      status: "success",
+      data: {
+        resultType: "matrix",
+        result: [
+          {
+            metric: { pod: "frontend-1", label_app_kubernetes_io_instance: "frontend" },
+            values: [[100, "1.0"]],
+          },
+        ],
+      },
     });
     const caller = await getCaller();
     const result = await caller.prometheus.getDeploymentMetrics({
@@ -176,10 +218,9 @@ describe("prometheus.getDeploymentMetrics", () => {
 
     expect(mockRangeQuery).toHaveBeenCalledTimes(16);
     const missing = result.compute.cpu.find((r) => r.app === "missing");
-    expect(missing).toBeDefined();
-    expect(missing?.series).toEqual([]);
+    expect(missing?.pods).toEqual([]);
     const frontend = result.compute.cpu.find((r) => r.app === "frontend");
-    expect(frontend).toBeDefined();
+    expect(frontend?.pods).toEqual([{ pod: "frontend-1", series: [{ t: 100, v: 1.0 }] }]);
     const missingPhase = result.health.podPhase.find((r) => r.app === "missing");
     expect(missingPhase?.pods).toEqual([]);
   });

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/index.ts
@@ -4,6 +4,7 @@ import {
   deploymentMetricsOutputSchema,
   k8sPodConfig,
   podLabels,
+  POD_LABEL_APP_INSTANCE,
   STEP_BY_RANGE,
   PROMETHEUS_TIME_RANGES,
   type DeploymentMetricsOutput,
@@ -18,11 +19,13 @@ import { ERROR_K8S_CLIENT_NOT_INITIALIZED } from "../../../k8s/errors/index.js";
 import { createPrometheusClient } from "../../../../clients/prometheus/index.js";
 import {
   buildPodPhaseQuery,
+  buildPodNamePromQLQueries,
   buildPromQLQueries,
   combineRatioSeriesByApp,
   deriveRateWindow,
   groupPodsByApp,
-  matrixToSeriesByApp,
+  matrixToPodSeriesByApp,
+  matrixToPodSeriesByAppFromMap,
   RANGE_METRIC_KEYS,
   vectorToPodPhaseByApp,
   type RangeMetricKey,
@@ -38,7 +41,7 @@ function emptyOutput(
   queriedAt: number,
   apps: string[]
 ): DeploymentMetricsOutput {
-  const empty = (): MetricSeriesByApp[] => apps.map((app) => ({ app, series: [] }));
+  const empty = (): MetricSeriesByApp[] => apps.map((app) => ({ app, pods: [] }));
   const emptyPhase = (): PodPhaseByApp[] => apps.map((app) => ({ app, pods: [] }));
   return {
     compute: {
@@ -80,37 +83,28 @@ export const getDeploymentMetricsProcedure = protectedProcedure
       throw new TRPCError(ERROR_K8S_CLIENT_NOT_INITIALIZED);
     }
 
+    // K8s pod listing is still needed for the live-only podPhase panel.
+    // Range queries no longer depend on it — they vector-match against
+    // kube_pod_labels server-side and so include historical pods.
     const labelSelector = `${podLabels.instance} in (${applications.join(",")})`;
     const podList = await k8sClient.listResource(k8sPodConfig, namespace, labelSelector);
-
     const podsByApp = groupPodsByApp(
       (podList.items ?? []) as Array<{ metadata: { name: string; labels?: Record<string, string> } }>,
       applications
     );
-
-    const podToApp = new Map<string, string>();
-    const allPodNames: string[] = [];
+    const livePodToApp = new Map<string, string>();
+    const livePodNames: string[] = [];
     for (const [app, pods] of podsByApp) {
       for (const podName of pods) {
-        podToApp.set(podName, app);
-        allPodNames.push(podName);
+        livePodToApp.set(podName, app);
+        livePodNames.push(podName);
       }
-    }
-
-    if (allPodNames.length === 0) {
-      return emptyOutput(range, queriedAt, applications);
     }
 
     const end = queriedAt;
     const step = STEP_BY_RANGE[range];
     const rangeSeconds = PROMETHEUS_TIME_RANGES[range];
     const start = end - rangeSeconds;
-    const queries = buildPromQLQueries({
-      namespace,
-      podNames: allPodNames,
-      lookbackWindow: deriveRateWindow(step),
-    });
-    const phaseQuery = buildPodPhaseQuery({ namespace, podNames: allPodNames });
 
     const prometheus = createPrometheusClient();
     const sharedAbort = new AbortController();
@@ -121,6 +115,29 @@ export const getDeploymentMetricsProcedure = protectedProcedure
     const combinedSignal = AbortSignal.any([sharedAbort.signal, budgetSignal]);
     const procedureStart = Date.now();
 
+    // Probe whether kube-state-metrics exposes kube_pod_labels for this
+    // namespace. Requires --metric-labels-allowlist=pods=[app.kubernetes.io/instance]
+    // on the KSM deployment; absent on many stock installations. When the metric
+    // is present we can use the kube_pod_labels join (includes historical pods);
+    // otherwise we fall back to filtering by live pod names from the K8s listing.
+    const kubePodLabelsProbe = await prometheus.instantQuery(
+      {
+        query: `count(kube_pod_labels{namespace="${namespace}", ${POD_LABEL_APP_INSTANCE}!=""})`,
+      },
+      combinedSignal
+    );
+    const hasKubePodLabels =
+      kubePodLabelsProbe.data.result.length > 0 && Number(kubePodLabelsProbe.data.result[0]?.value[1]) > 0;
+
+    // Without kube_pod_labels AND no live pods there is nothing to query.
+    if (!hasKubePodLabels && livePodNames.length === 0) {
+      return emptyOutput(range, queriedAt, applications);
+    }
+
+    const queries = hasKubePodLabels
+      ? buildPromQLQueries({ namespace, applications, lookbackWindow: deriveRateWindow(step) })
+      : buildPodNamePromQLQueries({ namespace, podNames: livePodNames, lookbackWindow: deriveRateWindow(step) });
+
     let rangeResults: PromQLMatrixResponse[];
     let phaseVector: PromQLVectorResponse;
     try {
@@ -129,7 +146,16 @@ export const getDeploymentMetricsProcedure = protectedProcedure
       const rangePromises = RANGE_METRIC_KEYS.map((key) =>
         prometheus.rangeQuery({ query: queries[key], start, end, step }, combinedSignal)
       );
-      const phasePromise = prometheus.instantQuery({ query: phaseQuery }, combinedSignal);
+      // podPhase is intrinsically about live pods. Skip the instant query
+      // when no live pods match — Prometheus would return an empty vector
+      // and an empty pod regex would be malformed.
+      const phasePromise: Promise<PromQLVectorResponse> =
+        livePodNames.length === 0
+          ? Promise.resolve({ status: "success", data: { resultType: "vector", result: [] } })
+          : prometheus.instantQuery(
+              { query: buildPodPhaseQuery({ namespace, podNames: livePodNames }) },
+              combinedSignal
+            );
       [rangeResults, phaseVector] = await Promise.all([Promise.all(rangePromises), phasePromise]);
     } catch (error) {
       sharedAbort.abort();
@@ -145,7 +171,7 @@ export const getDeploymentMetricsProcedure = protectedProcedure
       });
     } finally {
       console.info(
-        `[prometheus.getDeploymentMetrics] range=${range} apps=${applications.length} pods=${allPodNames.length} durationMs=${Date.now() - procedureStart}`
+        `[prometheus.getDeploymentMetrics] range=${range} apps=${applications.length} livePods=${livePodNames.length} hasKubePodLabels=${hasKubePodLabels} durationMs=${Date.now() - procedureStart}`
       );
     }
 
@@ -153,7 +179,9 @@ export const getDeploymentMetricsProcedure = protectedProcedure
       RANGE_METRIC_KEYS.map((key, idx) => [key, rangeResults[idx]!])
     );
     const seriesFor = (key: RangeMetricKey): MetricSeriesByApp[] =>
-      matrixToSeriesByApp(resultByKey.get(key)!, podToApp, applications);
+      hasKubePodLabels
+        ? matrixToPodSeriesByApp(resultByKey.get(key)!, applications)
+        : matrixToPodSeriesByAppFromMap(resultByKey.get(key)!, livePodToApp, applications);
 
     return {
       compute: {
@@ -174,7 +202,7 @@ export const getDeploymentMetricsProcedure = protectedProcedure
       health: {
         restarts: seriesFor("restarts"),
         oomEvents: seriesFor("oomEvents"),
-        podPhase: vectorToPodPhaseByApp(phaseVector, podToApp, applications),
+        podPhase: vectorToPodPhaseByApp(phaseVector, livePodToApp, applications),
       },
       quotas: {
         cpuRequests: seriesFor("cpuRequests"),

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.test.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { MetricSeriesByApp } from "@my-project/shared";
 import {
   escapeRegex,
   groupPodsByApp,
@@ -6,11 +7,9 @@ import {
   buildPodPhaseQuery,
   combineRatioSeriesByApp,
   deriveRateWindow,
-  matrixToSeriesByApp,
+  matrixToPodSeriesByApp,
   vectorToPodPhaseByApp,
 } from "./utils.js";
-
-const DEFAULT_BUILD_PARAMS = { lookbackWindow: "300s" } as const;
 
 describe("escapeRegex", () => {
   it("escapes regex meta-characters", () => {
@@ -62,95 +61,88 @@ describe("deriveRateWindow", () => {
 });
 
 describe("buildPromQLQueries", () => {
-  const queries = buildPromQLQueries({ namespace: "ns", podNames: ["pod-a", "pod-b"], ...DEFAULT_BUILD_PARAMS });
+  const queries = buildPromQLQueries({
+    namespace: "ns",
+    applications: ["app-a", "app-b"],
+    lookbackWindow: "300s",
+  });
 
   it.each([
-    [
-      "cpu",
-      'rate(container_cpu_usage_seconds_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
-    ],
-    [
-      "memory",
-      'container_memory_working_set_bytes{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}',
-    ],
-    ["memoryRss", 'container_memory_rss{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}'],
-    ["memoryCache", 'container_memory_cache{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}'],
-    ["restarts", 'increase(kube_pod_container_status_restarts_total{namespace="ns", pod=~"^(pod-a|pod-b)$"}[300s])'],
-    ["networkRx", 'rate(container_network_receive_bytes_total{namespace="ns", pod=~"^(pod-a|pod-b)$"}[300s])'],
-    ["networkTx", 'rate(container_network_transmit_bytes_total{namespace="ns", pod=~"^(pod-a|pod-b)$"}[300s])'],
-    [
-      "diskReadBytes",
-      'rate(container_fs_reads_bytes_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
-    ],
-    [
-      "diskWriteBytes",
-      'rate(container_fs_writes_bytes_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
-    ],
-    ["oomEvents", 'increase(container_oom_events_total{namespace="ns", pod=~"^(pod-a|pod-b)$"}[300s])'],
-    ["cpuRequests", 'kube_pod_container_resource_requests{namespace="ns", pod=~"^(pod-a|pod-b)$", resource="cpu"}'],
-    ["cpuLimits", 'kube_pod_container_resource_limits{namespace="ns", pod=~"^(pod-a|pod-b)$", resource="cpu"}'],
-    [
-      "memoryRequests",
-      'kube_pod_container_resource_requests{namespace="ns", pod=~"^(pod-a|pod-b)$", resource="memory"}',
-    ],
-    ["memoryLimits", 'kube_pod_container_resource_limits{namespace="ns", pod=~"^(pod-a|pod-b)$", resource="memory"}'],
+    ["cpu", 'rate(container_cpu_usage_seconds_total{namespace="ns", container!="", container!="POD"}[300s])'],
+    ["memory", 'container_memory_working_set_bytes{namespace="ns", container!="", container!="POD"}'],
+    ["memoryRss", 'container_memory_rss{namespace="ns", container!="", container!="POD"}'],
+    ["memoryCache", 'container_memory_cache{namespace="ns", container!="", container!="POD"}'],
+    ["restarts", 'increase(kube_pod_container_status_restarts_total{namespace="ns"}[300s])'],
+    ["networkRx", 'rate(container_network_receive_bytes_total{namespace="ns"}[300s])'],
+    ["networkTx", 'rate(container_network_transmit_bytes_total{namespace="ns"}[300s])'],
+    ["diskReadBytes", 'rate(container_fs_reads_bytes_total{namespace="ns", container!="", container!="POD"}[300s])'],
+    ["diskWriteBytes", 'rate(container_fs_writes_bytes_total{namespace="ns", container!="", container!="POD"}[300s])'],
+    ["oomEvents", 'increase(container_oom_events_total{namespace="ns"}[300s])'],
+    ["cpuRequests", 'kube_pod_container_resource_requests{namespace="ns", resource="cpu"}'],
+    ["cpuLimits", 'kube_pod_container_resource_limits{namespace="ns", resource="cpu"}'],
+    ["memoryRequests", 'kube_pod_container_resource_requests{namespace="ns", resource="memory"}'],
+    ["memoryLimits", 'kube_pod_container_resource_limits{namespace="ns", resource="memory"}'],
     [
       "cpuThrottledPeriods",
-      'rate(container_cpu_cfs_throttled_periods_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
+      'rate(container_cpu_cfs_throttled_periods_total{namespace="ns", container!="", container!="POD"}[300s])',
     ],
-    [
-      "cpuPeriods",
-      'rate(container_cpu_cfs_periods_total{namespace="ns", pod=~"^(pod-a|pod-b)$", container!="", container!="POD"}[300s])',
-    ],
-  ])("emits the expected PromQL fragment for %s", (key, fragment) => {
+    ["cpuPeriods", 'rate(container_cpu_cfs_periods_total{namespace="ns", container!="", container!="POD"}[300s])'],
+  ])("emits the expected inner expression for %s", (key, fragment) => {
     expect(queries[key as keyof typeof queries]).toContain(fragment);
   });
 
-  it("escapes regex meta-characters in pod names", () => {
-    const q = buildPromQLQueries({
-      namespace: "ns",
-      podNames: ["good-pod", "weird.pod"],
-      ...DEFAULT_BUILD_PARAMS,
-    });
-    expect(q.cpu).toContain('pod=~"^(good-pod|weird\\.pod)$"');
+  it("joins every metric with kube_pod_labels filtered by application", () => {
+    for (const [key, value] of Object.entries(queries)) {
+      expect(value, `query ${key}`).toContain(
+        '* on (namespace, pod) group_left(label_app_kubernetes_io_instance) kube_pod_labels{namespace="ns", label_app_kubernetes_io_instance=~"^(app-a|app-b)$"}'
+      );
+    }
   });
 
-  it("anchors the pod regex to prevent prefix-match ambiguity", () => {
-    const q = buildPromQLQueries({ namespace: "ns", podNames: ["web"], ...DEFAULT_BUILD_PARAMS });
-    expect(q.cpu).toContain('pod=~"^(web)$"');
-  });
-
-  it("wraps every metric in `sum by (pod) (...)` (regression guard for aggregation)", () => {
-    const all = buildPromQLQueries({ namespace: "ns", podNames: ["pod-a"], ...DEFAULT_BUILD_PARAMS });
-    for (const [key, value] of Object.entries(all)) {
-      expect(value, `query ${key}`).toMatch(/^sum by \(pod\) \(/);
+  it("wraps every metric in `sum by (pod, label_app_kubernetes_io_instance) (...)` (regression guard for aggregation)", () => {
+    for (const [key, value] of Object.entries(queries)) {
+      expect(value, `query ${key}`).toMatch(/^sum by \(pod, label_app_kubernetes_io_instance\) \(/);
       expect(value, `query ${key}`).toMatch(/\)$/);
     }
+  });
+
+  it("escapes regex meta-characters in application names", () => {
+    const q = buildPromQLQueries({
+      namespace: "ns",
+      applications: ["good-app", "weird.app"],
+      lookbackWindow: "300s",
+    });
+    expect(q.cpu).toContain('label_app_kubernetes_io_instance=~"^(good-app|weird\\.app)$"');
+  });
+
+  it("anchors the application regex to prevent prefix-match ambiguity", () => {
+    const q = buildPromQLQueries({
+      namespace: "ns",
+      applications: ["api"],
+      lookbackWindow: "300s",
+    });
+    expect(q.cpu).toContain('label_app_kubernetes_io_instance=~"^(api)$"');
   });
 
   it("scales rate window with the requested step", () => {
     const fast = buildPromQLQueries({
       namespace: "ns",
-      podNames: ["p"],
+      applications: ["a"],
       lookbackWindow: deriveRateWindow(15),
     });
     expect(fast.cpu).toContain("[300s]");
     const slow = buildPromQLQueries({
       namespace: "ns",
-      podNames: ["p"],
+      applications: ["a"],
       lookbackWindow: deriveRateWindow(300),
     });
     expect(slow.cpu).toContain("[1200s]");
   });
 
-  it("uses increase() with the rate window (bounded trailing interval, not the full range)", () => {
-    // Regression: a previous version evaluated increase() over the full
-    // selected range, so every datapoint counted events from t=start to T.
-    // A single restart then appeared as a rising plateau across the chart.
-    // Using the rate window keeps each datapoint's lookback bounded.
+  it("uses increase() with the rate window (bounded trailing interval)", () => {
     const q = buildPromQLQueries({
       namespace: "ns",
-      podNames: ["p"],
+      applications: ["a"],
       lookbackWindow: "1200s",
     });
     expect(q.restarts).toContain("increase(");
@@ -171,82 +163,80 @@ describe("buildPodPhaseQuery", () => {
   });
 });
 
-describe("matrixToSeriesByApp", () => {
-  it("maps each pod series to its app and aggregates by summing across the app's pods at each timestamp", () => {
-    const podToApp = new Map<string, string>([
-      ["frontend-1", "frontend"],
-      ["frontend-2", "frontend"],
-      ["api-1", "api"],
-    ]);
-    const matrix = {
-      status: "success" as const,
-      data: {
-        resultType: "matrix" as const,
-        result: [
-          {
-            metric: { pod: "frontend-1" },
-            values: [
-              [100, "1.0"],
-              [110, "2.0"],
-            ] as Array<[number, string]>,
-          },
-          {
-            metric: { pod: "frontend-2" },
-            values: [
-              [100, "0.5"],
-              [110, "0.5"],
-            ] as Array<[number, string]>,
-          },
-          { metric: { pod: "api-1" }, values: [[100, "3.0"]] as Array<[number, string]> },
-        ],
-      },
-    };
-    const known = ["frontend", "api", "worker"];
-    const result = matrixToSeriesByApp(matrix, podToApp, known);
+describe("matrixToPodSeriesByApp", () => {
+  const knownApps = ["frontend", "api", "worker"];
 
-    expect(result.find((r) => r.app === "frontend")?.series).toEqual([
-      { t: 100, v: 1.5 },
-      { t: 110, v: 2.5 },
-    ]);
-    expect(result.find((r) => r.app === "api")?.series).toEqual([{ t: 100, v: 3.0 }]);
-    expect(result.find((r) => r.app === "worker")?.series).toEqual([]);
-  });
-  it("aggregates partial-timestamp coverage", () => {
-    const podToApp = new Map<string, string>([
-      ["frontend-1", "frontend"],
-      ["frontend-2", "frontend"],
-    ]);
+  it("partitions matrix rows by app via the label_app_kubernetes_io_instance label", () => {
     const matrix = {
       status: "success" as const,
       data: {
         resultType: "matrix" as const,
         result: [
           {
-            metric: { pod: "frontend-1" },
+            metric: { pod: "frontend-1", label_app_kubernetes_io_instance: "frontend" },
             values: [
               [100, "1.0"],
               [110, "2.0"],
             ] as Array<[number, string]>,
           },
-          { metric: { pod: "frontend-2" }, values: [[100, "0.5"]] as Array<[number, string]> },
+          {
+            metric: { pod: "frontend-2", label_app_kubernetes_io_instance: "frontend" },
+            values: [[100, "0.5"]] as Array<[number, string]>,
+          },
+          {
+            metric: { pod: "api-1", label_app_kubernetes_io_instance: "api" },
+            values: [[100, "3.0"]] as Array<[number, string]>,
+          },
         ],
       },
     };
-    const result = matrixToSeriesByApp(matrix, podToApp, ["frontend"]);
-    expect(result[0]?.series).toEqual([
-      { t: 100, v: 1.5 },
-      { t: 110, v: 2.0 },
+    const result = matrixToPodSeriesByApp(matrix, knownApps);
+    expect(result.find((r) => r.app === "frontend")?.pods).toEqual([
+      {
+        pod: "frontend-1",
+        series: [
+          { t: 100, v: 1.0 },
+          { t: 110, v: 2.0 },
+        ],
+      },
+      { pod: "frontend-2", series: [{ t: 100, v: 0.5 }] },
     ]);
+    expect(result.find((r) => r.app === "api")?.pods).toEqual([{ pod: "api-1", series: [{ t: 100, v: 3.0 }] }]);
+    expect(result.find((r) => r.app === "worker")?.pods).toEqual([]);
   });
-  it("drops NaN and empty string values silently", () => {
-    const podToApp = new Map<string, string>([["p1", "app"]]);
+
+  it("does NOT sum across pods (each pod keeps its own series)", () => {
     const matrix = {
       status: "success" as const,
       data: {
         resultType: "matrix" as const,
         result: [
           {
-            metric: { pod: "p1" },
+            metric: { pod: "p1", label_app_kubernetes_io_instance: "app" },
+            values: [[100, "1.0"]] as Array<[number, string]>,
+          },
+          {
+            metric: { pod: "p2", label_app_kubernetes_io_instance: "app" },
+            values: [[100, "2.5"]] as Array<[number, string]>,
+          },
+        ],
+      },
+    };
+    const result = matrixToPodSeriesByApp(matrix, ["app"]);
+    expect(result[0]?.pods.map((p) => ({ pod: p.pod, last: p.series.at(-1)?.v }))).toEqual([
+      { pod: "p1", last: 1.0 },
+      { pod: "p2", last: 2.5 },
+    ]);
+  });
+
+  it("drops NaN and empty string values silently", () => {
+    const matrix = {
+      status: "success" as const,
+      data: {
+        resultType: "matrix" as const,
+        result: [
+          {
+            metric: { pod: "p1", label_app_kubernetes_io_instance: "app" },
             values: [
               [100, "NaN"],
               [110, "1.0"],
@@ -257,19 +247,68 @@ describe("matrixToSeriesByApp", () => {
         ],
       },
     };
-    const result = matrixToSeriesByApp(matrix, podToApp, ["app"]);
-    expect(result[0]?.series).toEqual([
+    const result = matrixToPodSeriesByApp(matrix, ["app"]);
+    expect(result[0]?.pods[0]?.series).toEqual([
       { t: 110, v: 1.0 },
       { t: 130, v: 2.5 },
     ]);
   });
-  it("preserves the order of `known` apps in the output", () => {
-    const result = matrixToSeriesByApp({ status: "success", data: { resultType: "matrix", result: [] } }, new Map(), [
-      "b",
-      "a",
-      "c",
-    ]);
-    expect(result.map((r) => r.app)).toEqual(["b", "a", "c"]);
+
+  it("drops series whose app label is not in `knownApps` (defensive)", () => {
+    const matrix = {
+      status: "success" as const,
+      data: {
+        resultType: "matrix" as const,
+        result: [
+          {
+            metric: { pod: "p1", label_app_kubernetes_io_instance: "stranger" },
+            values: [[100, "1"]] as Array<[number, string]>,
+          },
+        ],
+      },
+    };
+    const result = matrixToPodSeriesByApp(matrix, ["app"]);
+    expect(result[0]?.pods).toEqual([]);
+  });
+
+  it("drops series with no pod label or no app label (defensive)", () => {
+    const matrix = {
+      status: "success" as const,
+      data: {
+        resultType: "matrix" as const,
+        result: [
+          {
+            metric: { label_app_kubernetes_io_instance: "app" } as Record<string, string>,
+            values: [[100, "1"]] as Array<[number, string]>,
+          },
+          { metric: { pod: "p1" } as Record<string, string>, values: [[100, "1"]] as Array<[number, string]> },
+        ],
+      },
+    };
+    const result = matrixToPodSeriesByApp(matrix, ["app"]);
+    expect(result[0]?.pods).toEqual([]);
+  });
+
+  it("preserves the order of `knownApps` in the output and sorts pods by name within each app", () => {
+    const matrix = {
+      status: "success" as const,
+      data: {
+        resultType: "matrix" as const,
+        result: [
+          {
+            metric: { pod: "z-pod", label_app_kubernetes_io_instance: "app" },
+            values: [[100, "1"]] as Array<[number, string]>,
+          },
+          {
+            metric: { pod: "a-pod", label_app_kubernetes_io_instance: "app" },
+            values: [[100, "2"]] as Array<[number, string]>,
+          },
+        ],
+      },
+    };
+    const result = matrixToPodSeriesByApp(matrix, ["b", "a", "app"]);
+    expect(result.map((r) => r.app)).toEqual(["b", "a", "app"]);
+    expect(result.find((r) => r.app === "app")?.pods.map((p) => p.pod)).toEqual(["a-pod", "z-pod"]);
   });
 });
 
@@ -337,87 +376,114 @@ describe("vectorToPodPhaseByApp", () => {
 });
 
 describe("combineRatioSeriesByApp", () => {
-  const series = (app: string, points: Array<[number, number]>) => ({
-    app,
+  const podSeries = (pod: string, points: Array<[number, number]>) => ({
+    pod,
     series: points.map(([t, v]) => ({ t, v })),
   });
-
-  it("emits 100 * num/den at every timestamp where both have a finite, positive denominator", () => {
-    const num = [series("a", [[100, 2]]), series("b", [[100, 1]])];
-    const den = [series("a", [[100, 10]]), series("b", [[100, 4]])];
-    const result = combineRatioSeriesByApp(num, den);
-    expect(result.find((r) => r.app === "a")?.series).toEqual([{ t: 100, v: 20 }]);
-    expect(result.find((r) => r.app === "b")?.series).toEqual([{ t: 100, v: 25 }]);
+  const app = (name: string, pods: ReturnType<typeof podSeries>[]): MetricSeriesByApp => ({
+    app: name,
+    pods,
   });
 
-  it("drops timestamps where the denominator is zero or negative (avoids div-by-zero / nonsense ratios)", () => {
+  it("emits 100 * num/den for every (app, pod, t) where the matched denominator is finite and positive", () => {
+    const num = [app("a", [podSeries("a-1", [[100, 2]])]), app("b", [podSeries("b-1", [[100, 1]])])];
+    const den = [app("a", [podSeries("a-1", [[100, 10]])]), app("b", [podSeries("b-1", [[100, 4]])])];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result.find((r) => r.app === "a")?.pods[0]).toEqual({
+      pod: "a-1",
+      series: [{ t: 100, v: 20 }],
+    });
+    expect(result.find((r) => r.app === "b")?.pods[0]).toEqual({
+      pod: "b-1",
+      series: [{ t: 100, v: 25 }],
+    });
+  });
+
+  it("drops timestamps where the denominator is zero or negative", () => {
     const num = [
-      series("a", [
-        [100, 1],
-        [110, 2],
-        [120, 3],
+      app("a", [
+        podSeries("a-1", [
+          [100, 1],
+          [110, 2],
+          [120, 3],
+        ]),
       ]),
     ];
     const den = [
-      series("a", [
-        [100, 0],
-        [110, 5],
-        [120, -1],
+      app("a", [
+        podSeries("a-1", [
+          [100, 0],
+          [110, 5],
+          [120, -1],
+        ]),
       ]),
     ];
     const result = combineRatioSeriesByApp(num, den);
-    expect(result[0]?.series).toEqual([{ t: 110, v: 40 }]);
+    expect(result[0]?.pods[0]?.series).toEqual([{ t: 110, v: 40 }]);
   });
 
-  it("returns an empty series when the denominator series for an app is empty", () => {
-    const num = [series("a", [[100, 1]])];
-    const den = [{ app: "a", series: [] }];
-    const result = combineRatioSeriesByApp(num, den);
-    expect(result[0]?.series).toEqual([]);
-  });
-
-  it("drops numerator timestamps that have no matching denominator timestamp", () => {
+  it("drops numerator timestamps that have no matching denominator timestamp on the same pod", () => {
     const num = [
-      series("a", [
-        [100, 1],
-        [110, 2],
+      app("a", [
+        podSeries("a-1", [
+          [100, 1],
+          [110, 2],
+        ]),
       ]),
     ];
-    const den = [series("a", [[110, 5]])];
+    const den = [app("a", [podSeries("a-1", [[110, 5]])])];
     const result = combineRatioSeriesByApp(num, den);
-    expect(result[0]?.series).toEqual([{ t: 110, v: 40 }]);
+    expect(result[0]?.pods[0]?.series).toEqual([{ t: 110, v: 40 }]);
   });
 
-  it("returns an empty series when an app is missing from the denominator entirely", () => {
-    const num = [series("a", [[100, 1]]), series("b", [[100, 2]])];
-    const den = [series("a", [[100, 4]])];
+  it("returns an empty pod series when the denominator has no series for that pod", () => {
+    const num = [app("a", [podSeries("a-1", [[100, 1]])])];
+    const den = [app("a", [podSeries("a-2", [[100, 5]])])]; // different pod
     const result = combineRatioSeriesByApp(num, den);
-    expect(result.find((r) => r.app === "b")?.series).toEqual([]);
+    expect(result[0]?.pods[0]).toEqual({ pod: "a-1", series: [] });
   });
 
-  it("drops points with non-finite numerator or denominator values", () => {
+  it("returns an empty pods[] when the denominator app is missing entirely", () => {
+    const num = [app("a", [podSeries("a-1", [[100, 1]])]), app("b", [podSeries("b-1", [[100, 2]])])];
+    const den = [app("a", [podSeries("a-1", [[100, 4]])])];
+    const result = combineRatioSeriesByApp(num, den);
+    expect(result.find((r) => r.app === "b")?.pods[0]).toEqual({ pod: "b-1", series: [] });
+  });
+
+  it("drops points with non-finite numerator or denominator", () => {
     const num = [
-      series("a", [
-        [100, NaN],
-        [110, Infinity],
-        [120, 3],
+      app("a", [
+        podSeries("a-1", [
+          [100, NaN],
+          [110, Infinity],
+          [120, 3],
+        ]),
       ]),
     ];
     const den = [
-      series("a", [
-        [100, 2],
-        [110, 4],
-        [120, 6],
+      app("a", [
+        podSeries("a-1", [
+          [100, 2],
+          [110, 4],
+          [120, 6],
+        ]),
       ]),
     ];
     const result = combineRatioSeriesByApp(num, den);
-    expect(result[0]?.series).toEqual([{ t: 120, v: 50 }]);
+    expect(result[0]?.pods[0]?.series).toEqual([{ t: 120, v: 50 }]);
   });
 
-  it("preserves the order of `numerator`'s apps in the output", () => {
-    const num = [series("c", [[100, 1]]), series("a", [[100, 1]]), series("b", [[100, 1]])];
-    const den = [series("a", [[100, 2]]), series("b", [[100, 2]]), series("c", [[100, 2]])];
+  it("preserves the order of `numerator`'s apps and pods in the output", () => {
+    const num = [
+      app("c", [podSeries("c-2", [[100, 1]]), podSeries("c-1", [[100, 1]])]),
+      app("a", [podSeries("a-1", [[100, 1]])]),
+    ];
+    const den = [
+      app("a", [podSeries("a-1", [[100, 2]])]),
+      app("c", [podSeries("c-1", [[100, 2]]), podSeries("c-2", [[100, 2]])]),
+    ];
     const result = combineRatioSeriesByApp(num, den);
-    expect(result.map((r) => r.app)).toEqual(["c", "a", "b"]);
+    expect(result.map((r) => r.app)).toEqual(["c", "a"]);
+    expect(result[0]?.pods.map((p) => p.pod)).toEqual(["c-2", "c-1"]);
   });
 });

--- a/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.ts
+++ b/packages/trpc/src/routers/prometheus/procedures/getDeploymentMetrics/utils.ts
@@ -1,9 +1,12 @@
 import {
   podLabels,
   podPhaseSchema,
+  sortByName,
+  POD_LABEL_APP_INSTANCE,
   type PromQLMatrixResponse,
   type PromQLVectorResponse,
   type MetricSeriesByApp,
+  type MetricSeriesByPod,
   type PodPhaseByApp,
   type PodPhase,
 } from "@my-project/shared";
@@ -42,12 +45,10 @@ export function groupPodsByApp(pods: PodLike[], apps: string[]): Map<string, str
   return result;
 }
 
-interface BuildQueriesParams {
+interface BuildRangeQueriesParams {
   namespace: string;
-  podNames: string[];
-}
-
-interface BuildRangeQueriesParams extends BuildQueriesParams {
+  /** RFC-1123-constrained app names (validated by Zod at the schema). */
+  applications: string[];
   /**
    * Range-vector window for both `rate()` and `increase()` queries, e.g.
    * "300s". Derive from `deriveRateWindow(step)`. Restart/OOM `increase()`
@@ -79,90 +80,189 @@ export const RANGE_METRIC_KEYS = [
 
 export type RangeMetricKey = (typeof RANGE_METRIC_KEYS)[number];
 
-function buildPodRegex(podNames: string[]): string {
-  return `^(${podNames.map(escapeRegex).join("|")})$`;
+function buildRegexAlternation(values: string[]): string {
+  return `^(${values.map(escapeRegex).join("|")})$`;
 }
 
 /**
- * Build every range-query PromQL string the dashboard needs. Only `namespace`
- * and `podNames` are interpolated; everything else is fixed text. `namespace`
- * is already validated by Zod (RFC-1123). `podNames` are regex-escaped and
- * anchored here.
+ * Build every range-query PromQL string the dashboard needs. Each query
+ * vector-matches against `kube_pod_labels` so the result includes any pod
+ * (current or historical, within KSM retention) whose
+ * `app.kubernetes.io/instance` label matches `applications`. The
+ * `${POD_LABEL_APP_INSTANCE}` label is preserved through the
+ * `group_left(...)` clause so each output series carries both `pod` and
+ * the app it belonged to.
  *
- * Precondition: callers must not pass an empty `podNames` array (the resulting
- * `pod=~""` selector matches nothing). The procedure handler short-circuits
- * before calling this util when zero pods match.
+ * `namespace` and `applications` are validated by Zod (RFC-1123) at the
+ * tRPC boundary; `applications` are additionally regex-escaped here.
+ *
+ * Precondition: callers must not pass an empty `applications` array.
+ * Only use when `kube_pod_labels` is confirmed available — see
+ * `buildPodNamePromQLQueries` for the fallback.
  */
 export function buildPromQLQueries({
   namespace,
-  podNames,
+  applications,
   lookbackWindow,
 }: BuildRangeQueriesParams): Record<RangeMetricKey, string> {
-  const podRegex = buildPodRegex(podNames);
-  const base = `namespace="${namespace}", pod=~"${podRegex}"`;
-  const sel = `${base}, container!="", container!="POD"`;
+  // `namespace` goes only into PromQL equality matchers (`namespace="…"`).
+  // Zod's RFC-1123 regex constrains it to `[a-z0-9-]`, none of which are
+  // metacharacters in a double-quoted PromQL string, so no escaping is
+  // required. `applications` below DO need `escapeRegex()` because they
+  // are placed into a `=~` regex matcher.
+  const baseSel = `namespace="${namespace}"`;
+  const containerSel = `${baseSel}, container!="", container!="POD"`;
+  const join = `* on (namespace, pod) group_left(${POD_LABEL_APP_INSTANCE}) kube_pod_labels{namespace="${namespace}", ${POD_LABEL_APP_INSTANCE}=~"${buildRegexAlternation(applications)}"}`;
+  const wrap = (inner: string): string => `sum by (pod, ${POD_LABEL_APP_INSTANCE}) (${inner} ${join})`;
 
   return {
-    cpu: `sum by (pod) (rate(container_cpu_usage_seconds_total{${sel}}[${lookbackWindow}]))`,
-    memory: `sum by (pod) (container_memory_working_set_bytes{${sel}})`,
-    memoryRss: `sum by (pod) (container_memory_rss{${sel}})`,
-    memoryCache: `sum by (pod) (container_memory_cache{${sel}})`,
-    restarts: `sum by (pod) (increase(kube_pod_container_status_restarts_total{${base}}[${lookbackWindow}]))`,
-    networkRx: `sum by (pod) (rate(container_network_receive_bytes_total{${base}}[${lookbackWindow}]))`,
-    networkTx: `sum by (pod) (rate(container_network_transmit_bytes_total{${base}}[${lookbackWindow}]))`,
-    diskReadBytes: `sum by (pod) (rate(container_fs_reads_bytes_total{${sel}}[${lookbackWindow}]))`,
-    diskWriteBytes: `sum by (pod) (rate(container_fs_writes_bytes_total{${sel}}[${lookbackWindow}]))`,
-    oomEvents: `sum by (pod) (increase(container_oom_events_total{${base}}[${lookbackWindow}]))`,
-    cpuRequests: `sum by (pod) (kube_pod_container_resource_requests{${base}, resource="cpu"})`,
-    cpuLimits: `sum by (pod) (kube_pod_container_resource_limits{${base}, resource="cpu"})`,
-    memoryRequests: `sum by (pod) (kube_pod_container_resource_requests{${base}, resource="memory"})`,
-    memoryLimits: `sum by (pod) (kube_pod_container_resource_limits{${base}, resource="memory"})`,
-    cpuThrottledPeriods: `sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{${sel}}[${lookbackWindow}]))`,
-    cpuPeriods: `sum by (pod) (rate(container_cpu_cfs_periods_total{${sel}}[${lookbackWindow}]))`,
+    cpu: wrap(`rate(container_cpu_usage_seconds_total{${containerSel}}[${lookbackWindow}])`),
+    memory: wrap(`container_memory_working_set_bytes{${containerSel}}`),
+    memoryRss: wrap(`container_memory_rss{${containerSel}}`),
+    memoryCache: wrap(`container_memory_cache{${containerSel}}`),
+    restarts: wrap(`increase(kube_pod_container_status_restarts_total{${baseSel}}[${lookbackWindow}])`),
+    networkRx: wrap(`rate(container_network_receive_bytes_total{${baseSel}}[${lookbackWindow}])`),
+    networkTx: wrap(`rate(container_network_transmit_bytes_total{${baseSel}}[${lookbackWindow}])`),
+    diskReadBytes: wrap(`rate(container_fs_reads_bytes_total{${containerSel}}[${lookbackWindow}])`),
+    diskWriteBytes: wrap(`rate(container_fs_writes_bytes_total{${containerSel}}[${lookbackWindow}])`),
+    oomEvents: wrap(`increase(container_oom_events_total{${baseSel}}[${lookbackWindow}])`),
+    cpuRequests: wrap(`kube_pod_container_resource_requests{${baseSel}, resource="cpu"}`),
+    cpuLimits: wrap(`kube_pod_container_resource_limits{${baseSel}, resource="cpu"}`),
+    memoryRequests: wrap(`kube_pod_container_resource_requests{${baseSel}, resource="memory"}`),
+    memoryLimits: wrap(`kube_pod_container_resource_limits{${baseSel}, resource="memory"}`),
+    cpuThrottledPeriods: wrap(`rate(container_cpu_cfs_throttled_periods_total{${containerSel}}[${lookbackWindow}])`),
+    cpuPeriods: wrap(`rate(container_cpu_cfs_periods_total{${containerSel}}[${lookbackWindow}])`),
+  };
+}
+
+/**
+ * Fallback query builder for clusters where `kube_pod_labels` is not exposed
+ * by kube-state-metrics (requires `--metric-labels-allowlist` to enable).
+ * Filters by pod names from the live K8s listing instead of joining against
+ * `kube_pod_labels`. Results carry only the `pod` label; use
+ * `matrixToPodSeriesByAppFromMap` to group them by app.
+ *
+ * Precondition: `podNames` must be non-empty.
+ */
+export function buildPodNamePromQLQueries({
+  namespace,
+  podNames,
+  lookbackWindow,
+}: {
+  namespace: string;
+  podNames: string[];
+  lookbackWindow: string;
+}): Record<RangeMetricKey, string> {
+  const podRegex = buildRegexAlternation(podNames);
+  const baseSel = `namespace="${namespace}", pod=~"${podRegex}"`;
+  const containerSel = `${baseSel}, container!="", container!="POD"`;
+  const wrap = (inner: string): string => `sum by (pod) (${inner})`;
+
+  return {
+    cpu: wrap(`rate(container_cpu_usage_seconds_total{${containerSel}}[${lookbackWindow}])`),
+    memory: wrap(`container_memory_working_set_bytes{${containerSel}}`),
+    memoryRss: wrap(`container_memory_rss{${containerSel}}`),
+    memoryCache: wrap(`container_memory_cache{${containerSel}}`),
+    restarts: wrap(`increase(kube_pod_container_status_restarts_total{${baseSel}}[${lookbackWindow}])`),
+    networkRx: wrap(`rate(container_network_receive_bytes_total{${baseSel}}[${lookbackWindow}])`),
+    networkTx: wrap(`rate(container_network_transmit_bytes_total{${baseSel}}[${lookbackWindow}])`),
+    diskReadBytes: wrap(`rate(container_fs_reads_bytes_total{${containerSel}}[${lookbackWindow}])`),
+    diskWriteBytes: wrap(`rate(container_fs_writes_bytes_total{${containerSel}}[${lookbackWindow}])`),
+    oomEvents: wrap(`increase(container_oom_events_total{${baseSel}}[${lookbackWindow}])`),
+    cpuRequests: wrap(`kube_pod_container_resource_requests{${baseSel}, resource="cpu"}`),
+    cpuLimits: wrap(`kube_pod_container_resource_limits{${baseSel}, resource="cpu"}`),
+    memoryRequests: wrap(`kube_pod_container_resource_requests{${baseSel}, resource="memory"}`),
+    memoryLimits: wrap(`kube_pod_container_resource_limits{${baseSel}, resource="memory"}`),
+    cpuThrottledPeriods: wrap(`rate(container_cpu_cfs_throttled_periods_total{${containerSel}}[${lookbackWindow}])`),
+    cpuPeriods: wrap(`rate(container_cpu_cfs_periods_total{${containerSel}}[${lookbackWindow}])`),
   };
 }
 
 /** Build the single instant-query string for current pod phase. */
-export function buildPodPhaseQuery({ namespace, podNames }: BuildQueriesParams): string {
-  const podRegex = buildPodRegex(podNames);
-  return `kube_pod_status_phase{namespace="${namespace}", pod=~"${podRegex}"} == 1`;
+export function buildPodPhaseQuery({ namespace, podNames }: { namespace: string; podNames: string[] }): string {
+  return `kube_pod_status_phase{namespace="${namespace}", pod=~"${buildRegexAlternation(podNames)}"} == 1`;
 }
 
 /**
- * Convert a Prometheus matrix into per-app aggregated series. For each
- * timestamp present in any of an app's pod series, sum the values across that
- * app's pods. Apps with no matched pod series are present in the output with
- * an empty series array. Output order matches `knownApps`.
+ * Convert a Prometheus matrix into per-app, per-pod series. Each input
+ * series is identified by its `pod` label and partitioned by the
+ * `label_app_kubernetes_io_instance` label (see
+ * `POD_LABEL_APP_INSTANCE`). Pods whose app label is not in `knownApps`
+ * are dropped (defensive — the PromQL regex should already restrict
+ * this). Output preserves `knownApps` order; pods within each app are
+ * sorted by name for stable rendering.
  */
-export function matrixToSeriesByApp(
+export function matrixToPodSeriesByApp(matrix: PromQLMatrixResponse, knownApps: string[]): MetricSeriesByApp[] {
+  const perAppPods = new Map<string, Map<string, MetricSeriesByPod["series"]>>();
+  for (const app of knownApps) perAppPods.set(app, new Map());
+
+  for (const row of matrix.data.result) {
+    const podName = row.metric.pod;
+    const app = row.metric[POD_LABEL_APP_INSTANCE];
+    if (!podName || !app) continue;
+    const podMap = perAppPods.get(app);
+    if (!podMap) continue;
+    const points: MetricSeriesByPod["series"] = [];
+    for (const [t, value] of row.values) {
+      if (value === "") continue;
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) continue;
+      points.push({ t, v: numeric });
+    }
+    // Each PromQL query is `sum by (pod, label_app_kubernetes_io_instance)`,
+    // which guarantees one row per (pod, app) tuple. Last-write-wins here
+    // is therefore safe; a duplicate would indicate a Prometheus
+    // correctness bug rather than expected traffic.
+    podMap.set(podName, points);
+  }
+
+  return knownApps.map((app) => {
+    const podMap = perAppPods.get(app)!;
+    const sortedPodNames = [...podMap.keys()].sort(sortByName);
+    return {
+      app,
+      pods: sortedPodNames.map((pod) => ({ pod, series: podMap.get(pod)! })),
+    };
+  });
+}
+
+/**
+ * Fallback counterpart of `matrixToPodSeriesByApp` for clusters where the
+ * `kube_pod_labels` join is not available. Series carry only the `pod` label;
+ * the app is resolved via the live `podToApp` map from the K8s listing.
+ * Pods not present in `podToApp` are dropped.
+ */
+export function matrixToPodSeriesByAppFromMap(
   matrix: PromQLMatrixResponse,
   podToApp: Map<string, string>,
   knownApps: string[]
 ): MetricSeriesByApp[] {
-  const perApp = new Map<string, Map<number, number>>();
-  for (const app of knownApps) perApp.set(app, new Map());
+  const perAppPods = new Map<string, Map<string, MetricSeriesByPod["series"]>>();
+  for (const app of knownApps) perAppPods.set(app, new Map());
 
   for (const row of matrix.data.result) {
     const podName = row.metric.pod;
     if (!podName) continue;
     const app = podToApp.get(podName);
     if (!app) continue;
-    const bucket = perApp.get(app);
-    if (!bucket) continue;
-    for (const [ts, value] of row.values) {
+    const podMap = perAppPods.get(app);
+    if (!podMap) continue;
+    const points: MetricSeriesByPod["series"] = [];
+    for (const [t, value] of row.values) {
       if (value === "") continue;
       const numeric = Number(value);
       if (!Number.isFinite(numeric)) continue;
-      bucket.set(ts, (bucket.get(ts) ?? 0) + numeric);
+      points.push({ t, v: numeric });
     }
+    podMap.set(podName, points);
   }
 
   return knownApps.map((app) => {
-    const bucket = perApp.get(app)!;
-    const sortedTs = [...bucket.keys()].sort((a, b) => a - b);
+    const podMap = perAppPods.get(app)!;
+    const sortedPodNames = [...podMap.keys()].sort(sortByName);
     return {
       app,
-      series: sortedTs.map((t) => ({ t, v: bucket.get(t)! })),
+      pods: sortedPodNames.map((pod) => ({ pod, series: podMap.get(pod)! })),
     };
   });
 }
@@ -174,49 +274,57 @@ function coercePhase(value: string | undefined): PodPhase {
 }
 
 /**
- * Convert a `kube_pod_status_phase{...} == 1` vector into per-app pod-phase
- * lists. Each series has labels `pod` and `phase`; we group by app via the
- * shared podToApp map. Pods present in podToApp but missing from the vector
- * are not added (Prometheus only emits the matching phase).
- */
-/**
- * Combine two per-app series into a per-app ratio series, expressed as a
- * percentage (`100 * num / den`). Designed for "saturation"-style metrics like
- * CPU throttling where summing the underlying counters then dividing is the
- * mathematically correct rollup (you cannot meaningfully average ratios).
- *
- * Output preserves `numerator`'s app order. For each app, the result series
- * contains a point only at timestamps where both numerator and denominator
- * have a finite value AND the denominator is strictly positive. Apps absent
- * from the denominator emit an empty series — mirrors the "no capacity
- * configured → no data" semantic used by the client-side `computeUtilization`
- * helper for stat panels.
+ * Combine two per-pod series into a per-pod ratio series, expressed as a
+ * percentage (`100 * num / den`). For each app in `numerator`, for each
+ * pod, the result emits a point at every timestamp where both numerator
+ * and denominator have a finite value AND the denominator is strictly
+ * positive. Apps and pods missing from the denominator emit empty
+ * series — mirrors the "no capacity configured → no data" semantic
+ * used by the client-side `computeUtilization` helper.
  */
 export function combineRatioSeriesByApp(
   numerator: MetricSeriesByApp[],
   denominator: MetricSeriesByApp[]
 ): MetricSeriesByApp[] {
-  const denByApp = new Map<string, Map<number, number>>();
+  const denByAppPod = new Map<string, Map<string, Map<number, number>>>();
   for (const entry of denominator) {
-    const points = new Map<number, number>();
-    for (const point of entry.series) points.set(point.t, point.v);
-    denByApp.set(entry.app, points);
+    const podMap = new Map<string, Map<number, number>>();
+    for (const pod of entry.pods) {
+      const points = new Map<number, number>();
+      for (const p of pod.series) points.set(p.t, p.v);
+      podMap.set(pod.pod, points);
+    }
+    denByAppPod.set(entry.app, podMap);
   }
 
-  return numerator.map(({ app, series }) => {
-    const denPoints = denByApp.get(app);
-    if (!denPoints || denPoints.size === 0) return { app, series: [] };
-    const points: { t: number; v: number }[] = [];
-    for (const { t, v } of series) {
-      const den = denPoints.get(t);
-      if (den === undefined) continue;
-      if (!Number.isFinite(v) || !Number.isFinite(den) || den <= 0) continue;
-      points.push({ t, v: (100 * v) / den });
-    }
-    return { app, series: points };
+  return numerator.map(({ app, pods }) => {
+    const denPods = denByAppPod.get(app);
+    return {
+      app,
+      pods: pods.map(({ pod, series }) => {
+        const denPoints = denPods?.get(pod);
+        if (!denPoints || denPoints.size === 0) return { pod, series: [] };
+        const out: { t: number; v: number }[] = [];
+        for (const { t, v } of series) {
+          const den = denPoints.get(t);
+          if (den === undefined) continue;
+          if (!Number.isFinite(v) || !Number.isFinite(den) || den <= 0) continue;
+          out.push({ t, v: (100 * v) / den });
+        }
+        return { pod, series: out };
+      }),
+    };
   });
 }
 
+/**
+ * Convert a `kube_pod_status_phase{...} == 1` vector into per-app pod-phase
+ * lists. Each series has labels `pod` and `phase`; we group by app via the
+ * shared podToApp map (built from the live K8s pod list, since podPhase is
+ * intrinsically about currently running pods). Pods present in podToApp
+ * but missing from the vector are not added (Prometheus only emits the
+ * matching phase).
+ */
 export function vectorToPodPhaseByApp(
   vector: PromQLVectorResponse,
   podToApp: Map<string, string>,


### PR DESCRIPTION
Rework the Stage Monitoring tab to render one chart line per pod (matching the kubernetes-mixin Grafana dashboard) and to include historical pods — pods garbage-collected from the K8s API but still inside Prometheus retention — that the previous K8s-pod-list-driven query was hiding.
