### PR TITLE
EPMDEDP-16758: fix: Align OpenAPI spec to actual REST error envelope shape

### DIFF
--- a/apps/server/src/config/openapi.ts
+++ b/apps/server/src/config/openapi.ts
@@ -3,7 +3,9 @@ import {
   createCaller,
   type CustomSession,
   createContext,
+  rewriteErrorEnvelopeSchemas,
   type RouterInput,
+  UNKNOWN_ERROR_PHRASE,
 } from "@my-project/trpc";
 import { k8sCodebaseConfig } from "@my-project/shared";
 import {
@@ -111,7 +113,7 @@ export function registerOpenApi(
       // Derive both fields from safe, static sources — never expose error.message or stack.
       // `code` is a tRPC enum literal (e.g. "UNAUTHORIZED"); `message` is the HTTP status phrase.
       const code: string = error.code;
-      const message = STATUS_CODES[httpStatus] ?? "Unknown error";
+      const message = STATUS_CODES[httpStatus] ?? UNKNOWN_ERROR_PHRASE;
       const reason = extractCauseReason(error.cause);
       res.status(httpStatus).send({
         error: reason ? { code, reason, message } : { code, message },
@@ -842,6 +844,8 @@ export function registerOpenApi(
         },
       },
     });
+
+    rewriteErrorEnvelopeSchemas(openApiDocument);
 
     fastify.get("/rest/v1/openapi.json", async () => openApiDocument);
   }

--- a/packages/trpc/api/openapi.json
+++ b/packages/trpc/api/openapi.json
@@ -864,7 +864,8 @@
             "name": "stepName",
             "schema": {
               "type": "string",
-              "pattern": "^[a-z0-9][a-z0-9-]*$"
+              "pattern": "^[a-z0-9][a-z0-9-]*$",
+              "maxLength": 63
             }
           }
         ],
@@ -1589,212 +1590,197 @@
     "schemas": {
       "error.INTERNAL_SERVER_ERROR": {
         "type": "object",
+        "title": "INTERNAL_SERVER_ERROR error envelope (500)",
+        "description": "REST error envelope emitted by handleTRPCError. `message` is the static HTTP status phrase; `reason` (when present) is a stable machine-readable disambiguator that consumers should key off rather than parsing the human message.",
+        "required": [
+          "error"
+        ],
         "properties": {
-          "message": {
-            "type": "string",
-            "description": "The error message",
-            "example": "Internal server error"
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code",
-            "example": "INTERNAL_SERVER_ERROR"
-          },
-          "issues": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string"
-                }
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "tRPC error code (string literal)",
+                "example": "INTERNAL_SERVER_ERROR"
               },
-              "required": [
-                "message"
-              ]
-            },
-            "description": "An array of issues that were responsible for the error",
-            "example": []
+              "reason": {
+                "type": "string",
+                "description": "Stable machine-readable disambiguator (omitted when none applies)"
+              },
+              "message": {
+                "type": "string",
+                "description": "Static HTTP status phrase",
+                "example": "Internal Server Error"
+              }
+            }
           }
         },
-        "required": [
-          "message",
-          "code"
-        ],
-        "title": "Internal server error error (500)",
-        "description": "The error information",
         "example": {
-          "code": "INTERNAL_SERVER_ERROR",
-          "message": "Internal server error",
-          "issues": []
+          "error": {
+            "code": "INTERNAL_SERVER_ERROR",
+            "message": "Internal Server Error"
+          }
         }
       },
       "error.UNAUTHORIZED": {
         "type": "object",
+        "title": "UNAUTHORIZED error envelope (401)",
+        "description": "REST error envelope emitted by handleTRPCError. `message` is the static HTTP status phrase; `reason` (when present) is a stable machine-readable disambiguator that consumers should key off rather than parsing the human message.",
+        "required": [
+          "error"
+        ],
         "properties": {
-          "message": {
-            "type": "string",
-            "description": "The error message",
-            "example": "Authorization not provided"
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code",
-            "example": "UNAUTHORIZED"
-          },
-          "issues": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string"
-                }
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "tRPC error code (string literal)",
+                "example": "UNAUTHORIZED"
               },
-              "required": [
-                "message"
-              ]
-            },
-            "description": "An array of issues that were responsible for the error",
-            "example": []
+              "reason": {
+                "type": "string",
+                "description": "Stable machine-readable disambiguator (omitted when none applies)"
+              },
+              "message": {
+                "type": "string",
+                "description": "Static HTTP status phrase",
+                "example": "Unauthorized"
+              }
+            }
           }
         },
-        "required": [
-          "message",
-          "code"
-        ],
-        "title": "Authorization not provided error (401)",
-        "description": "The error information",
         "example": {
-          "code": "UNAUTHORIZED",
-          "message": "Authorization not provided",
-          "issues": []
+          "error": {
+            "code": "UNAUTHORIZED",
+            "message": "Unauthorized"
+          }
         }
       },
       "error.FORBIDDEN": {
         "type": "object",
+        "title": "FORBIDDEN error envelope (403)",
+        "description": "REST error envelope emitted by handleTRPCError. `message` is the static HTTP status phrase; `reason` (when present) is a stable machine-readable disambiguator that consumers should key off rather than parsing the human message.",
+        "required": [
+          "error"
+        ],
         "properties": {
-          "message": {
-            "type": "string",
-            "description": "The error message",
-            "example": "Insufficient access"
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code",
-            "example": "FORBIDDEN"
-          },
-          "issues": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string"
-                }
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "tRPC error code (string literal)",
+                "example": "FORBIDDEN"
               },
-              "required": [
-                "message"
-              ]
-            },
-            "description": "An array of issues that were responsible for the error",
-            "example": []
+              "reason": {
+                "type": "string",
+                "description": "Stable machine-readable disambiguator (omitted when none applies)"
+              },
+              "message": {
+                "type": "string",
+                "description": "Static HTTP status phrase",
+                "example": "Forbidden"
+              }
+            }
           }
         },
-        "required": [
-          "message",
-          "code"
-        ],
-        "title": "Insufficient access error (403)",
-        "description": "The error information",
         "example": {
-          "code": "FORBIDDEN",
-          "message": "Insufficient access",
-          "issues": []
+          "error": {
+            "code": "FORBIDDEN",
+            "message": "Forbidden"
+          }
         }
       },
       "error.BAD_REQUEST": {
         "type": "object",
+        "title": "BAD_REQUEST error envelope (400)",
+        "description": "REST error envelope emitted by handleTRPCError. `message` is the static HTTP status phrase; `reason` (when present) is a stable machine-readable disambiguator that consumers should key off rather than parsing the human message.",
+        "required": [
+          "error"
+        ],
         "properties": {
-          "message": {
-            "type": "string",
-            "description": "The error message",
-            "example": "Invalid input data"
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code",
-            "example": "BAD_REQUEST"
-          },
-          "issues": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string"
-                }
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "tRPC error code (string literal)",
+                "example": "BAD_REQUEST"
               },
-              "required": [
-                "message"
-              ]
-            },
-            "description": "An array of issues that were responsible for the error",
-            "example": []
+              "reason": {
+                "type": "string",
+                "description": "Stable machine-readable disambiguator (omitted when none applies)"
+              },
+              "message": {
+                "type": "string",
+                "description": "Static HTTP status phrase",
+                "example": "Bad Request"
+              }
+            }
           }
         },
-        "required": [
-          "message",
-          "code"
-        ],
-        "title": "Invalid input data error (400)",
-        "description": "The error information",
         "example": {
-          "code": "BAD_REQUEST",
-          "message": "Invalid input data",
-          "issues": []
+          "error": {
+            "code": "BAD_REQUEST",
+            "message": "Bad Request"
+          }
         }
       },
       "error.NOT_FOUND": {
         "type": "object",
+        "title": "NOT_FOUND error envelope (404)",
+        "description": "REST error envelope emitted by handleTRPCError. `message` is the static HTTP status phrase; `reason` (when present) is a stable machine-readable disambiguator that consumers should key off rather than parsing the human message.",
+        "required": [
+          "error"
+        ],
         "properties": {
-          "message": {
-            "type": "string",
-            "description": "The error message",
-            "example": "Not found"
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code",
-            "example": "NOT_FOUND"
-          },
-          "issues": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string"
-                }
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "tRPC error code (string literal)",
+                "example": "NOT_FOUND"
               },
-              "required": [
-                "message"
-              ]
-            },
-            "description": "An array of issues that were responsible for the error",
-            "example": []
+              "reason": {
+                "type": "string",
+                "description": "Stable machine-readable disambiguator (omitted when none applies)"
+              },
+              "message": {
+                "type": "string",
+                "description": "Static HTTP status phrase",
+                "example": "Not Found"
+              }
+            }
           }
         },
-        "required": [
-          "message",
-          "code"
-        ],
-        "title": "Not found error (404)",
-        "description": "The error information",
         "example": {
-          "code": "NOT_FOUND",
-          "message": "Not found",
-          "issues": []
+          "error": {
+            "code": "NOT_FOUND",
+            "message": "Not Found"
+          }
         }
       },
       "Finding": {

--- a/packages/trpc/scripts/generate-openapi.ts
+++ b/packages/trpc/scripts/generate-openapi.ts
@@ -1,4 +1,5 @@
 import { appRouter } from "../src/routers/index.js";
+import { rewriteErrorEnvelopeSchemas } from "../src/utils/openapi/index.js";
 import { generateOpenApiDocument } from "trpc-to-openapi";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname, relative, isAbsolute } from "node:path";
@@ -16,6 +17,8 @@ const doc = generateOpenApiDocument(appRouter, {
     },
   },
 });
+
+rewriteErrorEnvelopeSchemas(doc);
 
 const rawPath = process.argv[2] || "dist/openapi.json";
 const outPath = resolve(rawPath);

--- a/packages/trpc/src/index.ts
+++ b/packages/trpc/src/index.ts
@@ -4,3 +4,5 @@ export type { TRPCContext, CustomSession } from "./context/types.js";
 
 export { createContext } from "./context/create.js";
 export { appRouter, createCaller } from "./routers/index.js";
+
+export { rewriteErrorEnvelopeSchemas, UNKNOWN_ERROR_PHRASE } from "./utils/openapi/index.js";

--- a/packages/trpc/src/utils/openapi/index.test.ts
+++ b/packages/trpc/src/utils/openapi/index.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import type { OpenAPIObject } from "trpc-to-openapi";
+import { rewriteErrorEnvelopeSchemas } from "./index.js";
+
+interface RewrittenSchema {
+  type: string;
+  required: string[];
+  properties: {
+    error: {
+      type: string;
+      required: string[];
+      properties: {
+        code: { example: string };
+        reason: { description: string };
+        message: { example: string };
+      };
+    };
+  };
+  example: { error: { code: string; message: string } };
+}
+
+type DocWithSchemas = OpenAPIObject & { components: { schemas: Record<string, unknown> } };
+
+const makeDoc = (schemas: Record<string, unknown>): DocWithSchemas =>
+  ({
+    openapi: "3.1.0",
+    info: { title: "test", version: "1.0.0" },
+    components: { schemas },
+  }) as DocWithSchemas;
+
+describe("rewriteErrorEnvelopeSchemas", () => {
+  it("rewrites every error.* schema to describe the {error: {code, reason?, message}} envelope", () => {
+    const doc = makeDoc({
+      "error.BAD_REQUEST": {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+          code: { type: "string" },
+          issues: { type: "array" },
+        },
+        required: ["message", "code"],
+      },
+      "error.NOT_FOUND": {
+        type: "object",
+        properties: { message: { type: "string" }, code: { type: "string" } },
+        required: ["message", "code"],
+      },
+    });
+
+    rewriteErrorEnvelopeSchemas(doc);
+
+    const bad = doc.components.schemas["error.BAD_REQUEST"] as unknown as RewrittenSchema;
+
+    expect(bad.type).toBe("object");
+    expect(bad.required).toEqual(["error"]);
+    expect(bad.properties.error.type).toBe("object");
+    expect(bad.properties.error.required).toEqual(["code", "message"]);
+    expect(bad.properties.error.properties.code.example).toBe("BAD_REQUEST");
+    expect(bad.properties.error.properties.message.example).toBe("Bad Request");
+    expect(typeof bad.properties.error.properties.reason.description).toBe("string");
+    // The legacy top-level `issues` field is gone after the rewrite.
+    expect((bad.properties as Record<string, unknown>).issues).toBeUndefined();
+    expect(bad.example.error.code).toBe("BAD_REQUEST");
+    expect(bad.example.error.message).toBe("Bad Request");
+  });
+
+  it("uses the correct HTTP status phrase for each tRPC code", () => {
+    const doc = makeDoc({
+      "error.UNAUTHORIZED": {},
+      "error.FORBIDDEN": {},
+      "error.NOT_FOUND": {},
+      "error.TIMEOUT": {},
+      "error.CONFLICT": {},
+      "error.UNPROCESSABLE_CONTENT": {},
+      "error.TOO_MANY_REQUESTS": {},
+      "error.INTERNAL_SERVER_ERROR": {},
+    });
+
+    rewriteErrorEnvelopeSchemas(doc);
+
+    const phrase = (key: string) => (doc.components.schemas[key] as unknown as RewrittenSchema).example.error.message;
+
+    expect(phrase("error.UNAUTHORIZED")).toBe("Unauthorized");
+    expect(phrase("error.FORBIDDEN")).toBe("Forbidden");
+    expect(phrase("error.NOT_FOUND")).toBe("Not Found");
+    expect(phrase("error.TIMEOUT")).toBe("Request Timeout");
+    expect(phrase("error.CONFLICT")).toBe("Conflict");
+    expect(phrase("error.UNPROCESSABLE_CONTENT")).toBe("Unprocessable Entity");
+    expect(phrase("error.TOO_MANY_REQUESTS")).toBe("Too Many Requests");
+    expect(phrase("error.INTERNAL_SERVER_ERROR")).toBe("Internal Server Error");
+  });
+
+  it("leaves non-error.* schemas untouched", () => {
+    const original = {
+      type: "object",
+      properties: { kind: { type: "string", enum: ["created"] } },
+    };
+    const doc = makeDoc({
+      PipelineRunStartCreatedResponse: original,
+      "error.BAD_REQUEST": {},
+    });
+
+    rewriteErrorEnvelopeSchemas(doc);
+
+    expect(doc.components.schemas.PipelineRunStartCreatedResponse).toBe(original);
+  });
+
+  it("is a no-op when components.schemas is missing", () => {
+    const doc: OpenAPIObject = {
+      openapi: "3.1.0",
+      info: { title: "test", version: "1.0.0" },
+    };
+    expect(() => rewriteErrorEnvelopeSchemas(doc)).not.toThrow();
+  });
+
+  it("delegates to tRPC's runtime mapping for unknown codes (defaults to 500)", () => {
+    // tRPC's getStatusCodeFromKey returns 500 for any code not in
+    // TRPC_ERROR_CODES_BY_KEY — the same fallback a real client would see if
+    // a procedure threw with a custom code. Asserting this keeps the schema
+    // examples in lockstep with runtime behaviour.
+    const doc = makeDoc({ "error.UNKNOWN_CUSTOM_CODE": {} });
+    rewriteErrorEnvelopeSchemas(doc);
+    const schema = doc.components.schemas["error.UNKNOWN_CUSTOM_CODE"] as unknown as RewrittenSchema;
+    expect(schema.example.error.code).toBe("UNKNOWN_CUSTOM_CODE");
+    expect(schema.example.error.message).toBe("Internal Server Error");
+  });
+});

--- a/packages/trpc/src/utils/openapi/index.ts
+++ b/packages/trpc/src/utils/openapi/index.ts
@@ -1,0 +1,86 @@
+import { STATUS_CODES } from "node:http";
+import { TRPCError } from "@trpc/server";
+import { getHTTPStatusCodeFromError } from "@trpc/server/http";
+import type { OpenAPIObject } from "trpc-to-openapi";
+
+const ERROR_SCHEMA_PREFIX = "error.";
+
+/**
+ * Fallback `error.message` when an HTTP status has no canonical phrase.
+ * Imported by `handleTRPCError` so the wire payload and the OpenAPI example
+ * never drift.
+ */
+export const UNKNOWN_ERROR_PHRASE = "Unknown error";
+
+const ENVELOPE_DESCRIPTION =
+  "REST error envelope emitted by handleTRPCError. `message` is the static HTTP " +
+  "status phrase; `reason` (when present) is a stable machine-readable disambiguator " +
+  "that consumers should key off rather than parsing the human message.";
+
+const REASON_PROPERTY_SCHEMA = {
+  type: "string",
+  description: "Stable machine-readable disambiguator (omitted when none applies)",
+} as const;
+
+/**
+ * Rewrites every `error.<CODE>` schema in an OpenAPI document so it describes
+ * the REST envelope that `handleTRPCError` (apps/server/src/config/openapi.ts)
+ * actually emits:
+ *
+ *   { error: { code, reason?, message } }
+ *
+ * trpc-to-openapi's default output documents tRPC's native error JSON
+ * ({code, message, issues[]}), which is NOT what the Fastify adapter sends on
+ * the wire. Calling this rewriter brings the doc in line with what REST
+ * consumers (e.g. the Go CLI) actually receive, so generated client types are
+ * accurate and key off `error.reason` rather than hand-parsing.
+ *
+ * Schema names (`error.BAD_REQUEST`, `error.NOT_FOUND`, ...) are preserved so
+ * existing path `$ref` entries in the generated doc remain valid; only the
+ * schema bodies change.
+ */
+export function rewriteErrorEnvelopeSchemas(doc: OpenAPIObject): void {
+  const schemas = doc.components?.schemas;
+  if (!schemas) return;
+
+  for (const name of Object.keys(schemas)) {
+    if (!name.startsWith(ERROR_SCHEMA_PREFIX)) continue;
+
+    const trpcCode = name.slice(ERROR_SCHEMA_PREFIX.length);
+    // Derive status/phrase exactly as handleTRPCError does
+    // (apps/server/src/config/openapi.ts) so example.message matches the wire.
+    // The cast is safe at runtime: getHTTPStatusCodeFromError falls back to 500
+    // for any code not in TRPC_ERROR_CODES_BY_KEY.
+    const httpStatus = getHTTPStatusCodeFromError(new TRPCError({ code: trpcCode as TRPCError["code"] }));
+    const phrase = STATUS_CODES[httpStatus] ?? UNKNOWN_ERROR_PHRASE;
+
+    schemas[name] = {
+      type: "object",
+      title: `${trpcCode} error envelope (${httpStatus})`,
+      description: ENVELOPE_DESCRIPTION,
+      required: ["error"],
+      properties: {
+        error: {
+          type: "object",
+          required: ["code", "message"],
+          properties: {
+            code: {
+              type: "string",
+              description: "tRPC error code (string literal)",
+              example: trpcCode,
+            },
+            reason: REASON_PROPERTY_SCHEMA,
+            message: {
+              type: "string",
+              description: "Static HTTP status phrase",
+              example: phrase,
+            },
+          },
+        },
+      },
+      example: {
+        error: { code: trpcCode, message: phrase },
+      },
+    };
+  }
+}


### PR DESCRIPTION
Portal side: The auto-generated openapi.json documents tRPC's native error JSON ({code, message, issues[]}) but the Fastify adapter (handleTRPCError) wraps everything in {error: {code, reason?, message}}. This mismatch meant any SDK consumer (web client REST shims, third-party clients, future tools) would get incorrect types.

Added rewriteErrorEnvelopeSchemas() util to fix schemas post-generation. Wired into both build-time (scripts/generate-openapi.ts) and dev-time (/rest/v1/openapi.json endpoint) so the contract is always truthful.

CLI side: Synced the corrected error.* schemas into spec.json. Generated Go types now correctly expose .Error.{Code,Message,Reason} instead of phantom .Issues[] field. Added 408/409/422/429 status responses on /v1/pipelineruns/start for admission failures (the common 422 missing-required-param case).

Why: The spec is the contract publisher. A lying spec duplicates workarounds across all consumers (CLI hand-parses to dodge it; next consumer will too). Fixing it at the source eliminates tribal knowledge and provides accurate types for free to anyone building against the portal's REST API.

