### PR TITLE
EPMDEDP-16688: fix: Preserve pod template and task scheduling config in pipeline rerun

### DIFF
--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/schema.ts
@@ -414,6 +414,11 @@ export const pipelineRunSpecStatusEnum = z.enum([
   "PipelineRunPending",
 ]);
 
+const taskRunTemplateSchema = z.object({
+  serviceAccountName: z.string().optional(),
+  podTemplate: podTemplateSchema.optional(),
+});
+
 const specSchema = z.object({
   params: z.array(paramSchema).optional(),
   pipelineRef: pipelineRefSchema.optional(),
@@ -423,6 +428,7 @@ const specSchema = z.object({
   serviceAccountName: z.string().optional(),
   status: pipelineRunSpecStatusEnum.optional(),
   taskRunSpecs: z.array(taskRunSpecSchema).optional(),
+  taskRunTemplate: taskRunTemplateSchema.optional(),
   timeout: z.string().optional(),
   timeouts: z
     .object({

--- a/packages/shared/src/models/tektonResults/adapters.test.ts
+++ b/packages/shared/src/models/tektonResults/adapters.test.ts
@@ -303,6 +303,55 @@ describe("normalizeHistoryPipelineRun", () => {
     expect(result.spec.params).toHaveLength(2);
   });
 
+  it("should preserve scheduling/timeout spec fields needed for rerun signature", () => {
+    const decoded: DecodedPipelineRun = {
+      ...mockDecodedPipelineRun,
+      spec: {
+        ...mockDecodedPipelineRun.spec,
+        podTemplate: {
+          nodeSelector: { "kubernetes.io/os": "linux" },
+        },
+        taskRunTemplate: {
+          serviceAccountName: "tekton",
+          podTemplate: {
+            tolerations: [{ effect: "NoSchedule", key: "workload", operator: "Equal", value: "tekton" }],
+          },
+        },
+        taskRunSpecs: [
+          {
+            pipelineTaskName: "sonar",
+            serviceAccountName: "sonar-sa",
+            podTemplate: { nodeSelector: { "node-type": "sonar" } },
+          },
+        ],
+        timeouts: { pipeline: "1h0m0s", tasks: "30m", finally: "5m" },
+      },
+    };
+
+    const result = normalizeHistoryPipelineRun(decoded);
+
+    expect(result.spec.podTemplate?.nodeSelector?.["kubernetes.io/os"]).toBe("linux");
+
+    expect(result.spec.taskRunTemplate?.serviceAccountName).toBe("tekton");
+    expect(result.spec.taskRunTemplate?.podTemplate?.tolerations).toHaveLength(1);
+    expect(result.spec.taskRunTemplate?.podTemplate?.tolerations?.[0]?.key).toBe("workload");
+
+    expect(result.spec.taskRunSpecs).toHaveLength(1);
+    expect(result.spec.taskRunSpecs?.[0]?.pipelineTaskName).toBe("sonar");
+    // taskRunSpecs entry passes through by reference; runtime field names follow Tekton v1
+    // (serviceAccountName/podTemplate), not the stale v1beta1 names in taskRunSpecSchema.
+    const taskRunSpecRuntime = result.spec.taskRunSpecs?.[0] as unknown as {
+      serviceAccountName?: string;
+      podTemplate?: { nodeSelector?: Record<string, string> };
+    };
+    expect(taskRunSpecRuntime.serviceAccountName).toBe("sonar-sa");
+    expect(taskRunSpecRuntime.podTemplate?.nodeSelector?.["node-type"]).toBe("sonar");
+
+    expect(result.spec.timeouts?.pipeline).toBe("1h0m0s");
+    expect(result.spec.timeouts?.tasks).toBe("30m");
+    expect(result.spec.timeouts?.finally).toBe("5m");
+  });
+
   it("should preserve spec.pipelineSpec for archived inline pipelines", () => {
     const decoded: DecodedPipelineRun = {
       ...mockDecodedPipelineRun,

--- a/packages/shared/src/models/tektonResults/adapters.ts
+++ b/packages/shared/src/models/tektonResults/adapters.ts
@@ -63,7 +63,11 @@ export function normalizeHistoryPipelineRun(decoded: DecodedPipelineRun): Pipeli
       params: decoded.spec.params,
       workspaces: decoded.spec.workspaces,
       serviceAccountName: decoded.spec.serviceAccountName,
+      podTemplate: decoded.spec.podTemplate,
+      taskRunTemplate: decoded.spec.taskRunTemplate,
+      taskRunSpecs: decoded.spec.taskRunSpecs,
       timeout: decoded.spec.timeout,
+      timeouts: decoded.spec.timeouts,
     },
     status: decoded.status
       ? {

--- a/packages/shared/src/models/tektonResults/types.ts
+++ b/packages/shared/src/models/tektonResults/types.ts
@@ -129,6 +129,30 @@ export interface DecodedPipelineSpec {
   workspaces?: Array<{ name: string; optional?: boolean }>;
 }
 
+export interface DecodedPodTemplate {
+  affinity?: unknown;
+  tolerations?: unknown;
+  nodeSelector?: Record<string, string>;
+  securityContext?: unknown;
+  imagePullSecrets?: Array<{ name: string }>;
+  env?: unknown;
+  volumes?: unknown;
+  schedulerName?: string;
+  hostNetwork?: boolean;
+  priorityClassName?: string;
+}
+
+export interface DecodedTaskRunTemplate {
+  serviceAccountName?: string;
+  podTemplate?: DecodedPodTemplate;
+}
+
+export interface DecodedTaskRunSpec {
+  pipelineTaskName?: string;
+  serviceAccountName?: string;
+  podTemplate?: DecodedPodTemplate;
+}
+
 // PipelineRun spec
 export interface DecodedPipelineRunSpec {
   pipelineRef?: { name: string };
@@ -137,7 +161,10 @@ export interface DecodedPipelineRunSpec {
   workspaces?: Array<{ name: string; [key: string]: unknown }>;
   serviceAccountName?: string;
   timeout?: string;
-  taskRunTemplate?: { serviceAccountName?: string };
+  timeouts?: { pipeline?: string; tasks?: string; finally?: string };
+  podTemplate?: DecodedPodTemplate;
+  taskRunTemplate?: DecodedTaskRunTemplate;
+  taskRunSpecs?: DecodedTaskRunSpec[];
 }
 
 // Full decoded PipelineRun structure


### PR DESCRIPTION
Add DecodedPodTemplate, DecodedTaskRunTemplate, and DecodedTaskRunSpec types to capture Tekton pipeline scheduling configuration (affinity, tolerations, nodeSelector, serviceAccountName, podTemplate) and timeout settings.

Update normalizeHistoryPipelineRun adapter to pass through podTemplate, taskRunTemplate, taskRunSpecs, and timeouts from history records. This ensures that when reruns are triggered, they retain the original pipeline's scheduling constraints and timeout configuration, preserving the full rerun signature.

Add comprehensive test to verify all four spec-level scheduling fields pass through the normalization boundary correctly.

