### PR TITLE
EPMDEDP-16763: feat: Add severity filtering to SCA findings REST endpoint

### DIFF
--- a/apps/server/src/config/openapi.sca.test.ts
+++ b/apps/server/src/config/openapi.sca.test.ts
@@ -620,6 +620,10 @@ describe("GET /rest/v1/sca/findings", () => {
     vi.clearAllMocks();
     app = buildFastify();
     await app.ready();
+    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
+    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
+      MOCK_PROJECT
+    );
   });
 
   afterEach(async () => {
@@ -627,10 +631,6 @@ describe("GET /rest/v1/sca/findings", () => {
   });
 
   it("happy path — returns sorted findings with truncated flag", async () => {
-    stubCaller.k8s.get.mockResolvedValue({ spec: { defaultBranch: "main" } });
-    stubCaller.dependencyTrack.getProjectByNameAndVersion.mockResolvedValue(
-      MOCK_PROJECT
-    );
     stubCaller.dependencyTrack.getFindingsByProject.mockResolvedValue([
       makeFinding("LOW", "axios", "CVE-2023-001"),
       makeFinding("CRITICAL", "lodash", "CVE-2022-002"),
@@ -661,5 +661,94 @@ describe("GET /rest/v1/sca/findings", () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.json<{ error: string }>().error).toMatch(/codebase/);
+  });
+
+  it("severity filter excludes findings outside the requested set", async () => {
+    stubCaller.dependencyTrack.getFindingsByProject.mockResolvedValue([
+      makeFinding("CRITICAL", "lodash", "CVE-1"),
+      makeFinding("HIGH", "axios", "CVE-2"),
+      makeFinding("MEDIUM", "express", "CVE-3"),
+      makeFinding("LOW", "react", "CVE-4"),
+    ]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/findings?codebase=my-service&severity=CRITICAL,HIGH",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      status: string;
+      items: Array<{ vulnerability: { severity: string } }>;
+      truncated: boolean;
+    }>();
+    expect(body.status).toBe("OK");
+    expect(body.truncated).toBe(false);
+    expect(body.items).toHaveLength(2);
+    expect(body.items.map((i) => i.vulnerability.severity).sort()).toEqual([
+      "CRITICAL",
+      "HIGH",
+    ]);
+  });
+
+  it("severity filter cap: 1500 critical findings → 1000 returned, truncated=true", async () => {
+    const huge = Array.from({ length: 1500 }, (_, i) =>
+      makeFinding("CRITICAL", `pkg-${String(i).padStart(4, "0")}`, `CVE-${i}`)
+    );
+    stubCaller.dependencyTrack.getFindingsByProject.mockResolvedValue(huge);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/findings?codebase=my-service&severity=CRITICAL",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ items: unknown[]; truncated: boolean }>();
+    expect(body.items).toHaveLength(1000);
+    expect(body.truncated).toBe(true);
+  });
+
+  it("severity filter under cap: 50 critical of 1500 mixed → 50 returned, truncated=false", async () => {
+    const mixed = [
+      ...Array.from({ length: 50 }, (_, i) =>
+        makeFinding(
+          "CRITICAL",
+          `crit-${String(i).padStart(2, "0")}`,
+          `CVE-CRIT-${i}`
+        )
+      ),
+      ...Array.from({ length: 1450 }, (_, i) =>
+        makeFinding("LOW", `low-${String(i).padStart(4, "0")}`, `CVE-LOW-${i}`)
+      ),
+    ];
+    stubCaller.dependencyTrack.getFindingsByProject.mockResolvedValue(mixed);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/findings?codebase=my-service&severity=CRITICAL",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      items: Array<{ vulnerability: { severity: string } }>;
+      truncated: boolean;
+    }>();
+    expect(body.items).toHaveLength(50);
+    expect(body.truncated).toBe(false);
+    expect(
+      body.items.every((i) => i.vulnerability.severity === "CRITICAL")
+    ).toBe(true);
+  });
+
+  it("returns 400 when severity contains an unknown value", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/v1/sca/findings?codebase=my-service&severity=garbage",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(
+      /severity must be a comma-separated/
+    );
   });
 });

--- a/apps/server/src/config/openapi.ts
+++ b/apps/server/src/config/openapi.ts
@@ -22,6 +22,7 @@ import {
   toZeroIndexedPage,
   truncateFindings,
   type ResolvedBranch,
+  type ScaSeverity,
 } from "./sca-helpers.js";
 import { TRPCError } from "@trpc/server";
 import { getHTTPStatusCodeFromError } from "@trpc/server/http";
@@ -727,12 +728,21 @@ export function registerOpenApi(
       branch?: string;
       suppressed?: "true" | "false";
       source?: string;
+      severity?: string;
     };
   }>("/rest/v1/sca/findings", async (req, res) => {
     try {
-      const { codebase, branch, suppressed, source } = req.query;
+      const { codebase, branch, suppressed, source, severity } = req.query;
       if (!codebase) {
         return res.code(400).send({ error: "codebase is required" });
+      }
+
+      const parsedSeverity = parseSeverityCsv(severity);
+      if (parsedSeverity === "invalid") {
+        return res.code(400).send({
+          error:
+            "severity must be a comma-separated list of CRITICAL|HIGH|MEDIUM|LOW|INFO|UNASSIGNED",
+        });
       }
 
       const caller = await buildCaller(req, res);
@@ -760,8 +770,17 @@ export function registerOpenApi(
         source: source || undefined,
       });
 
+      // Filter BEFORE sort/truncate so the 1000-row cap applies to the
+      // matching set; `truncated=true` therefore means "more matching findings
+      // exist than were returned", not "more unfiltered rows existed upstream".
+      const filtered = parsedSeverity
+        ? all.filter((f) =>
+            parsedSeverity.has(f.vulnerability.severity as ScaSeverity)
+          )
+        : all;
+
       // Deterministic sort per spec §D10, then truncate at SCA_FINDINGS_MAX.
-      const sorted = sortFindings(all);
+      const sorted = sortFindings(filtered);
       const { items, truncated } = truncateFindings(sorted);
 
       return {

--- a/apps/server/src/config/sca-helpers.ts
+++ b/apps/server/src/config/sca-helpers.ts
@@ -32,6 +32,8 @@ export const SCA_SEVERITIES = [
 export type ScaSeverity = (typeof SCA_SEVERITIES)[number];
 export type SeveritySet = ReadonlySet<ScaSeverity>;
 
+const SCA_SEVERITIES_SET = new Set<string>(SCA_SEVERITIES);
+
 /** Cap on auto-paging iterations when the severity filter triggers the full-project scan loop. */
 export const SCA_PAGE_SIZE_MAX_PAGES = 50;
 
@@ -161,13 +163,12 @@ export function parseSeverityCsv(
   raw: string | undefined
 ): SeveritySet | "invalid" | undefined {
   if (raw === undefined || raw === "") return undefined;
-  const allowed = new Set<string>(SCA_SEVERITIES);
   const out = new Set<ScaSeverity>();
   for (const token of raw.split(",")) {
     const trimmed = token.trim();
     if (trimmed === "") continue;
     const upper = trimmed.toUpperCase();
-    if (!allowed.has(upper)) return "invalid";
+    if (!SCA_SEVERITIES_SET.has(upper)) return "invalid";
     out.add(upper as ScaSeverity);
   }
   if (out.size === 0) return undefined;

--- a/packages/trpc/api/openapi.json
+++ b/packages/trpc/api/openapi.json
@@ -1049,6 +1049,338 @@
           }
         }
       }
+    },
+    "/v1/sca/findings": {
+      "get": {
+        "operationId": "sca-findings",
+        "tags": [
+          "sca"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "codebase",
+            "description": "Codebase (KubeRocketCI Codebase CR) name.",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "branch",
+            "description": "Branch override; defaults to the codebase's spec.defaultBranch.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "suppressed",
+            "description": "Include suppressed findings.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "description": "Filter findings by analyzer source (e.g. NPM, OSSINDEX_ANALYZER).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "severity",
+            "description": "Comma-separated list of severities to include. Allowed values: CRITICAL, HIGH, MEDIUM, LOW, INFO, UNASSIGNED. The filter is applied before the 1000-row server cap, so `truncated=true` reports that more matching findings exist than were returned.",
+            "schema": {
+              "type": "string",
+              "pattern": "^(CRITICAL|HIGH|MEDIUM|LOW|INFO|UNASSIGNED)(,(CRITICAL|HIGH|MEDIUM|LOW|INFO|UNASSIGNED))*$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response. status='NONE' when no Dep-Track project matches the codebase+branch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "OK",
+                        "NONE"
+                      ]
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Finding"
+                      }
+                    },
+                    "truncated": {
+                      "type": "boolean",
+                      "description": "True when more matching findings exist than were returned (1000-row server cap)."
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "items",
+                    "truncated"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Codebase not found or default branch missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.NOT_FOUND"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream Dep-Track failure"
+          },
+          "503": {
+            "description": "Dep-Track integration not configured"
+          }
+        }
+      }
+    },
+    "/v1/sca/components": {
+      "get": {
+        "operationId": "sca-components",
+        "tags": [
+          "sca"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "codebase",
+            "description": "Codebase (KubeRocketCI Codebase CR) name.",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "branch",
+            "description": "Branch override; defaults to the codebase's spec.defaultBranch.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageNumber",
+            "description": "1-indexed page number.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "description": "Page size, capped at 100.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*$"
+            }
+          },
+          {
+            "in": "query",
+            "name": "onlyOutdated",
+            "description": "Only outdated components.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "onlyDirect",
+            "description": "Only direct dependencies.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "severity",
+            "description": "Comma-separated list of severities to include. Allowed values: CRITICAL, HIGH, MEDIUM, LOW, INFO, UNASSIGNED. When set, the portal auto-pages Dep-Track and filters across the entire project before paginating; `truncated=true` indicates the safety cap was hit and not all matches were inspected.",
+            "schema": {
+              "type": "string",
+              "pattern": "^(CRITICAL|HIGH|MEDIUM|LOW|INFO|UNASSIGNED)(,(CRITICAL|HIGH|MEDIUM|LOW|INFO|UNASSIGNED))*$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response. status='NONE' when no Dep-Track project matches the codebase+branch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "OK",
+                        "NONE"
+                      ]
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DtComponent"
+                      }
+                    },
+                    "totalCount": {
+                      "type": "integer"
+                    },
+                    "truncated": {
+                      "type": "boolean",
+                      "description": "True when the auto-paging safety cap fired before all components were inspected."
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "items",
+                    "totalCount",
+                    "truncated"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Codebase not found or default branch missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.NOT_FOUND"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream Dep-Track failure"
+          },
+          "503": {
+            "description": "Dep-Track integration not configured"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1270,6 +1602,212 @@
           "message": "Not found",
           "issues": []
         }
+      },
+      "Finding": {
+        "type": "object",
+        "description": "Dependency-Track finding (component + vulnerability + analysis + attribution).",
+        "properties": {
+          "component": {
+            "type": "object",
+            "properties": {
+              "uuid": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "group": {
+                "type": "string"
+              },
+              "latestVersion": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "uuid",
+              "name"
+            ]
+          },
+          "vulnerability": {
+            "type": "object",
+            "properties": {
+              "vulnId": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "severity": {
+                "type": "string",
+                "enum": [
+                  "CRITICAL",
+                  "HIGH",
+                  "MEDIUM",
+                  "LOW",
+                  "INFO",
+                  "UNASSIGNED"
+                ]
+              },
+              "severityRank": {
+                "type": "number"
+              },
+              "cwes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "cweId": {
+                      "type": "number"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "cweId",
+                    "name"
+                  ]
+                }
+              },
+              "aliases": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    },
+                    "vulnId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "source",
+                    "vulnId"
+                  ]
+                }
+              },
+              "cvssV2BaseScore": {
+                "type": "number"
+              },
+              "cvssV3BaseScore": {
+                "type": "number"
+              },
+              "epssScore": {
+                "type": "number"
+              },
+              "epssPercentile": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "vulnId",
+              "source",
+              "severity"
+            ]
+          },
+          "analysis": {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "EXPLOITABLE",
+                  "IN_TRIAGE",
+                  "RESOLVED",
+                  "FALSE_POSITIVE",
+                  "NOT_AFFECTED",
+                  "NOT_SET"
+                ]
+              },
+              "isSuppressed": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "isSuppressed"
+            ]
+          },
+          "attribution": {
+            "type": "object",
+            "properties": {
+              "analyzerIdentity": {
+                "type": "string"
+              },
+              "attributedOn": {
+                "type": "number"
+              },
+              "alternateIdentifier": {
+                "type": "string"
+              },
+              "referenceUrl": {
+                "type": "string"
+              }
+            }
+          },
+          "matrix": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "component",
+          "vulnerability"
+        ]
+      },
+      "DtComponent": {
+        "type": "object",
+        "description": "Dependency-Track component (project dependency) row.",
+        "properties": {
+          "uuid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "purl": {
+            "type": "string"
+          },
+          "latestVersion": {
+            "type": "string"
+          },
+          "isOutdated": {
+            "type": "boolean"
+          },
+          "metrics": {
+            "type": "object",
+            "description": "Per-component vulnerability counts.",
+            "properties": {
+              "critical": {
+                "type": "integer"
+              },
+              "high": {
+                "type": "integer"
+              },
+              "medium": {
+                "type": "integer"
+              },
+              "low": {
+                "type": "integer"
+              },
+              "unassigned": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "required": [
+          "uuid",
+          "name"
+        ]
       },
       "TaskRunRecordsResponse": {
         "type": "object",


### PR DESCRIPTION
Implement query parameter-based filtering that lets clients request findings by severity level. The filter is applied before pagination and truncation, so the 1000-row cap applies only to matching results and `truncated=true` accurately reports more matching findings exist.

Includes test coverage for filter validation, truncation behavior with large result sets, under-cap scenarios, and error cases. Updates OpenAPI spec with parameter constraints and Finding schema.
