### PR TITLE
feat: Add PipelineRun trigger endpoint with CLI parameter support

### DIFF
--- a/apps/server/src/config/openapi.pipelineRun.test.ts
+++ b/apps/server/src/config/openapi.pipelineRun.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { TRPCError } from "@trpc/server";
+import type { DBSessionStore } from "@/clients/db-session-store/index.js";
+import { createMockedDBSessionStore } from "@my-project/trpc/__mocks__/context.js";
+import { mockSession } from "@my-project/trpc/__mocks__/session.js";
+import type { CustomSession } from "@my-project/trpc";
+
+const stubCaller = vi.hoisted(() => ({
+  pipelineRun: {
+    start: vi.fn(),
+  },
+}));
+
+vi.mock("@my-project/trpc", async (importActual) => {
+  const actual = await importActual<typeof import("@my-project/trpc")>();
+  return {
+    ...actual,
+    createContext: vi.fn().mockReturnValue({}),
+    createCaller: vi.fn().mockReturnValue(stubCaller),
+  };
+});
+
+import { registerOpenApi } from "./openapi.js";
+
+const MOCK_SESSION_STORE = createMockedDBSessionStore(
+  mockSession as unknown as CustomSession
+) as unknown as DBSessionStore;
+
+const MOCK_OIDC_CONFIG = {
+  issuerURL: "https://oidc.example.com",
+  clientID: "client-id",
+  clientSecret: "client-secret",
+  scope: "openid",
+  codeChallengeMethod: "S256",
+};
+
+function buildFastify(): FastifyInstance {
+  const app = Fastify({ logger: false });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.decorateRequest("session", null as any);
+
+  registerOpenApi(app, {
+    sessionStore: MOCK_SESSION_STORE,
+    oidcConfig: MOCK_OIDC_CONFIG,
+    portalUrl: "http://localhost:8000",
+  });
+
+  return app;
+}
+
+const BASE_PAYLOAD = {
+  namespace: "edp",
+  pipeline: "foo-build",
+};
+
+describe("POST /rest/v1/pipelineruns/start", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = buildFastify();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("happy path — forwards body to caller.pipelineRun.start and returns created row", async () => {
+    stubCaller.pipelineRun.start.mockResolvedValue({
+      kind: "created",
+      row: {
+        name: "foo-build-run-x9k2p",
+        status: "Pending",
+        project: "my-app",
+        pr: "",
+        author: "",
+        type: "build",
+        started: "",
+        duration: "",
+      },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/rest/v1/pipelineruns/start",
+      payload: {
+        ...BASE_PAYLOAD,
+        params: { "git-revision": "main" },
+        labels: { "app.edp.epam.com/codebase": "my-app" },
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ kind: string; row: { name: string } }>();
+    expect(body.kind).toBe("created");
+    expect(body.row.name).toBe("foo-build-run-x9k2p");
+    expect(stubCaller.pipelineRun.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pipeline: "foo-build",
+        params: { "git-revision": "main" },
+      })
+    );
+  });
+
+  it("dry-run path — forwards dryRun=true and returns manifest", async () => {
+    stubCaller.pipelineRun.start.mockResolvedValue({
+      kind: "dryRun",
+      manifest: { apiVersion: "tekton.dev/v1", kind: "PipelineRun" },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/rest/v1/pipelineruns/start",
+      payload: { ...BASE_PAYLOAD, dryRun: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      kind: string;
+      manifest: Record<string, unknown>;
+    }>();
+    expect(body.kind).toBe("dryRun");
+    expect(body.manifest.kind).toBe("PipelineRun");
+    expect(body.manifest.apiVersion).toBe("tekton.dev/v1");
+  });
+
+  it("Pipeline NOT_FOUND surfaces reason but never the verbatim message", async () => {
+    stubCaller.pipelineRun.start.mockRejectedValue(
+      new TRPCError({
+        code: "NOT_FOUND",
+        message: "pipeline 'ghost' not found",
+        cause: { source: "k8s", reason: "pipeline_not_found" },
+      })
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/rest/v1/pipelineruns/start",
+      payload: { ...BASE_PAYLOAD, pipeline: "ghost" },
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{
+      error: { code: string; reason?: string; message: string };
+    }>();
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.error.reason).toBe("pipeline_not_found");
+    expect(body.error.message).toBe("Not Found");
+    // Regression: the verbatim message — including the pipeline name — must
+    // never reach the wire.
+    expect(res.body).not.toContain("ghost");
+  });
+
+  it("TriggerTemplate NOT_FOUND surfaces trigger_template_not_found reason", async () => {
+    stubCaller.pipelineRun.start.mockRejectedValue(
+      new TRPCError({
+        code: "NOT_FOUND",
+        message:
+          "pipeline 'foo-build' references TriggerTemplate 'foo-tt' which does not exist",
+        cause: { source: "k8s", reason: "trigger_template_not_found" },
+      })
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/rest/v1/pipelineruns/start",
+      payload: { ...BASE_PAYLOAD },
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{
+      error: { code: string; reason?: string; message: string };
+    }>();
+    expect(body.error.reason).toBe("trigger_template_not_found");
+    expect(body.error.message).toBe("Not Found");
+    expect(res.body).not.toContain("foo-tt");
+  });
+
+  it("malformed TT label — BAD_REQUEST surfaces malformed_trigger_template_label reason", async () => {
+    stubCaller.pipelineRun.start.mockRejectedValue(
+      new TRPCError({
+        code: "BAD_REQUEST",
+        message: "pipeline 'foo-build' has malformed TriggerTemplate label",
+        cause: {
+          source: "validation",
+          reason: "malformed_trigger_template_label",
+        },
+      })
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/rest/v1/pipelineruns/start",
+      payload: { ...BASE_PAYLOAD },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ error: { code: string; reason?: string } }>();
+    expect(body.error.reason).toBe("malformed_trigger_template_label");
+  });
+
+  it("error response omits reason when cause does not provide one", async () => {
+    stubCaller.pipelineRun.start.mockRejectedValue(
+      new TRPCError({ code: "NOT_FOUND", message: "internal detail" })
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/rest/v1/pipelineruns/start",
+      payload: { ...BASE_PAYLOAD, pipeline: "ghost" },
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{
+      error: { code: string; reason?: string; message: string };
+    }>();
+    expect(body.error.reason).toBeUndefined();
+    expect(body.error.message).toBe("Not Found");
+    expect(res.body).not.toContain("internal detail");
+  });
+
+  it("RBAC denied — TRPCError FORBIDDEN → HTTP 403", async () => {
+    stubCaller.pipelineRun.start.mockRejectedValue(
+      new TRPCError({ code: "FORBIDDEN", message: "permission denied" })
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/rest/v1/pipelineruns/start",
+      payload: { ...BASE_PAYLOAD },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("upstream failure — TRPCError INTERNAL_SERVER_ERROR → HTTP 500", async () => {
+    stubCaller.pipelineRun.start.mockRejectedValue(
+      new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "boom" })
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/rest/v1/pipelineruns/start",
+      payload: { ...BASE_PAYLOAD },
+    });
+
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/apps/server/src/config/openapi.ts
+++ b/apps/server/src/config/openapi.ts
@@ -98,6 +98,11 @@ export function registerOpenApi(
    * tRPC errors (e.g. UNAUTHORIZED would surface as HTTP 500 instead of 401).
    * TODO: this helper can be deleted once fastifyTRPCOpenApiPlugin handles
    * error mapping natively.
+   *
+   * If a procedure attaches `cause.reason` (a stable, machine-readable tag),
+   * it is surfaced verbatim so REST clients can disambiguate same-status
+   * errors without parsing the human message. The verbatim `error.message`
+   * is never exposed.
    */
   function handleTRPCError(error: unknown, res: FastifyReply): never {
     if (error instanceof TRPCError) {
@@ -106,9 +111,18 @@ export function registerOpenApi(
       // `code` is a tRPC enum literal (e.g. "UNAUTHORIZED"); `message` is the HTTP status phrase.
       const code: string = error.code;
       const message = STATUS_CODES[httpStatus] ?? "Unknown error";
-      res.status(httpStatus).send({ error: { code, message } });
+      const reason = extractCauseReason(error.cause);
+      res.status(httpStatus).send({
+        error: reason ? { code, reason, message } : { code, message },
+      });
     }
     throw error;
+  }
+
+  function extractCauseReason(cause: unknown): string | undefined {
+    if (typeof cause !== "object" || cause === null) return undefined;
+    const value = (cause as { reason?: unknown }).reason;
+    return typeof value === "string" ? value : undefined;
   }
 
   // ---------------------------------------------------------------------------
@@ -159,6 +173,23 @@ export function registerOpenApi(
       try {
         const caller = await buildCaller(req, res);
         return await caller.k8s.get(req.body);
+      } catch (error) {
+        return handleTRPCError(error, res);
+      }
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // PipelineRun
+  // ---------------------------------------------------------------------------
+
+  // POST /rest/v1/pipelineruns/start (protected)
+  fastify.post<{ Body: RouterInput["pipelineRun"]["start"] }>(
+    "/rest/v1/pipelineruns/start",
+    async (req, res) => {
+      try {
+        const caller = await buildCaller(req, res);
+        return await caller.pipelineRun.start(req.body);
       } catch (error) {
         return handleTRPCError(error, res);
       }

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/labels.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/labels.ts
@@ -7,4 +7,6 @@ export const pipelineRunLabels = {
   cdPipeline: "app.edp.epam.com/cdpipeline",
   stage: "app.edp.epam.com/stage",
   cdStage: "app.edp.epam.com/cdstage",
+  changeNumber: "app.edp.epam.com/changenumber",
+  gitAuthor: "app.edp.epam.com/gitauthor",
 } as const;

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.test.ts
@@ -99,4 +99,384 @@ describe("testing createPipelineRunDraftFromPipeline", () => {
       },
     });
   });
+
+  it("TT path: resolves $(tt.params.*) string placeholders to Pipeline defaults", () => {
+    const triggerTemplate = {
+      spec: {
+        resourcetemplates: [
+          {
+            metadata: {},
+            spec: {
+              pipelineRef: { name: "old-name" },
+              params: [
+                { name: "git-source-url", value: "$(tt.params.git-source-url)" },
+                { name: "git-source-revision", value: "$(tt.params.git-source-revision)" },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const pipeline = {
+      metadata: { name: "my-pipeline" },
+      spec: {
+        params: [
+          { name: "git-source-url", type: "string", default: "https://github.com/example/repo.git" },
+          { name: "git-source-revision", type: "string", default: "main" },
+        ],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      triggerTemplate as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    expect(result.spec.params).toEqual([
+      { name: "git-source-url", value: "https://github.com/example/repo.git" },
+      { name: "git-source-revision", value: "main" },
+    ]);
+  });
+
+  it("TT path: resolves $(tt.params.*) array placeholder to [] when Pipeline param has no default", () => {
+    const triggerTemplate = {
+      spec: {
+        resourcetemplates: [
+          {
+            metadata: {},
+            spec: {
+              pipelineRef: { name: "image-scan-remote" },
+              params: [
+                { name: "IMAGE_NAMES", value: "$(tt.params.IMAGE_NAMES)" },
+                { name: "CODEBASE_NAME", value: "$(tt.params.CODEBASE_NAME)" },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const pipeline = {
+      metadata: { name: "image-scan-remote" },
+      spec: {
+        params: [
+          { name: "IMAGE_NAMES", type: "array" },
+          { name: "CODEBASE_NAME", type: "string" },
+        ],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      triggerTemplate as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    expect(result.spec.params).toEqual([
+      { name: "IMAGE_NAMES", value: [] },
+      { name: "CODEBASE_NAME", value: "" },
+    ]);
+  });
+
+  it("TT path: uses Pipeline array default when present", () => {
+    const triggerTemplate = {
+      spec: {
+        resourcetemplates: [
+          {
+            metadata: {},
+            spec: {
+              pipelineRef: { name: "my-pipeline" },
+              params: [{ name: "TAGS", value: "$(tt.params.TAGS)" }],
+            },
+          },
+        ],
+      },
+    };
+    const pipeline = {
+      metadata: { name: "my-pipeline" },
+      spec: {
+        params: [{ name: "TAGS", type: "array", default: ["latest", "stable"] }],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      triggerTemplate as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    expect(result.spec.params).toEqual([{ name: "TAGS", value: ["latest", "stable"] }]);
+  });
+
+  it("TT path: resolves $(tt.params.*) in metadata.labels (K8s rejects $ and () in label values)", () => {
+    const triggerTemplate = {
+      spec: {
+        resourcetemplates: [
+          {
+            metadata: {
+              generateName: "deploy-ansible-run-",
+              labels: {
+                "app.edp.epam.com/cdpipeline": "$(tt.params.CDPIPELINE)",
+                "app.edp.epam.com/cdstage": "$(tt.params.CDSTAGE)",
+                "app.edp.epam.com/pipelinetype": "deploy",
+              },
+            },
+            spec: {
+              pipelineRef: { name: "deploy-ansible" },
+              params: [
+                { name: "CDPIPELINE", value: "$(tt.params.CDPIPELINE)" },
+                { name: "CDSTAGE", value: "$(tt.params.CDSTAGE)" },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const pipeline = {
+      metadata: { name: "deploy-ansible" },
+      spec: {
+        params: [
+          { name: "CDPIPELINE", type: "string" },
+          { name: "CDSTAGE", type: "string", default: "dev" },
+        ],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      triggerTemplate as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    // Labels must not contain $() — K8s returns 422 for those characters.
+    expect(result.metadata.labels?.["app.edp.epam.com/cdpipeline"]).toBe("");
+    expect(result.metadata.labels?.["app.edp.epam.com/cdstage"]).toBe("dev");
+    // Non-placeholder label passes through unchanged.
+    expect(result.metadata.labels?.["app.edp.epam.com/pipelinetype"]).toBe("deploy");
+    // spec.params are also resolved correctly.
+    expect(result.spec.params).toEqual([
+      { name: "CDPIPELINE", value: "" },
+      { name: "CDSTAGE", value: "dev" },
+    ]);
+  });
+
+  it('TT path: array param gets [] in spec.params even after string pass set it to ""', () => {
+    const triggerTemplate = {
+      spec: {
+        resourcetemplates: [
+          {
+            metadata: {
+              labels: { "app.edp.epam.com/images": "$(tt.params.IMAGE_NAMES)" },
+            },
+            spec: {
+              pipelineRef: { name: "image-scan" },
+              params: [{ name: "IMAGE_NAMES", value: "$(tt.params.IMAGE_NAMES)" }],
+            },
+          },
+        ],
+      },
+    };
+    const pipeline = {
+      metadata: { name: "image-scan" },
+      spec: {
+        params: [{ name: "IMAGE_NAMES", type: "array" }],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      triggerTemplate as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    // In spec.params the array param must be [] (not "").
+    expect(result.spec.params).toEqual([{ name: "IMAGE_NAMES", value: [] }]);
+    // In the label (string context) it stays "".
+    expect(result.metadata.labels?.["app.edp.epam.com/images"]).toBe("");
+  });
+
+  it("TT path: resolves composite $(tt.params.*) label values like $(tt.params.A)-$(tt.params.B)", () => {
+    const triggerTemplate = {
+      spec: {
+        resourcetemplates: [
+          {
+            metadata: {
+              labels: {
+                "app.edp.epam.com/cdstage": "$(tt.params.CDPIPELINE)-$(tt.params.CDSTAGE)",
+                "app.edp.epam.com/pipelinetype": "deploy",
+              },
+            },
+            spec: {
+              pipelineRef: { name: "deploy-ansible" },
+              params: [],
+            },
+          },
+        ],
+      },
+    };
+    const pipeline = {
+      metadata: { name: "deploy-ansible" },
+      spec: {
+        params: [
+          { name: "CDPIPELINE", type: "string", default: "my-pipeline" },
+          { name: "CDSTAGE", type: "string", default: "dev" },
+        ],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      triggerTemplate as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    // Composite placeholder is interpolated — no forbidden characters remain.
+    expect(result.metadata.labels?.["app.edp.epam.com/cdstage"]).toBe("my-pipeline-dev");
+    // Non-placeholder label is unchanged.
+    expect(result.metadata.labels?.["app.edp.epam.com/pipelinetype"]).toBe("deploy");
+  });
+
+  it("TT path: composite label resolving to '-' (no defaults) is sanitized to ''", () => {
+    const triggerTemplate = {
+      spec: {
+        resourcetemplates: [
+          {
+            metadata: {
+              labels: {
+                "app.edp.epam.com/cdstage": "$(tt.params.CDPIPELINE)-$(tt.params.CDSTAGE)",
+                "app.edp.epam.com/pipelinetype": "deploy",
+              },
+            },
+            spec: { pipelineRef: { name: "deploy-ansible" }, params: [] },
+          },
+        ],
+      },
+    };
+    const pipeline = {
+      metadata: { name: "deploy-ansible" },
+      spec: {
+        // Neither param has a default → both resolve to "" → composite is "-"
+        params: [
+          { name: "CDPIPELINE", type: "string" },
+          { name: "CDSTAGE", type: "string" },
+        ],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      triggerTemplate as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    // "-" is not a valid K8s label value — must be sanitized to "".
+    expect(result.metadata.labels?.["app.edp.epam.com/cdstage"]).toBe("");
+    expect(result.metadata.labels?.["app.edp.epam.com/pipelinetype"]).toBe("deploy");
+  });
+
+  it("TT path: non-placeholder param values are left unchanged", () => {
+    const triggerTemplate = {
+      spec: {
+        resourcetemplates: [
+          {
+            metadata: {},
+            spec: {
+              pipelineRef: { name: "my-pipeline" },
+              params: [{ name: "static-param", value: "hardcoded-value" }],
+            },
+          },
+        ],
+      },
+    };
+    const pipeline = {
+      metadata: { name: "my-pipeline" },
+      spec: {
+        params: [{ name: "static-param", type: "string", default: "different-value" }],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      triggerTemplate as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    expect(result.spec.params).toEqual([{ name: "static-param", value: "hardcoded-value" }]);
+  });
+
+  it("no-TT path: workspaces get volumeClaimTemplate bindings", () => {
+    const pipeline = {
+      metadata: {
+        name: "autotests-gradle",
+        namespace: "edp",
+        labels: { "app.edp.epam.com/pipelinetype": "tests" },
+      },
+      spec: {
+        params: [{ name: "git-source-url", type: "string", default: "https://github.com/example.git" }],
+        workspaces: [{ name: "shared-workspace" }, { name: "ssh-creds" }],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      undefined as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    expect(result.spec.workspaces).toEqual([
+      {
+        name: "shared-workspace",
+        volumeClaimTemplate: {
+          spec: {
+            accessModes: ["ReadWriteOnce"],
+            resources: { requests: { storage: "1Gi" } },
+          },
+        },
+      },
+      {
+        name: "ssh-creds",
+        volumeClaimTemplate: {
+          spec: {
+            accessModes: ["ReadWriteOnce"],
+            resources: { requests: { storage: "1Gi" } },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("no-TT path: pipeline with no workspaces omits the field entirely", () => {
+    const pipeline = {
+      metadata: {
+        name: "simple-pipeline",
+        namespace: "edp",
+        labels: { "app.edp.epam.com/pipelinetype": "build" },
+      },
+      spec: { params: [] },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      undefined as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    expect(result.spec.workspaces).toBeUndefined();
+  });
+
+  it('no-TT path: array param with no default gets [] not ""', () => {
+    const pipeline = {
+      metadata: {
+        name: "scan-pipeline",
+        namespace: "edp",
+        labels: { "app.edp.epam.com/pipelinetype": "security" },
+      },
+      spec: {
+        params: [
+          { name: "IMAGE_NAMES", type: "array" },
+          { name: "CODEBASE_NAME", type: "string", default: "my-app" },
+        ],
+      },
+    };
+
+    const result = createPipelineRunDraftFromPipeline(
+      undefined as unknown as TriggerTemplate,
+      pipeline as unknown as Pipeline
+    );
+
+    expect(result.spec.params).toEqual([
+      { name: "IMAGE_NAMES", value: [] },
+      { name: "CODEBASE_NAME", value: "my-app" },
+    ]);
+  });
 });

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.ts
@@ -5,15 +5,124 @@ import { TriggerTemplate } from "../../../TriggerTemplate/index.js";
 import { pipelineLabels } from "../../../Pipeline/labels.js";
 import { pipelineRunLabels } from "../../labels.js";
 
+// Matches Tekton Triggers placeholder syntax: $(tt.params.<name>)
+const TT_PARAM_RE = /^\$\(tt\.params\.([^)]+)\)$/;
+
+type PipelineParamSpec = NonNullable<Pipeline["spec"]["params"]>[number];
+
+// Build a name→string mapping for every Pipeline param. Array defaults become
+// "" because arrays cannot appear in K8s label or annotation values.
+function buildStringDefaults(pipelineParams: PipelineParamSpec[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const p of pipelineParams) {
+    const def = p.default;
+    map.set(p.name, def == null || Array.isArray(def) ? "" : String(def));
+  }
+  return map;
+}
+
+// Recursively walk obj and replace every $(tt.params.X) placeholder in any
+// string value with its string default. Handles both whole-value placeholders
+// and composite strings like "$(tt.params.A)-$(tt.params.B)". This sanitises
+// metadata.labels, metadata.annotations, and all other string-typed fields
+// before K8s submission — the placeholder syntax contains characters ($, (, ))
+// that are forbidden in K8s label values, causing 422 rejections.
+function resolveStringPlaceholders(obj: unknown, defaults: Map<string, string>): unknown {
+  if (typeof obj === "string") {
+    return obj.replace(/\$\(tt\.params\.([^)]+)\)/g, (_, name: string) => defaults.get(name) ?? "");
+  }
+  if (Array.isArray(obj)) {
+    return obj.map((item) => resolveStringPlaceholders(item, defaults));
+  }
+  if (obj !== null && typeof obj === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      result[k] = resolveStringPlaceholders(v, defaults);
+    }
+    return result;
+  }
+  return obj;
+}
+
+// K8s label value must be empty or match [A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9].
+// A composite placeholder like "$(tt.params.A)-$(tt.params.B)" can resolve to
+// "-" (both empty), which K8s rejects with 422. Replace invalid results with "".
+const K8S_LABEL_VALUE_RE = /^[A-Za-z0-9]([A-Za-z0-9\-_.]{0,61}[A-Za-z0-9])?$/;
+
+function sanitizeLabelValues(labels: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(labels)) {
+    out[k] = typeof v === "string" && v !== "" && !K8S_LABEL_VALUE_RE.test(v) ? "" : v;
+  }
+  return out;
+}
+
+// Apply type-aware resolution to spec.params entries. Handles two cases:
+//   1. Value is still a $(tt.params.X) placeholder (string pass was skipped).
+//   2. Value is "" and the param is an array type — the string pass set it to
+//      "" because arrays can't be labels, but spec.params must carry [].
+function resolveTtParams(
+  draftParams: Array<{ name: string; value: unknown }>,
+  pipelineParams: PipelineParamSpec[]
+): Array<{ name: string; value: unknown }> {
+  const byName = new Map(pipelineParams.map((p) => [p.name, p]));
+
+  return draftParams.map((param) => {
+    const spec = byName.get(param.name);
+
+    // Case 1: unresolved placeholder
+    if (typeof param.value === "string" && TT_PARAM_RE.test(param.value)) {
+      const value = spec?.default ?? (spec?.type === "array" ? [] : "");
+      return { name: param.name, value };
+    }
+
+    // Case 2: array param degraded to "" by the string pass
+    if (spec?.type === "array" && param.value === "") {
+      return { name: param.name, value: spec.default ?? [] };
+    }
+
+    return param;
+  });
+}
+
 const getPipelineRunFromTriggerTemplate = (triggerTemplate: TriggerTemplate, pipeline: Pipeline) => {
   if (!triggerTemplate) {
     return null;
   }
 
-  const pipelineRun = triggerTemplate.spec.resourcetemplates?.[0];
+  const template = triggerTemplate.spec.resourcetemplates?.[0];
+  if (!template) {
+    return null;
+  }
 
-  if (pipelineRun && pipelineRun.spec && pipelineRun.spec.pipelineRef) {
+  // Deep-clone so mutations below never write back into the original
+  // TriggerTemplate object (e.g. a K8s watch cache entry).
+  let pipelineRun = structuredClone(template);
+
+  // Always pin pipelineRef to the user-requested pipeline.
+  if (pipelineRun.spec?.pipelineRef) {
     pipelineRun.spec.pipelineRef.name = pipeline.metadata.name;
+  }
+
+  if (pipeline.spec?.params) {
+    // Pass 1: resolve ALL $(tt.params.*) throughout the entire template as
+    // strings. Fixes labels, annotations, and any other string-typed field.
+    const stringDefaults = buildStringDefaults(pipeline.spec.params);
+    pipelineRun = resolveStringPlaceholders(pipelineRun, stringDefaults) as typeof pipelineRun;
+
+    // Pass 1b: sanitize label values. Composite placeholders can resolve to
+    // strings like "-" that are syntactically invalid K8s label values.
+    if (pipelineRun.metadata?.labels && typeof pipelineRun.metadata.labels === "object") {
+      pipelineRun.metadata.labels = sanitizeLabelValues(
+        pipelineRun.metadata.labels as Record<string, unknown>
+      ) as typeof pipelineRun.metadata.labels;
+    }
+
+    // Pass 2: re-apply type-aware resolution to spec.params so that array
+    // params get [] instead of the "" assigned by the string pass above.
+    if (Array.isArray(pipelineRun.spec?.params)) {
+      pipelineRun.spec.params = resolveTtParams(pipelineRun.spec.params, pipeline.spec.params);
+    }
   }
 
   return pipelineRun;
@@ -50,12 +159,24 @@ export const createPipelineRunDraftFromPipeline = (
       pipelineRef: {
         name: pipeline.metadata.name,
       },
-      params: (pipeline.spec.params || []).map((param: { name: string; default?: unknown }) => {
-        return {
-          name: param.name,
-          value: param.default || "",
-        };
-      }),
+      params: (pipeline.spec.params || []).map((param: { name: string; type?: string; default?: unknown }) => ({
+        name: param.name,
+        value: param.default ?? (param.type === "array" ? [] : ""),
+      })),
+      ...(pipeline.spec.workspaces?.length
+        ? {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            workspaces: pipeline.spec.workspaces.map((ws: { name: string }) => ({
+              name: ws.name,
+              volumeClaimTemplate: {
+                spec: {
+                  accessModes: ["ReadWriteOnce"],
+                  resources: { requests: { storage: "1Gi" } },
+                },
+              },
+            })) as any[],
+          }
+        : {}),
     },
   };
 

--- a/packages/shared/src/models/tektonResults/types.ts
+++ b/packages/shared/src/models/tektonResults/types.ts
@@ -397,8 +397,6 @@ export interface TektonResultTask {
  * Returned when user selects a specific task
  */
 export interface TektonResultTaskLogs {
-  /** Friendly task name */
-  taskName: string;
   /** Full TaskRun name */
   taskRunName: string;
   /** Full log content for this TaskRun */

--- a/packages/trpc/api/openapi.json
+++ b/packages/trpc/api/openapi.json
@@ -514,6 +514,194 @@
         }
       }
     },
+    "/v1/pipelineruns/start": {
+      "post": {
+        "operationId": "pipelineRun-start",
+        "tags": [
+          "pipelinerun"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "namespace": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+                    "minLength": 1,
+                    "maxLength": 253
+                  },
+                  "pipeline": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+                    "minLength": 1,
+                    "maxLength": 253
+                  },
+                  "params": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string",
+                      "pattern": "^([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)?$"
+                    }
+                  },
+                  "dryRun": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": [
+                  "namespace",
+                  "pipeline"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "created"
+                          ]
+                        },
+                        "row": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "project": {
+                              "type": "string"
+                            },
+                            "pr": {
+                              "type": "string"
+                            },
+                            "author": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "started": {
+                              "type": "string"
+                            },
+                            "duration": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "status",
+                            "project",
+                            "pr",
+                            "author",
+                            "type",
+                            "started",
+                            "duration"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "row"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "dryRun"
+                          ]
+                        },
+                        "manifest": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "manifest"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/pipeline-runs/{resultUid}/logs": {
       "get": {
         "operationId": "tektonResults-getPipelineRunLogs",
@@ -540,7 +728,9 @@
             "name": "namespace",
             "schema": {
               "type": "string",
-              "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+              "minLength": 1,
+              "maxLength": 253
             },
             "required": true
           },
@@ -652,7 +842,9 @@
             "name": "namespace",
             "schema": {
               "type": "string",
-              "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+              "minLength": 1,
+              "maxLength": 253
             },
             "required": true
           },
@@ -661,7 +853,9 @@
             "name": "taskRunName",
             "schema": {
               "type": "string",
-              "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+              "minLength": 1,
+              "maxLength": 253
             },
             "required": true
           },
@@ -682,9 +876,6 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "taskName": {
-                      "type": "string"
-                    },
                     "taskRunName": {
                       "type": "string"
                     },
@@ -703,7 +894,6 @@
                     }
                   },
                   "required": [
-                    "taskName",
                     "taskRunName",
                     "logs",
                     "hasLogs",
@@ -792,7 +982,9 @@
             "name": "namespace",
             "schema": {
               "type": "string",
-              "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+              "minLength": 1,
+              "maxLength": 253
             },
             "required": true
           }
@@ -878,7 +1070,9 @@
             "name": "namespace",
             "schema": {
               "type": "string",
-              "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+              "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+              "minLength": 1,
+              "maxLength": 253
             },
             "required": true
           },

--- a/packages/trpc/src/routers/index.ts
+++ b/packages/trpc/src/routers/index.ts
@@ -6,6 +6,7 @@ import { dependencyTrackRouter } from "./dependencyTrack/index.js";
 import { gitfusionRouter } from "./gitfusion/index.js";
 import { k8sRouter } from "./k8s/index.js";
 import { prometheusRouter } from "./prometheus/index.js";
+import { pipelineRunRouter } from "./pipelineRun/index.js";
 import { sonarqubeRouter } from "./sonarqube/index.js";
 import { tektonResultsRouter } from "./tektonResults/index.js";
 
@@ -16,6 +17,7 @@ export const appRouter = t.router({
   gitfusion: gitfusionRouter,
   k8s: k8sRouter,
   prometheus: prometheusRouter,
+  pipelineRun: pipelineRunRouter,
   sonarqube: sonarqubeRouter,
   tektonResults: tektonResultsRouter,
 });

--- a/packages/trpc/src/routers/pipelineRun/helpers.test.ts
+++ b/packages/trpc/src/routers/pipelineRun/helpers.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import type { Pipeline, PipelineRun, PipelineRunDraft } from "@my-project/shared";
+import {
+  EMPTY_START_ROW,
+  deriveDuration,
+  deriveStatus,
+  getTriggerTemplateLabel,
+  mergeLabels,
+  mergeParams,
+  prepareStartDraft,
+  projectPipelineRunRow,
+} from "./helpers.js";
+
+describe("mergeParams", () => {
+  it("returns sorted defaults when no overrides", () => {
+    const got = mergeParams(
+      [
+        { name: "b", value: "B" },
+        { name: "a", value: "A" },
+      ],
+      {}
+    );
+    expect(got).toEqual([
+      { name: "a", value: "A" },
+      { name: "b", value: "B" },
+    ]);
+  });
+
+  it("user value wins on key collision", () => {
+    const got = mergeParams([{ name: "git-revision", value: "main" }], { "git-revision": "feat" });
+    expect(got).toEqual([{ name: "git-revision", value: "feat" }]);
+  });
+
+  it("appends user keys absent from defaults, sorted", () => {
+    const got = mergeParams([{ name: "a", value: "A" }], { z: "Z", b: "B" });
+    expect(got.map((p) => p.name)).toEqual(["a", "b", "z"]);
+  });
+
+  it("handles undefined defaults and overrides", () => {
+    expect(mergeParams(undefined, undefined)).toEqual([]);
+    expect(mergeParams(undefined, { k: "v" })).toEqual([{ name: "k", value: "v" }]);
+    expect(mergeParams([{ name: "k", value: "v" }], undefined)).toEqual([{ name: "k", value: "v" }]);
+  });
+
+  it("preserves empty-string user values (Tekton allows them)", () => {
+    const got = mergeParams([{ name: "image-tag", value: "latest" }], { "image-tag": "" });
+    expect(got).toEqual([{ name: "image-tag", value: "" }]);
+  });
+});
+
+describe("mergeLabels", () => {
+  it("user labels override draft labels", () => {
+    const got = mergeLabels({ a: "1", b: "2" }, { b: "OVERRIDE", c: "3" });
+    expect(got).toEqual({ a: "1", b: "OVERRIDE", c: "3" });
+  });
+
+  it("drops undefined draft label values", () => {
+    const got = mergeLabels({ a: "1", b: undefined }, {});
+    expect(got).toEqual({ a: "1" });
+  });
+
+  it("returns {} when both inputs are empty", () => {
+    expect(mergeLabels(undefined, undefined)).toEqual({});
+  });
+});
+
+describe("prepareStartDraft", () => {
+  const baseDraft = {
+    apiVersion: "tekton.dev/v1",
+    kind: "PipelineRun",
+    metadata: { name: "old-name", namespace: "edp", labels: { a: "1" } },
+    spec: {
+      pipelineRef: { name: "foo-build" },
+      params: [{ name: "git-revision", value: "main" }],
+    },
+  } as unknown as PipelineRunDraft;
+
+  it("replaces metadata.name with metadata.generateName and pins namespace", () => {
+    const got = prepareStartDraft(baseDraft, "foo-build", "edp", undefined, undefined) as Record<string, unknown>;
+    const meta = got.metadata as Record<string, unknown>;
+
+    expect(meta.name).toBeUndefined();
+    expect(meta.generateName).toBe("foo-build-run-");
+    expect(meta.namespace).toBe("edp");
+  });
+
+  it("does not mutate the input draft", () => {
+    prepareStartDraft(baseDraft, "foo-build", "edp", { "git-revision": "feat" }, { extra: "x" });
+    expect((baseDraft.metadata as Record<string, unknown>).name).toBe("old-name");
+    expect((baseDraft.metadata as Record<string, unknown>).labels).toEqual({ a: "1" });
+    expect((baseDraft.spec as { params: unknown }).params).toEqual([{ name: "git-revision", value: "main" }]);
+  });
+
+  it("merges user params over Pipeline defaults (user wins)", () => {
+    const got = prepareStartDraft(
+      baseDraft,
+      "foo-build",
+      "edp",
+      { "git-revision": "feat-branch" },
+      undefined
+    ) as Record<string, unknown>;
+
+    const params = (got.spec as { params: Array<{ name: string; value: unknown }> }).params;
+    expect(params.find((p) => p.name === "git-revision")?.value).toBe("feat-branch");
+  });
+
+  it("merges user labels over draft labels (user wins)", () => {
+    const got = prepareStartDraft(baseDraft, "foo-build", "edp", undefined, {
+      a: "OVERRIDE",
+      extra: "x",
+    }) as Record<string, unknown>;
+
+    const labels = (got.metadata as { labels: Record<string, string> }).labels;
+    expect(labels.a).toBe("OVERRIDE");
+    expect(labels.extra).toBe("x");
+  });
+
+  it("pins namespace to the requested namespace", () => {
+    const got = prepareStartDraft(baseDraft, "foo-build", "other-ns", undefined, undefined) as Record<string, unknown>;
+    expect((got.metadata as Record<string, unknown>).namespace).toBe("other-ns");
+  });
+});
+
+describe("projectPipelineRunRow", () => {
+  it("returns empty row when input is null/undefined", () => {
+    expect(projectPipelineRunRow(undefined)).toEqual(EMPTY_START_ROW);
+    expect(projectPipelineRunRow(null)).toEqual(EMPTY_START_ROW);
+  });
+
+  it("projects labels to row fields", () => {
+    const pr = {
+      metadata: {
+        name: "foo-build-run-x9k2p",
+        namespace: "edp",
+        labels: {
+          "app.edp.epam.com/codebase": "my-app",
+          "app.edp.epam.com/pipelinetype": "build",
+          "app.edp.epam.com/changenumber": "44",
+          "app.edp.epam.com/gitauthor": "alice",
+        },
+      },
+      status: { conditions: [{ type: "Succeeded", status: "Unknown" }], startTime: "2026-01-01T00:00:00Z" },
+    } as unknown as PipelineRun;
+
+    const row = projectPipelineRunRow(pr);
+    expect(row.name).toBe("foo-build-run-x9k2p");
+    expect(row.project).toBe("my-app");
+    expect(row.pr).toBe("44");
+    expect(row.author).toBe("alice");
+    expect(row.type).toBe("build");
+    expect(row.status).toBe("Running");
+    expect(row.started).toBe("2026-01-01T00:00:00Z");
+    expect(row.duration).toBe(""); // no completionTime yet
+  });
+
+  it("derives empty cells for unpopulated labels", () => {
+    const pr = {
+      metadata: { name: "x", namespace: "edp", labels: {} },
+      status: {},
+    } as unknown as PipelineRun;
+
+    const row = projectPipelineRunRow(pr);
+    expect(row.project).toBe("");
+    expect(row.pr).toBe("");
+    expect(row.status).toBe("Pending");
+  });
+});
+
+describe("deriveStatus", () => {
+  it("Pending when no condition", () => {
+    expect(deriveStatus(undefined)).toBe("Pending");
+  });
+
+  it("Succeeded on True", () => {
+    expect(deriveStatus({ status: "True" })).toBe("Succeeded");
+  });
+
+  it("Failed on False default reason", () => {
+    expect(deriveStatus({ status: "False", reason: "TaskRunFailed" })).toBe("Failed");
+  });
+
+  it("Cancelled on PipelineRunCancelled", () => {
+    expect(deriveStatus({ status: "False", reason: "PipelineRunCancelled" })).toBe("Cancelled");
+  });
+
+  it("Timeout on PipelineRunTimeout", () => {
+    expect(deriveStatus({ status: "False", reason: "PipelineRunTimeout" })).toBe("Timeout");
+  });
+
+  it("Running on Unknown / other", () => {
+    expect(deriveStatus({ status: "Unknown" })).toBe("Running");
+  });
+});
+
+describe("deriveDuration", () => {
+  it("empty when missing start", () => {
+    expect(deriveDuration(undefined, "2026-01-01T00:00:30Z")).toBe("");
+  });
+
+  it("empty when missing end", () => {
+    expect(deriveDuration("2026-01-01T00:00:00Z", undefined)).toBe("");
+  });
+
+  it("formats seconds-only", () => {
+    expect(deriveDuration("2026-01-01T00:00:00Z", "2026-01-01T00:00:30Z")).toBe("30s");
+  });
+
+  it("formats minutes+seconds", () => {
+    expect(deriveDuration("2026-01-01T00:00:00Z", "2026-01-01T00:01:30Z")).toBe("1m30s");
+  });
+
+  it("handles invalid timestamps", () => {
+    expect(deriveDuration("not-a-date", "2026-01-01T00:00:00Z")).toBe("");
+  });
+});
+
+describe("getTriggerTemplateLabel", () => {
+  it("returns label value when present", () => {
+    const pipe = {
+      metadata: {
+        name: "x",
+        namespace: "edp",
+        labels: { "app.edp.epam.com/triggertemplate": "foo-tt" },
+      },
+    } as unknown as Pipeline;
+    expect(getTriggerTemplateLabel(pipe)).toBe("foo-tt");
+  });
+
+  it("returns undefined when absent", () => {
+    const pipe = { metadata: { name: "x", namespace: "edp", labels: {} } } as unknown as Pipeline;
+    expect(getTriggerTemplateLabel(pipe)).toBeUndefined();
+  });
+
+  it("returns undefined when label is empty string", () => {
+    const pipe = {
+      metadata: { name: "x", namespace: "edp", labels: { "app.edp.epam.com/triggertemplate": "" } },
+    } as unknown as Pipeline;
+    expect(getTriggerTemplateLabel(pipe)).toBeUndefined();
+  });
+});

--- a/packages/trpc/src/routers/pipelineRun/helpers.ts
+++ b/packages/trpc/src/routers/pipelineRun/helpers.ts
@@ -1,0 +1,205 @@
+import {
+  pipelineLabels,
+  pipelineRunLabels,
+  type Pipeline,
+  type PipelineRun,
+  type PipelineRunDraft,
+} from "@my-project/shared";
+import { type PipelineRunStartRow } from "../../schemas/pipelineRunStartRow.js";
+
+/** Empty start row. Used in the dry-run path (no live resource exists yet). */
+export const EMPTY_START_ROW: PipelineRunStartRow = {
+  name: "",
+  status: "",
+  project: "",
+  pr: "",
+  author: "",
+  type: "",
+  started: "",
+  duration: "",
+};
+
+/** Tekton PipelineRun param entry as supplied by the platform's CRD. */
+export interface PipelineParam {
+  name: string;
+  value?: unknown;
+}
+
+/**
+ * Merge user-supplied param overrides over Pipeline defaults.
+ *
+ * - Defaults appear first (one per name); user-supplied overrides replace
+ *   their value in place.
+ * - Names absent from defaults are added.
+ * - Final output is sorted alphabetically by name so dry-run manifests are
+ *   deterministic for diffs and snapshot tests.
+ */
+export function mergeParams(
+  defaults: readonly PipelineParam[] | undefined,
+  userParams: Readonly<Record<string, string>> | undefined
+): PipelineParam[] {
+  const overrides = userParams ?? {};
+  const out: PipelineParam[] = [];
+  const seen = new Set<string>();
+
+  for (const def of defaults ?? []) {
+    if (Object.hasOwn(overrides, def.name)) {
+      out.push({ name: def.name, value: overrides[def.name] });
+    } else {
+      out.push({ name: def.name, value: def.value });
+    }
+
+    seen.add(def.name);
+  }
+
+  for (const [name, value] of Object.entries(overrides)) {
+    if (!seen.has(name)) {
+      out.push({ name, value });
+    }
+  }
+
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Merge user-supplied labels over the draft's existing labels. User wins on
+ * key collisions, which lets callers override TriggerTemplate-seeded label
+ * values.
+ */
+export function mergeLabels(
+  draftLabels: Readonly<Record<string, string | undefined>> | undefined,
+  userLabels: Readonly<Record<string, string>> | undefined
+): Record<string, string> {
+  const out: Record<string, string> = {};
+
+  for (const [k, v] of Object.entries(draftLabels ?? {})) {
+    if (typeof v === "string") {
+      out[k] = v;
+    }
+  }
+
+  for (const [k, v] of Object.entries(userLabels ?? {})) {
+    out[k] = v;
+  }
+
+  return out;
+}
+
+/**
+ * Clone the helper-built draft and apply the start procedure's pre-create
+ * mutations:
+ *   - Replace `metadata.name` with `metadata.generateName` so the apiserver
+ *     assigns the suffix; the response carries the populated `metadata.name`.
+ *   - Pin `metadata.namespace` to the user-requested namespace.
+ *   - Merge user labels over draft labels (user wins).
+ *   - Merge user params over Pipeline defaults (user wins, sorted).
+ *
+ * The function is pure: the input draft is not mutated.
+ */
+export function prepareStartDraft(
+  baseDraft: PipelineRunDraft,
+  pipelineName: string,
+  namespace: string,
+  userParams: Readonly<Record<string, string>> | undefined,
+  userLabels: Readonly<Record<string, string>> | undefined
+): PipelineRunDraft {
+  const cloned = structuredClone(baseDraft) as unknown as Record<string, unknown>;
+
+  const metadata = (cloned.metadata ?? {}) as Record<string, unknown>;
+  delete metadata.name;
+  metadata.generateName = `${pipelineName}-run-`;
+  metadata.namespace = namespace;
+  metadata.labels = mergeLabels(metadata.labels as Record<string, string | undefined> | undefined, userLabels);
+  cloned.metadata = metadata;
+
+  const spec = (cloned.spec ?? {}) as Record<string, unknown>;
+  const defaults = Array.isArray(spec.params) ? (spec.params as PipelineParam[]) : undefined;
+  spec.params = mergeParams(defaults, userParams);
+  cloned.spec = spec;
+
+  return cloned as unknown as PipelineRunDraft;
+}
+
+/** Project a created PipelineRun into the start-procedure row shape. */
+export function projectPipelineRunRow(pr: PipelineRun | undefined | null): PipelineRunStartRow {
+  if (!pr) {
+    return { ...EMPTY_START_ROW };
+  }
+
+  const labels = pr.metadata?.labels ?? {};
+  const succeededCondition = pr.status?.conditions?.find((c) => c.type === "Succeeded");
+
+  return {
+    name: pr.metadata?.name ?? "",
+    status: deriveStatus(succeededCondition),
+    project: labels[pipelineRunLabels.codebase] ?? "",
+    pr: labels[pipelineRunLabels.changeNumber] ?? "",
+    author: labels[pipelineRunLabels.gitAuthor] ?? "",
+    type: labels[pipelineRunLabels.pipelineType] ?? "",
+    started: pr.status?.startTime ?? pr.metadata?.creationTimestamp ?? "",
+    duration: deriveDuration(pr.status?.startTime, pr.status?.completionTime),
+  };
+}
+
+interface PipelineRunCondition {
+  type?: string;
+  status?: string;
+  reason?: string;
+}
+
+/**
+ * Derive a user-facing status string from a PipelineRun condition.
+ * Returns "Pending" when no condition is present (a freshly-created run
+ * lacks status until the controller schedules it).
+ */
+export function deriveStatus(c: PipelineRunCondition | undefined): string {
+  if (!c) {
+    return "Pending";
+  }
+
+  switch (c.status) {
+    case "True":
+      return "Succeeded";
+    case "False":
+      switch (c.reason) {
+        case "Cancelled":
+        case "PipelineRunCancelled":
+          return "Cancelled";
+        case "PipelineRunTimeout":
+          return "Timeout";
+        default:
+          return "Failed";
+      }
+    default:
+      return "Running";
+  }
+}
+
+/** Compute "Xm Ys" style duration. Empty when start or completion is missing. */
+export function deriveDuration(startTime: string | undefined, completionTime: string | undefined): string {
+  if (!startTime || !completionTime) {
+    return "";
+  }
+
+  const start = Date.parse(startTime);
+  const end = Date.parse(completionTime);
+
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) {
+    return "";
+  }
+
+  const totalSec = Math.round((end - start) / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+
+  return m > 0 ? `${m}m${s}s` : `${s}s`;
+}
+
+/**
+ * Returns the TriggerTemplate label value if the Pipeline carries one,
+ * undefined otherwise. Empty strings are treated as absent.
+ */
+export function getTriggerTemplateLabel(pipeline: Pipeline): string | undefined {
+  const value = pipeline.metadata?.labels?.[pipelineLabels.triggerTemplate];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/trpc/src/routers/pipelineRun/index.ts
+++ b/packages/trpc/src/routers/pipelineRun/index.ts
@@ -1,0 +1,6 @@
+import { t } from "../../trpc.js";
+import { start } from "./procedures/index.js";
+
+export const pipelineRunRouter = t.router({
+  start,
+});

--- a/packages/trpc/src/routers/pipelineRun/lookup.ts
+++ b/packages/trpc/src/routers/pipelineRun/lookup.ts
@@ -1,0 +1,44 @@
+import { K8sApiError } from "@my-project/shared";
+import { TRPCError } from "@trpc/server";
+import { handleK8sError } from "../k8s/utils/handleK8sError/index.js";
+
+/**
+ * Build the standard `cause` shape used by `handleK8sError` so downstream
+ * consumers treat not-found errors the same as any other K8s error. `reason`
+ * is a stable machine-readable tag the REST adapter surfaces in the response
+ * body so clients can branch on it without parsing the verbatim message
+ * (which is replaced with a static status phrase at the REST boundary).
+ */
+export function k8sNotFoundCause(error: K8sApiError, reason: string) {
+  return {
+    source: "k8s" as const,
+    reason,
+    statusCode: error.statusCode,
+    statusText: error.statusText,
+    responseBody: error.responseBody,
+  };
+}
+
+/**
+ * Wrap a K8s `getResource` call so a 404 surfaces as a tRPC `NOT_FOUND` with
+ * a stable `reason` tag. Any other error flows through `handleK8sError`.
+ */
+export async function getResourceOrThrowNotFound<T>(
+  fetch: () => Promise<T>,
+  message: string,
+  reason: string
+): Promise<T> {
+  try {
+    return await fetch();
+  } catch (error) {
+    if (error instanceof K8sApiError && error.statusCode === 404) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message,
+        cause: k8sNotFoundCause(error, reason),
+      });
+    }
+
+    throw handleK8sError(error);
+  }
+}

--- a/packages/trpc/src/routers/pipelineRun/procedures/index.ts
+++ b/packages/trpc/src/routers/pipelineRun/procedures/index.ts
@@ -1,0 +1,1 @@
+export { pipelineRunStartProcedure as start } from "./start/index.js";

--- a/packages/trpc/src/routers/pipelineRun/procedures/start/index.test.ts
+++ b/packages/trpc/src/routers/pipelineRun/procedures/start/index.test.ts
@@ -1,0 +1,357 @@
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { K8sClient } from "../../../../clients/k8s/index.js";
+import { K8sApiError } from "@my-project/shared";
+
+vi.mock("../../../../clients/k8s/index.js", () => ({
+  K8sClient: vi.fn(),
+}));
+
+describe("pipelineRun.start", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+  let mockK8sClientInstance: {
+    KubeConfig: object;
+    getResource: Mock;
+    createResource: Mock;
+  };
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+    mockK8sClientInstance = {
+      KubeConfig: {},
+      getResource: vi.fn(),
+      createResource: vi.fn(),
+    };
+    (K8sClient as unknown as Mock).mockImplementation(() => mockK8sClientInstance);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseInput = {
+    namespace: "edp",
+    pipeline: "foo-build",
+  };
+
+  const minimalPipeline = {
+    apiVersion: "tekton.dev/v1",
+    kind: "Pipeline",
+    metadata: { name: "foo-build", namespace: "edp", labels: {} },
+    spec: { params: [{ name: "git-revision", default: "main" }] },
+  };
+
+  const minimalCreatedPipelineRun = {
+    apiVersion: "tekton.dev/v1",
+    kind: "PipelineRun",
+    metadata: {
+      name: "foo-build-run-x9k2p",
+      namespace: "edp",
+      labels: { "app.edp.epam.com/pipelinetype": "build" },
+    },
+    spec: { pipelineRef: { name: "foo-build" } },
+    status: {},
+  };
+
+  it("happy path — creates a PipelineRun with merged params", async () => {
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(minimalPipeline);
+    mockK8sClientInstance.createResource.mockResolvedValueOnce(minimalCreatedPipelineRun);
+
+    const caller = createCaller(mockContext);
+    const result = await caller.pipelineRun.start({
+      ...baseInput,
+      params: { "git-revision": "feat-branch" },
+    });
+
+    expect(mockK8sClientInstance.getResource).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "Pipeline" }),
+      "foo-build",
+      "edp"
+    );
+
+    // Verify the create call carried the merged param + generateName.
+    const [, , draft] = mockK8sClientInstance.createResource.mock.calls[0];
+    expect((draft as { metadata: { generateName?: string; name?: string } }).metadata.generateName).toBe(
+      "foo-build-run-"
+    );
+    expect((draft as { metadata: { name?: string } }).metadata.name).toBeUndefined();
+
+    const params = (draft as { spec: { params: Array<{ name: string; value: unknown }> } }).spec.params;
+    const gitRevision = params.find((p) => p.name === "git-revision");
+    expect(gitRevision?.value).toBe("feat-branch");
+
+    expect(result.kind).toBe("created");
+    if (result.kind !== "created") throw new Error("expected created");
+    expect(result.row.name).toBe("foo-build-run-x9k2p");
+    expect(result.row.type).toBe("build");
+  });
+
+  it("Pipeline 404 throws NOT_FOUND with verbatim message and pipeline_not_found reason", async () => {
+    mockK8sClientInstance.getResource.mockRejectedValueOnce(new K8sApiError(404, "Not Found", "{}"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.pipelineRun.start({ ...baseInput, pipeline: "ghost" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "pipeline 'ghost' not found",
+      cause: { source: "k8s", reason: "pipeline_not_found" },
+    });
+
+    expect(mockK8sClientInstance.createResource).not.toHaveBeenCalled();
+  });
+
+  it("Pipeline references TT but TT 404 throws NOT_FOUND with trigger_template_not_found reason", async () => {
+    const pipelineWithTT = {
+      ...minimalPipeline,
+      metadata: {
+        ...minimalPipeline.metadata,
+        labels: { "app.edp.epam.com/triggertemplate": "foo-tt" },
+      },
+    };
+
+    // First getResource (Pipeline) succeeds; second (TriggerTemplate) 404s.
+    mockK8sClientInstance.getResource
+      .mockResolvedValueOnce(pipelineWithTT)
+      .mockRejectedValueOnce(new K8sApiError(404, "Not Found", "{}"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.pipelineRun.start(baseInput)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "pipeline 'foo-build' references a TriggerTemplate that does not exist",
+      cause: { source: "k8s", reason: "trigger_template_not_found" },
+    });
+
+    expect(mockK8sClientInstance.createResource).not.toHaveBeenCalled();
+  });
+
+  it("malformed TT label — fails fast with BAD_REQUEST, no K8s round-trip", async () => {
+    const pipelineWithBadTT = {
+      ...minimalPipeline,
+      metadata: {
+        ...minimalPipeline.metadata,
+        labels: { "app.edp.epam.com/triggertemplate": "Not_A_Valid_DNS_Name!" },
+      },
+    };
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(pipelineWithBadTT);
+
+    const caller = createCaller(mockContext);
+    await expect(caller.pipelineRun.start(baseInput)).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      cause: { reason: "malformed_trigger_template_label" },
+    });
+
+    // Pipeline lookup happened (1 call); TT lookup did NOT.
+    expect(mockK8sClientInstance.getResource).toHaveBeenCalledTimes(1);
+    expect(mockK8sClientInstance.createResource).not.toHaveBeenCalled();
+  });
+
+  it("trigger-template-not-found still emits in dry-run mode (Pipeline-existence + TT lookup precede dry-run short-circuit)", async () => {
+    const pipelineWithTT = {
+      ...minimalPipeline,
+      metadata: { ...minimalPipeline.metadata, labels: { "app.edp.epam.com/triggertemplate": "foo-tt" } },
+    };
+
+    mockK8sClientInstance.getResource
+      .mockResolvedValueOnce(pipelineWithTT)
+      .mockRejectedValueOnce(new K8sApiError(404, "Not Found", "{}"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.pipelineRun.start({ ...baseInput, dryRun: true })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+
+    expect(mockK8sClientInstance.createResource).not.toHaveBeenCalled();
+  });
+
+  it("RBAC denied — K8s 403 maps to FORBIDDEN", async () => {
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(minimalPipeline);
+    mockK8sClientInstance.createResource.mockRejectedValueOnce(new K8sApiError(403, "Forbidden", "{}"));
+
+    const caller = createCaller(mockContext);
+    await expect(caller.pipelineRun.start(baseInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("dry-run path — returns rendered manifest, skips create", async () => {
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(minimalPipeline);
+
+    const caller = createCaller(mockContext);
+    const result = await caller.pipelineRun.start({
+      ...baseInput,
+      params: { "git-revision": "main" },
+      labels: { "app.edp.epam.com/codebase": "my-app" },
+      dryRun: true,
+    });
+
+    expect(mockK8sClientInstance.createResource).not.toHaveBeenCalled();
+    expect(result.kind).toBe("dryRun");
+    if (result.kind !== "dryRun") throw new Error("expected dryRun");
+
+    const metadata = result.manifest.metadata as { generateName?: string; labels?: Record<string, string> };
+    const spec = result.manifest.spec as { params: Array<{ name: string; value: unknown }> };
+    expect(metadata.generateName).toBe("foo-build-run-");
+    expect(metadata.labels?.["app.edp.epam.com/codebase"]).toBe("my-app");
+    expect(spec.params.find((p) => p.name === "git-revision")?.value).toBe("main");
+  });
+
+  it("generateName round-trip — response carries apiserver-assigned name", async () => {
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(minimalPipeline);
+    mockK8sClientInstance.createResource.mockResolvedValueOnce({
+      ...minimalCreatedPipelineRun,
+      metadata: { ...minimalCreatedPipelineRun.metadata, name: "foo-build-run-7zxQ4" },
+    });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.pipelineRun.start(baseInput);
+
+    expect(result.kind).toBe("created");
+    if (result.kind !== "created") throw new Error("expected created");
+    expect(result.row.name).toBe("foo-build-run-7zxQ4");
+  });
+
+  it("uninitialized K8s client — throws INTERNAL_SERVER_ERROR before any K8s call", async () => {
+    mockK8sClientInstance.KubeConfig = null as unknown as object;
+
+    const caller = createCaller(mockContext);
+    await expect(caller.pipelineRun.start(baseInput)).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
+
+    expect(mockK8sClientInstance.getResource).not.toHaveBeenCalled();
+    expect(mockK8sClientInstance.createResource).not.toHaveBeenCalled();
+  });
+
+  it(".strict() input rejects unknown fields", async () => {
+    const caller = createCaller(mockContext);
+    // @ts-expect-error — deliberately passing unknown field
+    await expect(caller.pipelineRun.start({ ...baseInput, foo: "bar" })).rejects.toThrow();
+  });
+
+  it("rejects invalid pipeline name (DNS-1123)", async () => {
+    const caller = createCaller(mockContext);
+    await expect(caller.pipelineRun.start({ ...baseInput, pipeline: "Foo_Build" })).rejects.toThrow();
+  });
+
+  it("null draft from createPipelineRunDraftFromPipeline → INTERNAL_SERVER_ERROR", async () => {
+    // TriggerTemplate with no resourcetemplates → helper returns null.
+    const pipelineWithTT = {
+      ...minimalPipeline,
+      metadata: {
+        ...minimalPipeline.metadata,
+        labels: { "app.edp.epam.com/triggertemplate": "foo-tt" },
+      },
+    };
+    const emptyTriggerTemplate = {
+      apiVersion: "triggers.tekton.dev/v1beta1",
+      kind: "TriggerTemplate",
+      metadata: { name: "foo-tt", namespace: "edp" },
+      spec: { resourcetemplates: [] },
+    };
+
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(pipelineWithTT).mockResolvedValueOnce(emptyTriggerTemplate);
+
+    const caller = createCaller(mockContext);
+    await expect(caller.pipelineRun.start(baseInput)).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+      message: expect.stringContaining("failed to build PipelineRun draft"),
+    });
+
+    expect(mockK8sClientInstance.createResource).not.toHaveBeenCalled();
+  });
+
+  it("TT path: $(tt.params.*) placeholders resolved to Pipeline defaults before create", async () => {
+    const pipelineWithTT = {
+      ...minimalPipeline,
+      metadata: {
+        ...minimalPipeline.metadata,
+        labels: { "app.edp.epam.com/triggertemplate": "image-scan-tt" },
+      },
+      spec: {
+        params: [
+          { name: "IMAGE_NAMES", type: "array" },
+          { name: "CODEBASE_NAME", type: "string", default: "my-app" },
+        ],
+      },
+    };
+
+    const triggerTemplate = {
+      apiVersion: "triggers.tekton.dev/v1beta1",
+      kind: "TriggerTemplate",
+      metadata: { name: "image-scan-tt", namespace: "edp" },
+      spec: {
+        resourcetemplates: [
+          {
+            apiVersion: "tekton.dev/v1",
+            kind: "PipelineRun",
+            metadata: { generateName: "image-scan-remote-run-" },
+            spec: {
+              pipelineRef: { name: "image-scan-remote" },
+              params: [
+                { name: "IMAGE_NAMES", value: "$(tt.params.IMAGE_NAMES)" },
+                { name: "CODEBASE_NAME", value: "$(tt.params.CODEBASE_NAME)" },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(pipelineWithTT).mockResolvedValueOnce(triggerTemplate);
+    mockK8sClientInstance.createResource.mockResolvedValueOnce(minimalCreatedPipelineRun);
+
+    const caller = createCaller(mockContext);
+    await caller.pipelineRun.start(baseInput);
+
+    const [, , draft] = mockK8sClientInstance.createResource.mock.calls[0];
+    const params = (draft as { spec: { params: Array<{ name: string; value: unknown }> } }).spec.params;
+
+    const imageNames = params.find((p) => p.name === "IMAGE_NAMES");
+    expect(imageNames?.value).toEqual([]);
+
+    const codebaseName = params.find((p) => p.name === "CODEBASE_NAME");
+    expect(codebaseName?.value).toBe("my-app");
+  });
+
+  it("user labels override TT-seeded label values", async () => {
+    const pipelineWithTT = {
+      ...minimalPipeline,
+      metadata: {
+        ...minimalPipeline.metadata,
+        labels: { "app.edp.epam.com/triggertemplate": "foo-tt" },
+      },
+    };
+
+    const triggerTemplate = {
+      apiVersion: "triggers.tekton.dev/v1beta1",
+      kind: "TriggerTemplate",
+      metadata: { name: "foo-tt", namespace: "edp" },
+      spec: {
+        resourcetemplates: [
+          {
+            apiVersion: "tekton.dev/v1",
+            kind: "PipelineRun",
+            metadata: {
+              name: "tt-default-name",
+              labels: { "app.edp.epam.com/codebase": "default-codebase" },
+            },
+            spec: { pipelineRef: { name: "old" }, params: [] },
+          },
+        ],
+      },
+    };
+
+    mockK8sClientInstance.getResource.mockResolvedValueOnce(pipelineWithTT).mockResolvedValueOnce(triggerTemplate);
+    mockK8sClientInstance.createResource.mockResolvedValueOnce(minimalCreatedPipelineRun);
+
+    const caller = createCaller(mockContext);
+    await caller.pipelineRun.start({
+      ...baseInput,
+      labels: { "app.edp.epam.com/codebase": "user-override" },
+    });
+
+    const [, , draft] = mockK8sClientInstance.createResource.mock.calls[0];
+    const labels = (draft as { metadata: { labels: Record<string, string> } }).metadata.labels;
+    expect(labels["app.edp.epam.com/codebase"]).toBe("user-override");
+  });
+});

--- a/packages/trpc/src/routers/pipelineRun/procedures/start/index.ts
+++ b/packages/trpc/src/routers/pipelineRun/procedures/start/index.ts
@@ -1,0 +1,117 @@
+import {
+  createPipelineRunDraftFromPipeline,
+  k8sPipelineConfig,
+  k8sPipelineRunConfig,
+  k8sTriggerTemplateConfig,
+  type Pipeline,
+  type PipelineRun,
+  type TriggerTemplate,
+} from "@my-project/shared";
+import { pipelineRunStartRowSchema } from "../../../../schemas/pipelineRunStartRow.js";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { K8sClient } from "../../../../clients/k8s/index.js";
+import { ERROR_K8S_CLIENT_NOT_INITIALIZED } from "../../../k8s/errors/index.js";
+import { handleK8sError } from "../../../k8s/utils/handleK8sError/index.js";
+import { protectedProcedure } from "../../../../procedures/protected/index.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
+import { getTriggerTemplateLabel, prepareStartDraft, projectPipelineRunRow } from "../../helpers.js";
+import { getResourceOrThrowNotFound } from "../../lookup.js";
+
+const startInputSchema = z
+  .object({
+    namespace: tektonInputSchemas.namespace,
+    pipeline: tektonInputSchemas.k8sName,
+    params: z.record(tektonInputSchemas.paramName, z.string()).optional(),
+    labels: z.record(tektonInputSchemas.k8sLabelKey, tektonInputSchemas.k8sLabelValue).optional(),
+    dryRun: z.boolean().optional().default(false),
+  })
+  .strict();
+
+/**
+ * Discriminated by `kind`:
+ *   - `created` — apiserver assigned a name; `row` carries the projected list
+ *     entry.
+ *   - `dryRun` — no resource was created; `manifest` is the rendered PipelineRun
+ *     resource as a JSON object (not a serialised string — consumers parse
+ *     once at the transport layer).
+ */
+const manifestSchema = z.record(z.string(), z.unknown());
+
+const startOutputSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("created"), row: pipelineRunStartRowSchema }).strict(),
+  z.object({ kind: z.literal("dryRun"), manifest: manifestSchema }).strict(),
+]);
+
+export const pipelineRunStartProcedure = protectedProcedure
+  .meta({ openapi: { method: "POST", path: "/v1/pipelineruns/start", protect: true, tags: ["pipelinerun"] } })
+  .input(startInputSchema)
+  .output(startOutputSchema)
+  .mutation(async ({ input, ctx }): Promise<z.infer<typeof startOutputSchema>> => {
+    const k8sClient = new K8sClient(ctx.session);
+
+    if (!k8sClient.KubeConfig) {
+      throw new TRPCError(ERROR_K8S_CLIENT_NOT_INITIALIZED);
+    }
+
+    const pipeline = await getResourceOrThrowNotFound<Pipeline>(
+      () => k8sClient.getResource(k8sPipelineConfig, input.pipeline, input.namespace) as Promise<Pipeline>,
+      `pipeline '${input.pipeline}' not found`,
+      "pipeline_not_found"
+    );
+
+    let triggerTemplate: TriggerTemplate | undefined;
+    const ttLabel = getTriggerTemplateLabel(pipeline);
+    if (ttLabel) {
+      // Defense-in-depth: the apiserver will reject a malformed name, but
+      // validating locally turns a typo'd label into a fast BAD_REQUEST instead
+      // of a network round-trip with an opaque K8s error.
+      const ttLabelCheck = tektonInputSchemas.k8sName.safeParse(ttLabel);
+      if (!ttLabelCheck.success) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `pipeline '${input.pipeline}' has malformed TriggerTemplate label`,
+          cause: { source: "validation" as const, reason: "malformed_trigger_template_label" },
+        });
+      }
+
+      triggerTemplate = await getResourceOrThrowNotFound<TriggerTemplate>(
+        () => k8sClient.getResource(k8sTriggerTemplateConfig, ttLabel, input.namespace) as Promise<TriggerTemplate>,
+        `pipeline '${input.pipeline}' references a TriggerTemplate that does not exist`,
+        "trigger_template_not_found"
+      );
+    }
+
+    const baseDraft = createPipelineRunDraftFromPipeline(triggerTemplate, pipeline);
+    if (!baseDraft) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `failed to build PipelineRun draft for '${input.pipeline}'`,
+      });
+    }
+
+    const draft = prepareStartDraft(baseDraft, input.pipeline, input.namespace, input.params, input.labels);
+
+    // Return the resource as an object so transport layers (tRPC + Fastify)
+    // serialise it once and consumers don't pay a double-parse tax. The CLI
+    // can then re-encode as YAML for `kubectl apply -f -` or pass through as
+    // JSON for AI-agent consumers.
+    if (input.dryRun) {
+      return {
+        kind: "dryRun",
+        manifest: draft as Record<string, unknown>,
+      };
+    }
+
+    let created: PipelineRun;
+    try {
+      created = (await k8sClient.createResource(k8sPipelineRunConfig, input.namespace, draft)) as PipelineRun;
+    } catch (error) {
+      throw handleK8sError(error);
+    }
+
+    return {
+      kind: "created",
+      row: projectPipelineRunRow(created),
+    };
+  });

--- a/packages/trpc/src/routers/tektonResults/procedures/getPipelineRun/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/getPipelineRun/index.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { decodeTektonRecordData, DecodedPipelineRun } from "@my-project/shared";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
-import { tektonInputSchemas } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 /**
  * Get a single PipelineRun from Tekton Results by result_uid and record_uid

--- a/packages/trpc/src/routers/tektonResults/procedures/getPipelineRunLogs/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/getPipelineRunLogs/index.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { decodeTektonRecordData, parseRecordName, DecodedPipelineRun, DecodedLogRecord } from "@my-project/shared";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
-import { tektonInputSchemas } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 /** Escape a value for safe interpolation into a CEL string literal. */
 function escapeCELString(value: string): string {

--- a/packages/trpc/src/routers/tektonResults/procedures/getPipelineRunResults/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/getPipelineRunResults/index.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { tektonResultsListOutputSchema } from "@my-project/shared";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
-import { tektonInputSchemas } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 /**
  * Get PipelineRun results from the Tekton Results `ListResults` API.

--- a/packages/trpc/src/routers/tektonResults/procedures/getSummary/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/getSummary/index.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
 import { DEFAULT_SUMMARY_METRICS, TektonSummaryResponse } from "@my-project/shared";
-import { tektonInputSchemas } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 /**
  * Server-side TTL cache for getSummary results with singleflight coalescing.

--- a/packages/trpc/src/routers/tektonResults/procedures/getTaskList/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/getTaskList/index.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { decodeTektonRecordData, DecodedPipelineRun, TektonResultTask } from "@my-project/shared";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
-import { tektonInputSchemas } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 /**
  * Get list of tasks (with metadata only, no logs) from a PipelineRun in Tekton Results

--- a/packages/trpc/src/routers/tektonResults/procedures/getTaskRunLogs/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/getTaskRunLogs/index.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { decodeTektonRecordData, parseRecordName, DecodedLogRecord, TektonResultTaskLogs } from "@my-project/shared";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
-import { tektonInputSchemas } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 /**
  * Get logs for a single TaskRun from Tekton Results
@@ -25,7 +25,6 @@ export const getTaskRunLogsProcedure = protectedProcedure
   )
   .output(
     z.object({
-      taskName: z.string(),
       taskRunName: z.string(),
       logs: z.string(),
       hasLogs: z.boolean(),
@@ -49,7 +48,6 @@ export const getTaskRunLogsProcedure = protectedProcedure
 
       if (records.length === 0) {
         return {
-          taskName: "", // Will be extracted from taskRunName if needed
           taskRunName,
           logs: "",
           hasLogs: false,
@@ -99,7 +97,6 @@ export const getTaskRunLogsProcedure = protectedProcedure
       }
 
       return {
-        taskName: "", // Could be extracted from taskRunName or fetched separately if needed
         taskRunName,
         logs: logs || "No logs available for this TaskRun",
         hasLogs: logParts.length > 0,
@@ -108,7 +105,6 @@ export const getTaskRunLogsProcedure = protectedProcedure
       } satisfies TektonResultTaskLogs;
     } catch (error) {
       return {
-        taskName: "",
         taskRunName,
         logs: "",
         hasLogs: false,

--- a/packages/trpc/src/routers/tektonResults/procedures/getTaskRunRecords/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/getTaskRunRecords/index.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { type DecodedTaskRun, taskRunRecordsOutputSchema } from "@my-project/shared";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
-import { decodeRecords, tektonInputSchemas } from "../../utils.js";
+import { decodeRecords } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 /**
  * Get all TaskRun records for a PipelineRun from Tekton Results.

--- a/packages/trpc/src/routers/tektonResults/procedures/listRecords/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/listRecords/index.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
-import { tektonInputSchemas } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 export const listTektonRecordsProcedure = protectedProcedure
   .input(
     z.object({
       namespace: tektonInputSchemas.namespace,
-      filter: z.string().optional(),
+      filter: tektonInputSchemas.celFilter,
       pageSize: z.number().optional().default(50),
       pageToken: z.string().optional(),
       orderBy: z.string().optional().default("create_time desc"),

--- a/packages/trpc/src/routers/tektonResults/procedures/listResults/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/listResults/index.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import { createTektonResultsClient } from "../../../../clients/tektonResults/index.js";
-import { tektonInputSchemas } from "../../utils.js";
+import { tektonInputSchemas } from "../../../../schemas/tektonInput.js";
 
 export const listTektonResultsProcedure = protectedProcedure
   .input(
     z.object({
       namespace: tektonInputSchemas.namespace,
-      filter: z.string().optional(),
+      filter: tektonInputSchemas.celFilter,
       pageSize: z.number().optional().default(50),
       pageToken: z.string().optional(),
       orderBy: z.string().optional().default("create_time desc"),

--- a/packages/trpc/src/routers/tektonResults/utils.ts
+++ b/packages/trpc/src/routers/tektonResults/utils.ts
@@ -1,43 +1,5 @@
 import { TRPCError } from "@trpc/server";
 import { decodeTektonRecordData, TektonResultRecord } from "@my-project/shared";
-import { z } from "zod";
-
-/**
- * Zod schemas for Tekton Results input validation.
- * Constraining to valid Kubernetes / UUID characters prevents CEL injection
- * when values are interpolated into filter expressions.
- */
-export const tektonInputSchemas = {
-  /** RFC 1123 DNS label: lowercase alphanumeric + hyphens, 1-253 chars */
-  k8sName: z.string().regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, "Invalid Kubernetes resource name"),
-  /** K8s namespace: same as DNS label */
-  namespace: z.string().regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, "Invalid namespace"),
-  /** UUID v4 format */
-  uuid: z.string().uuid("Invalid UUID"),
-  /** Step name: lowercase alphanumeric + hyphens */
-  stepName: z.string().regex(/^[a-z0-9][a-z0-9-]*$/, "Invalid step name"),
-  /**
-   * CEL filter expression: allows alphanumeric, whitespace, and common CEL
-   * operators/punctuation. Rejects shell metacharacters, backticks, and `@`
-   * to prevent injection when the value is interpolated into filter strings.
-   *
-   * Defense-in-depth: the Tekton Results backend compiles CEL via cel-go and
-   * converts the AST to SQL (cel2sql), but string literals are interpolated
-   * into SQL without parameterization (see cel2sql/interpreter.go
-   * interpretConstExpr). This regex blocks characters that could escape the
-   * SQL string context.
-   */
-  celFilter: z
-    .string()
-    .optional()
-    .refine(
-      (val) => {
-        if (!val) return true;
-        return /^[a-zA-Z0-9\s_.\[\]()'",!=<>&|+\-*/%:]+$/.test(val);
-      },
-      { message: "Invalid filter: contains disallowed characters" }
-    ),
-} as const;
 
 /**
  * Decode an array of Tekton Result records into typed objects.

--- a/packages/trpc/src/schemas/pipelineRunStartRow.ts
+++ b/packages/trpc/src/schemas/pipelineRunStartRow.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+/**
+ * Row shape returned by the `pipelineRun.start` procedure on the live-create
+ * path. Mirrors the `krci pipelinerun list` columns exactly so CLI users
+ * pivot directly between the two verbs.
+ */
+export const pipelineRunStartRowSchema = z
+  .object({
+    name: z.string(),
+    status: z.string(),
+    project: z.string(),
+    pr: z.string(),
+    author: z.string(),
+    type: z.string(),
+    started: z.string(),
+    duration: z.string(),
+  })
+  .strict();
+
+export type PipelineRunStartRow = z.infer<typeof pipelineRunStartRowSchema>;

--- a/packages/trpc/src/schemas/tektonInput.test.ts
+++ b/packages/trpc/src/schemas/tektonInput.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { tektonInputSchemas } from "./tektonInput.js";
+
+describe("tektonInputSchemas.k8sName", () => {
+  it("accepts a single-character RFC 1123 DNS label", () => {
+    expect(tektonInputSchemas.k8sName.parse("a")).toBe("a");
+    expect(tektonInputSchemas.k8sName.parse("0")).toBe("0");
+  });
+
+  it("accepts standard hyphenated names", () => {
+    expect(tektonInputSchemas.k8sName.parse("foo-build")).toBe("foo-build");
+  });
+
+  it("rejects empty strings", () => {
+    expect(() => tektonInputSchemas.k8sName.parse("")).toThrow();
+  });
+
+  it("rejects names longer than 253 chars", () => {
+    expect(() => tektonInputSchemas.k8sName.parse("a".repeat(254))).toThrow();
+  });
+
+  it("rejects uppercase, underscores, and other invalid characters", () => {
+    expect(() => tektonInputSchemas.k8sName.parse("Foo")).toThrow();
+    expect(() => tektonInputSchemas.k8sName.parse("foo_bar")).toThrow();
+    expect(() => tektonInputSchemas.k8sName.parse("-leading-hyphen")).toThrow();
+    expect(() => tektonInputSchemas.k8sName.parse("trailing-hyphen-")).toThrow();
+  });
+});
+
+describe("tektonInputSchemas.namespace", () => {
+  it("accepts a single-character namespace", () => {
+    expect(tektonInputSchemas.namespace.parse("a")).toBe("a");
+  });
+
+  it("rejects empty strings", () => {
+    expect(() => tektonInputSchemas.namespace.parse("")).toThrow();
+  });
+
+  it("rejects values exceeding 253 chars", () => {
+    expect(() => tektonInputSchemas.namespace.parse("a".repeat(254))).toThrow();
+  });
+});
+
+describe("tektonInputSchemas.celFilter", () => {
+  it("accepts undefined", () => {
+    expect(tektonInputSchemas.celFilter.parse(undefined)).toBeUndefined();
+  });
+
+  it("accepts a typical CEL expression", () => {
+    const expr = "data_type == 'results.tekton.dev/v1alpha3.Log' && data.spec.resource.name == 'foo'";
+    expect(tektonInputSchemas.celFilter.parse(expr)).toBe(expr);
+  });
+
+  it("rejects shell metacharacters that could escape the SQL string context", () => {
+    expect(() => tektonInputSchemas.celFilter.parse("foo`bar`")).toThrow();
+    expect(() => tektonInputSchemas.celFilter.parse("foo@bar")).toThrow();
+    expect(() => tektonInputSchemas.celFilter.parse("foo;DROP TABLE x")).toThrow();
+  });
+});

--- a/packages/trpc/src/schemas/tektonInput.ts
+++ b/packages/trpc/src/schemas/tektonInput.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+/**
+ * Zod schemas for Tekton / Kubernetes input validation, shared across routers
+ * (`tektonResults`, `pipelineRun`, …). Constraining to valid Kubernetes / UUID
+ * characters prevents CEL injection when values are interpolated into filter
+ * expressions and bounds the surface accepted at the tRPC boundary.
+ */
+export const tektonInputSchemas = {
+  /** RFC 1123 DNS label: lowercase alphanumeric + hyphens, 1-253 chars */
+  k8sName: z
+    .string()
+    .min(1)
+    .max(253)
+    .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, "Invalid Kubernetes resource name"),
+  /** K8s namespace: same as DNS label */
+  namespace: z
+    .string()
+    .min(1)
+    .max(253)
+    .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, "Invalid namespace"),
+  /** UUID v4 format */
+  uuid: z.string().uuid("Invalid UUID"),
+  /** Step name: lowercase alphanumeric + hyphens, max 63 chars (K8s container name limit) */
+  stepName: z
+    .string()
+    .max(63)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, "Invalid step name"),
+  /**
+   * Tekton param name. Tekton's CRD enforces `^[A-Za-z_][A-Za-z0-9_-]*$` for
+   * param *definitions*, but pipelines defined elsewhere (Helm-style configs,
+   * ArgoCD application params) routinely use dot-separated names like
+   * `chart.version` or `image.tag` for user-supplied overrides at
+   * `pipelineRun.spec.params[].name`, which the apiserver does not re-validate
+   * against the definition pattern. Allow `.` and `/` so override keys are not
+   * rejected here. Capped at 253 chars to bound input size at the boundary.
+   */
+  paramName: z
+    .string()
+    .max(253)
+    .regex(/^[A-Za-z_][A-Za-z0-9_./-]*$/, "Invalid param name"),
+  /**
+   * K8s label key: optional DNS-subdomain prefix + name segment (≤63 chars,
+   * alphanumeric edges, dots/hyphens/underscores allowed). Defense-in-depth
+   * against unconstrained record keys reaching K8s metadata.
+   */
+  k8sLabelKey: z
+    .string()
+    .regex(
+      /^([a-z0-9]([-a-z0-9.]{0,251}[a-z0-9])?\/)?[A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$/,
+      "Invalid label key"
+    ),
+  /**
+   * K8s label value: ≤63 chars, alphanumeric edges, dots/hyphens/underscores.
+   * Empty string is valid per K8s.
+   */
+  k8sLabelValue: z.string().regex(/^([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)?$/, "Invalid label value"),
+  /**
+   * CEL filter expression: allows alphanumeric, whitespace, and common CEL
+   * operators/punctuation. Rejects shell metacharacters, backticks, and `@`
+   * to prevent injection when the value is interpolated into filter strings.
+   *
+   * Defense-in-depth: the Tekton Results backend compiles CEL via cel-go and
+   * converts the AST to SQL, but string literals are interpolated into SQL
+   * without parameterization. This regex blocks characters that could escape
+   * the SQL string context.
+   */
+  celFilter: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        return /^[a-zA-Z0-9\s_.\[\]()'",!=<>&|+\-*/%:]+$/.test(val);
+      },
+      { message: "Invalid filter: contains disallowed characters" }
+    ),
+} as const;


### PR DESCRIPTION
## Summary

Implement a new tRPC-based REST endpoint (`POST /v1/pipelineruns/start`) to trigger and execute PipelineRuns directly from the CLI or API.

## Features

- Parameter overrides for PipelineRuns
- Custom label injection with collision resolution
- TriggerTemplate integration for automated parameter sourcing
- Dry-run mode for manifest previewing
- Comprehensive input validation via Zod schemas

## Implementation

- New `pipelineRun` tRPC router with `start` procedure
- Helpers for param/label merging, resource lookup, draft preparation, and row projection
- New Zod schemas (`tektonInput`, `pipelineRunStartRow`) for strict input validation
- OpenAPI definitions extended for the new endpoint
- Extensive unit test coverage for the start procedure and schema validation

## Test plan

- [x] Verify `POST /v1/pipelineruns/start` triggers a PipelineRun with default params
- [x] Verify user-supplied params override Pipeline defaults
- [x] Verify user-supplied labels merge correctly (user wins on collisions)
- [x] Verify TriggerTemplate-driven flow when the Pipeline has the corresponding label
- [x] Verify `dryRun: true` returns the manifest without creating a resource
- [x] Verify input validation rejects malformed namespace, pipeline name, params, labels