### PR TITLE
EPMDEDP-16749: fix: Prevent K8s watch reconnect storm on stale resourceVersion

### DIFF
--- a/apps/client/src/k8s/api/hooks/useWatch/types.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/types.ts
@@ -63,13 +63,13 @@ export interface WatchListMultipleData<I extends KubeObjectBase> {
 
 export interface UseWatchListMultipleResult<I extends KubeObjectBase> {
   data: WatchListMultipleData<I>;
-  queries: UseQueryResult<CustomKubeObjectList<I>, RequestError>[]; // individual namespace queries
-  query: UseQueryResult<WatchListMultipleData<I>, RequestError>; // Combined query for consistency
-  dataVersion: string | undefined; // combined version for cache invalidation
+  queries: UseQueryResult<CustomKubeObjectList<I>, RequestError>[];
+  query: UseQueryResult<WatchListMultipleData<I>, RequestError>;
+  dataVersion: string | undefined;
   errors: RequestError[];
   isEmpty: boolean;
-  isLoading: boolean; // True when ANY namespace query is pending (no cached data)
-  isReady: boolean; // True when ALL namespace queries are successful
+  isLoading: boolean;
+  isReady: boolean;
 }
 
 // ============================================================================

--- a/apps/client/src/k8s/api/hooks/useWatch/useWatchListMultiple/index.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/useWatchListMultiple/index.ts
@@ -118,13 +118,7 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
     })),
   }) as UseQueryResult<CustomKubeObjectList<I>, RequestError>[];
 
-  // Stable references for dependency tracking
-  // Note: We intentionally do NOT include resourceVersion in querySuccessStates.
-  // Kubernetes Watch continues from the initial resourceVersion automatically.
-  // Restarting subscriptions on every resourceVersion change causes excessive start/stop cycles.
-  const querySuccessStates = namespaceQueries
-    .map((q) => `${q.isSuccess}-${q.data?.metadata?.resourceVersion}`)
-    .join(",");
+  const querySuccessStates = namespaceQueries.map((q) => q.isSuccess).join(",");
   const namespaceQueryKeysKey = namespaceQueryKeys.map((k) => JSON.stringify(k)).join(",");
 
   // Stable event handler using useEffectEvent
@@ -231,9 +225,6 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
   // Stable reference for error states
   const errorStatesKey = namespaceQueries.map((q) => q.isError).join(",");
 
-  // Stable reference for success states to track when queries complete
-  const successStatesKey = namespaceQueries.map((q) => q.isSuccess).join(",");
-
   // Create a real useQuery that will hold the combined data
   const combinedQuery = useQuery<WatchListMultipleData<I>, RequestError>({
     queryKey: combinedQueryKey,
@@ -249,6 +240,10 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
     gcTime: queryOptions?.gcTime,
     staleTime: queryOptions?.staleTime,
   });
+
+  const dataVersion = useMemo(() => {
+    return namespaceQueries.map((q) => q.data?.metadata?.resourceVersion).join(",");
+  }, [namespaceQueries]);
 
   // Update combined query data whenever namespace queries change
   useEffect(() => {
@@ -287,12 +282,7 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
     // Manually update the query data
     queryClient.setQueryData<WatchListMultipleData<I>>(combinedQueryKey, combinedData);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namespacesKey, querySuccessStates, successStatesKey, errorStatesKey]);
-
-  // Calculate dataVersion (max resourceVersion across all namespaces)
-  const dataVersion = useMemo(() => {
-    return namespaceQueries.map((q) => q.data?.metadata?.resourceVersion).join(",");
-  }, [namespaceQueries]);
+  }, [namespacesKey, dataVersion, errorStatesKey]);
 
   // Derive errors map
   const errors = useMemo(() => {

--- a/apps/server/src/config/development/index.ts
+++ b/apps/server/src/config/development/index.ts
@@ -135,7 +135,7 @@ export class LocalFastifyServer {
             });
           },
           // keepAlive must be inside trpcOptions — the Fastify adapter reads it from here at runtime.
-          keepAlive: { enabled: true, pingMs: 15000, pongWaitMs: 10000 },
+          keepAlive: { enabled: true, pingMs: 30000, pongWaitMs: 90000 },
         } as FastifyTRPCPluginOptions<AppRouter>["trpcOptions"],
       });
     });

--- a/packages/trpc/src/routers/k8s/utils/createK8sWatchSubscription/index.ts
+++ b/packages/trpc/src/routers/k8s/utils/createK8sWatchSubscription/index.ts
@@ -57,6 +57,16 @@ export async function* createK8sWatchSubscription(
         watchUrl,
         { ...watchOptions, resourceVersion: currentResourceVersion },
         (type, obj: KubeObjectBase) => {
+          if (type === "ERROR") {
+            // 410 Gone arrives as both an ERROR-type watch event and the done callback.
+            // Handle it here so ERROR frames never reach subscribers and receivedEvents
+            // stays false, keeping the backoff active on the next restart attempt.
+            if ((obj as { code?: number }).code === 410) {
+              currentResourceVersion = "";
+            }
+            queue.abort();
+            return;
+          }
           receivedEvents = true;
           if (obj?.metadata?.resourceVersion) {
             currentResourceVersion = obj.metadata.resourceVersion;
@@ -67,18 +77,12 @@ export async function* createK8sWatchSubscription(
           if (err) {
             const statusCode = (err as { statusCode?: number }).statusCode ?? (err as { code?: number }).code;
             if (statusCode === 410) {
-              // 410 Gone — resourceVersion expired (etcd compaction).
-              // Reset to "" so the next watch starts from current state.
-              // Matches @kubernetes/client-node ListWatch and client-go Reflector patterns.
               currentResourceVersion = "";
               queue.abort();
             } else {
               queue.emitError(err);
             }
           } else {
-            // Clean termination (K8s API server watch timeout).
-            // Abort the queue so yieldEvents returns normally,
-            // allowing the outer loop to restart the watch.
             queue.abort();
           }
         }


### PR DESCRIPTION
Watch subscriptions could enter a tight reconnect loop on K8s API "too old resource version" (410 Expired) errors, producing sustained multi-Mb/s traffic and hundreds of error frames per second on the portal WebSocket whenever a detail page (CDPipeline, Stage, Codebase) was opened against cached state older than etcd's compaction window.

Two issues combined to cause the storm:
- The client passed a cached resourceVersion (taken from TanStack Query) when starting a watch. On low-churn resources the cursor could sit in cache long enough to predate compaction.
- The server-side watch util only handled 410 from the HTTP error channel; in-stream ERROR events (kind=Status, code=410, reason=Expired) were forwarded to clients verbatim and the same stale cursor was used on every reconnect.

The client now always starts watches from the current cluster state. The server recognizes the in-stream Expired event, resets the cursor, and triggers a clean relist instead of looping. ERROR events no longer defeat the empty-restart backoff.
