### PR TITLE
feat(webhook-triggers): add Webhook Triggers section

### DIFF
--- a/apps/client/src/core/components/AuthorAvatar/index.tsx
+++ b/apps/client/src/core/components/AuthorAvatar/index.tsx
@@ -36,7 +36,7 @@ const getInitials = (name: string): string => {
 };
 
 const sizeClasses = {
-  sm: "size-6 text-[10px]",
+  sm: "size-6 text-xs",
   md: "size-8 text-xs",
 } as const;
 

--- a/apps/client/src/core/components/CodeEditor/index.tsx
+++ b/apps/client/src/core/components/CodeEditor/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import MonacoEditor from "@monaco-editor/react";
 import * as yaml from "js-yaml";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
+import { useMonacoTheme } from "@/core/hooks/useTheme";
 
 export type CodeEditorChangeHandler = (text: string, json: object | null, error?: Error) => void;
 
@@ -32,7 +33,7 @@ const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
       language = "yaml",
       height = "500px",
       readOnly = !onChange,
-      theme = "vs-light",
+      theme,
       options,
       serialize = (input: unknown) => yaml.dump(input),
       parse = (text: string) => yaml.load(text) as object,
@@ -40,6 +41,9 @@ const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
     },
     ref
   ) => {
+    const monacoTheme = useMonacoTheme();
+    const resolvedTheme = theme ?? monacoTheme;
+
     const [text, setText] = React.useState<string>("");
     const [error, setError] = React.useState<Error | null>(null);
     const [calculatedHeight, setCalculatedHeight] = React.useState<number>(500);
@@ -163,7 +167,7 @@ const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
             language={language}
             value={text}
             onChange={handleChange}
-            theme={theme}
+            theme={resolvedTheme}
             options={{
               readOnly,
               minimap: { enabled: false },
@@ -182,7 +186,7 @@ const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
         language={language}
         value={text}
         onChange={handleChange}
-        theme={theme}
+        theme={resolvedTheme}
         options={{
           readOnly,
           minimap: { enabled: false },

--- a/apps/client/src/core/components/CreateResourceDialog/index.tsx
+++ b/apps/client/src/core/components/CreateResourceDialog/index.tsx
@@ -102,7 +102,6 @@ export default function CreateResourceDialog({ state }: CreateResourceDialogProp
               if (err) setParseError(err.message);
               else setParseError(null);
             }}
-            theme="vs-light"
             options={{ minimap: { enabled: false } }}
           />
           {parseError && <Alert variant="destructive">{parseError}</Alert>}

--- a/apps/client/src/core/components/EditorYAML/index.tsx
+++ b/apps/client/src/core/components/EditorYAML/index.tsx
@@ -52,7 +52,6 @@ export default function EditorYAML({ props, state }: KubeResourceEditorProps) {
               else setError(null);
               onChange?.(text, json, err);
             }}
-            theme="vs-light"
             options={{
               readOnly,
               minimap: { enabled: false },

--- a/apps/client/src/core/components/MetricCard/index.tsx
+++ b/apps/client/src/core/components/MetricCard/index.tsx
@@ -3,12 +3,12 @@ import { LoadingSpinner } from "@/core/components/ui/LoadingSpinner";
 import { TriangleAlert, ArrowRight } from "lucide-react";
 import { STATUS_COLOR } from "@/k8s/constants/colors";
 import { Link } from "@tanstack/react-router";
-import { SecurityMetricCardProps } from "./types";
+import { MetricCardProps } from "./types";
 
 /**
- * Reusable security metric card component
+ * Reusable metric card component
  *
- * Displays security metrics (SAST/SCA) with a consistent layout:
+ * Displays metrics with a consistent layout:
  * - Title with optional badge on the left
  * - Metric badges on the right
  * - Empty state with warning icon when no data available
@@ -16,7 +16,7 @@ import { SecurityMetricCardProps } from "./types";
  * - Responsive design (hides badges on mobile)
  *
  * @example
- * <SecurityMetricCard
+ * <MetricCard
  *   title="Code Quality (SonarQube)"
  *   badge={<QualityGateBadge status="OK" />}
  *   hasData={!!data}
@@ -24,9 +24,9 @@ import { SecurityMetricCardProps } from "./types";
  *   detailsLink={{ to: "/sast/projects/$namespace/$projectKey", params: {...} }}
  * >
  *   <SonarQubeMetricsList measures={data?.measures} />
- * </SecurityMetricCard>
+ * </MetricCard>
  */
-export function SecurityMetricCard({
+export function MetricCard({
   title,
   badge,
   children,
@@ -35,7 +35,7 @@ export function SecurityMetricCard({
   hasData = true,
   emptyStateMessage = "No metrics available",
   detailsLink,
-}: SecurityMetricCardProps) {
+}: MetricCardProps) {
   const cardContent = (
     <CardContent className="p-6">
       <div className="flex items-start justify-between gap-6">

--- a/apps/client/src/core/components/MetricCard/types.ts
+++ b/apps/client/src/core/components/MetricCard/types.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-export interface SecurityMetricCardProps {
+export interface MetricCardProps {
   /**
    * Card title (e.g., "Code Quality (SonarQube)")
    */

--- a/apps/client/src/core/components/ResourceIconLink/index.tsx
+++ b/apps/client/src/core/components/ResourceIconLink/index.tsx
@@ -29,7 +29,7 @@ const iconSizeByBtnSize = (btnSize: ButtonSize) => {
 const textDisplaySizeClasses = (btnSize: ButtonSize) => {
   switch (btnSize) {
     case "xs":
-      return "px-2 py-0.5 text-[11px] gap-1 rounded-md";
+      return "px-2 py-0.5 text-xs gap-1 rounded-md";
     case "sm":
       return "px-2.5 py-1 text-xs gap-1.5 rounded-lg";
     case "lg":

--- a/apps/client/src/core/components/sidebar/SidebarSubGroupMenuItem.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarSubGroupMenuItem.tsx
@@ -73,7 +73,7 @@ export const SidebarSubGroupMenuItem = ({ subGroup, parentGroupId, onNavigate }:
   return (
     <div>
       {/* Sub-group header */}
-      <div className="text-muted-foreground border-border mt-3 mb-2 border-b px-2 py-1.5 text-[11px] font-medium tracking-wider uppercase first:mt-1">
+      <div className="text-muted-foreground border-border mt-3 mb-2 border-b px-2 py-1.5 text-xs font-medium tracking-wider uppercase first:mt-1">
         {subGroup.title}
       </div>
       {/* Sub-group items */}

--- a/apps/client/src/core/components/sidebar/navigationConfig.ts
+++ b/apps/client/src/core/components/sidebar/navigationConfig.ts
@@ -8,8 +8,11 @@ import {
   CloudUpload,
   Code,
   Database,
+  FileCode,
   FileText,
+  Funnel,
   GitBranch,
+  Globe,
   Layers,
   Link2,
   PanelsTopLeft,
@@ -19,6 +22,8 @@ import {
   Shield,
   ShieldAlert,
   ShieldCheck,
+  Webhook,
+  Zap,
 } from "lucide-react";
 import { routeCICD, routeConfiguration, routeObservability, routeSecurity } from "@/core/router";
 import { PATH_OVERVIEW_FULL } from "@/modules/platform/overview/pages/details/route";
@@ -42,6 +47,12 @@ import { PATH_CDPIPELINES_FULL } from "@/modules/platform/cdpipelines/pages/list
 import { PATH_PIPELINERUNS_FULL } from "@/modules/platform/tekton/pages/pipelinerun-list/route";
 import { PATH_PIPELINES_FULL } from "@/modules/platform/tekton/pages/pipeline-list/route";
 import { PATH_TASKS_FULL } from "@/modules/platform/tekton/pages/task-list/route";
+import { PATH_EVENT_LISTENERS_FULL } from "@/modules/platform/tekton/pages/event-listener-list/route";
+import { PATH_TRIGGERS_FULL } from "@/modules/platform/tekton/pages/trigger-list/route";
+import { PATH_TRIGGER_TEMPLATES_FULL } from "@/modules/platform/tekton/pages/trigger-template-list/route";
+import { PATH_TRIGGER_BINDINGS_FULL } from "@/modules/platform/tekton/pages/trigger-binding-list/route";
+import { PATH_INTERCEPTORS_FULL } from "@/modules/platform/tekton/pages/interceptor-list/route";
+import { PATH_CLUSTER_INTERCEPTORS_FULL } from "@/modules/platform/tekton/pages/cluster-interceptor-list/route";
 import { PATH_CONFIG_QUICKLINKS_FULL } from "@/modules/platform/configuration/modules/quicklinks/route";
 import { PATH_CONFIG_NEXUS_FULL } from "@/modules/platform/configuration/modules/nexus/route";
 import { PATH_CONFIG_REGISTRY_FULL } from "@/modules/platform/configuration/modules/registry/route";
@@ -102,6 +113,37 @@ export function createNavigationConfig(clusterName: string, namespace: string): 
             to: PATH_TASKS_FULL,
             params: clusterDefaultParams,
           },
+        },
+        {
+          title: "Webhook Triggers",
+          children: [
+            {
+              title: "Event Listeners",
+              icon: Webhook,
+              route: { to: PATH_EVENT_LISTENERS_FULL, params: clusterDefaultParams },
+            },
+            { title: "Triggers", icon: Zap, route: { to: PATH_TRIGGERS_FULL, params: clusterDefaultParams } },
+            {
+              title: "Trigger Templates",
+              icon: FileCode,
+              route: { to: PATH_TRIGGER_TEMPLATES_FULL, params: clusterDefaultParams },
+            },
+            {
+              title: "Trigger Bindings",
+              icon: Link2,
+              route: { to: PATH_TRIGGER_BINDINGS_FULL, params: clusterDefaultParams },
+            },
+            {
+              title: "Interceptors",
+              icon: Funnel,
+              route: { to: PATH_INTERCEPTORS_FULL, params: clusterDefaultParams },
+            },
+            {
+              title: "Cluster Interceptors",
+              icon: Globe,
+              route: { to: PATH_CLUSTER_INTERCEPTORS_FULL, params: clusterDefaultParams },
+            },
+          ],
         },
       ],
     },

--- a/apps/client/src/core/components/ui/title-status/index.tsx
+++ b/apps/client/src/core/components/ui/title-status/index.tsx
@@ -43,7 +43,7 @@ export default function Component() {
                   <step.icon className="size-4" />
                 </StepperIndicator>
                 <div className="flex flex-col items-start gap-1">
-                  <div className="text-muted-foreground text-[10px] font-semibold uppercase">Step {index + 1}</div>
+                  <div className="text-muted-foreground text-xs font-semibold uppercase">Step {index + 1}</div>
                   <StepperTitle className="group-data-[state=inactive]/step:text-muted-foreground text-start text-base font-semibold">
                     {step.title}
                   </StepperTitle>

--- a/apps/client/src/core/components/ui/toggle-button-group/index.tsx
+++ b/apps/client/src/core/components/ui/toggle-button-group/index.tsx
@@ -9,6 +9,8 @@ export interface ToggleButtonGroupProps<T extends string> {
   size?: "sm" | "default" | "lg";
   children: React.ReactElement<ToggleButtonProps<T>>[];
   className?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
 }
 
 export interface ToggleButtonProps<T extends string> {
@@ -24,6 +26,8 @@ export function ToggleButtonGroup<T extends string>({
   size = "sm",
   children,
   className,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: ToggleButtonGroupProps<T>) {
   const handleButtonClick = (buttonValue: T) => (event: React.MouseEvent<HTMLElement>) => {
     if (exclusive) {
@@ -37,7 +41,12 @@ export function ToggleButtonGroup<T extends string>({
   };
 
   return (
-    <div className={cn("inline-flex rounded-md border", className)} role="group">
+    <div
+      className={cn("inline-flex rounded-md border", className)}
+      role="group"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+    >
       {React.Children.map(children, (child, index) => {
         if (!React.isValidElement<ToggleButtonProps<T>>(child)) {
           return child;

--- a/apps/client/src/core/router/index.ts
+++ b/apps/client/src/core/router/index.ts
@@ -59,6 +59,18 @@ import { routeStageDetails } from "@/modules/platform/cdpipelines/pages/stage-de
 import { routeStageCreate } from "@/modules/platform/cdpipelines/pages/stages/create/route";
 import { routeTaskList } from "@/modules/platform/tekton/pages/task-list/route";
 import { routeTaskDetails } from "@/modules/platform/tekton/pages/task-details/route";
+import { routeEventListenerList } from "@/modules/platform/tekton/pages/event-listener-list/route";
+import { routeEventListenerDetails } from "@/modules/platform/tekton/pages/event-listener-details/route";
+import { routeTriggerList } from "@/modules/platform/tekton/pages/trigger-list/route";
+import { routeTriggerDetails } from "@/modules/platform/tekton/pages/trigger-details/route";
+import { routeTriggerTemplateList } from "@/modules/platform/tekton/pages/trigger-template-list/route";
+import { routeTriggerTemplateDetails } from "@/modules/platform/tekton/pages/trigger-template-details/route";
+import { routeTriggerBindingList } from "@/modules/platform/tekton/pages/trigger-binding-list/route";
+import { routeTriggerBindingDetails } from "@/modules/platform/tekton/pages/trigger-binding-details/route";
+import { routeInterceptorList } from "@/modules/platform/tekton/pages/interceptor-list/route";
+import { routeInterceptorDetails } from "@/modules/platform/tekton/pages/interceptor-details/route";
+import { routeClusterInterceptorList } from "@/modules/platform/tekton/pages/cluster-interceptor-list/route";
+import { routeClusterInterceptorDetails } from "@/modules/platform/tekton/pages/cluster-interceptor-details/route";
 import { routePipelineMetrics } from "@/modules/platform/observability/pages/pipeline-metrics/route";
 import { routeSCA } from "@/modules/platform/security/pages/sca/route";
 import { routeSCAProjects } from "@/modules/platform/security/pages/sca-projects/route";
@@ -110,6 +122,18 @@ const routeTree = rootRoute.addChildren([
         routeTaskDetails,
         routePipelineRunList,
         routePipelineRunDetails,
+        routeEventListenerList,
+        routeEventListenerDetails,
+        routeTriggerList,
+        routeTriggerDetails,
+        routeTriggerTemplateList,
+        routeTriggerTemplateDetails,
+        routeTriggerBindingList,
+        routeTriggerBindingDetails,
+        routeInterceptorList,
+        routeInterceptorDetails,
+        routeClusterInterceptorList,
+        routeClusterInterceptorDetails,
       ]),
       routeObservability.addChildren([routePipelineMetrics]),
       routeSecurity.addChildren([

--- a/apps/client/src/k8s/api/groups/Tekton/ClusterInterceptor/hooks/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/ClusterInterceptor/hooks/index.ts
@@ -1,0 +1,14 @@
+import {
+  createUsePermissionsHook,
+  createUseWatchListHook,
+  createUseWatchItemHook,
+  UseWatchItemParamsWithoutResourceConfig,
+  UseWatchListParamsWithoutResourceConfig,
+} from "@/k8s/api/hooks/hook-creators";
+import { k8sClusterInterceptorConfig, ClusterInterceptor } from "@my-project/shared";
+
+export const useClusterInterceptorPermissions = createUsePermissionsHook(k8sClusterInterceptorConfig);
+export const useClusterInterceptorWatchList = (params?: UseWatchListParamsWithoutResourceConfig<ClusterInterceptor>) =>
+  createUseWatchListHook<ClusterInterceptor>(k8sClusterInterceptorConfig)(params);
+export const useClusterInterceptorWatchItem = (params: UseWatchItemParamsWithoutResourceConfig<ClusterInterceptor>) =>
+  createUseWatchItemHook<ClusterInterceptor>(k8sClusterInterceptorConfig)(params);

--- a/apps/client/src/k8s/api/groups/Tekton/ClusterInterceptor/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/ClusterInterceptor/index.ts
@@ -1,0 +1,1 @@
+export * from "./hooks";

--- a/apps/client/src/k8s/api/groups/Tekton/EventListener/hooks/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/EventListener/hooks/index.ts
@@ -1,0 +1,19 @@
+import {
+  createUsePermissionsHook,
+  createUseWatchListHook,
+  createUseWatchItemHook,
+  createUseWatchListMultipleHook,
+  UseWatchItemParamsWithoutResourceConfig,
+  UseWatchListParamsWithoutResourceConfig,
+  UseWatchListMultipleParamsWithoutResourceConfig,
+} from "@/k8s/api/hooks/hook-creators";
+import { k8sEventListenerConfig, EventListener } from "@my-project/shared";
+
+export const useEventListenerPermissions = createUsePermissionsHook(k8sEventListenerConfig);
+export const useEventListenerWatchList = (params?: UseWatchListParamsWithoutResourceConfig<EventListener>) =>
+  createUseWatchListHook<EventListener>(k8sEventListenerConfig)(params);
+export const useEventListenerWatchItem = (params: UseWatchItemParamsWithoutResourceConfig<EventListener>) =>
+  createUseWatchItemHook<EventListener>(k8sEventListenerConfig)(params);
+export const useEventListenerWatchListMultiple = (
+  params?: UseWatchListMultipleParamsWithoutResourceConfig<EventListener>
+) => createUseWatchListMultipleHook<EventListener>(k8sEventListenerConfig)(params);

--- a/apps/client/src/k8s/api/groups/Tekton/EventListener/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/EventListener/index.ts
@@ -1,0 +1,1 @@
+export * from "./hooks";

--- a/apps/client/src/k8s/api/groups/Tekton/Interceptor/hooks/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/Interceptor/hooks/index.ts
@@ -1,0 +1,14 @@
+import {
+  createUsePermissionsHook,
+  createUseWatchListHook,
+  createUseWatchItemHook,
+  UseWatchItemParamsWithoutResourceConfig,
+  UseWatchListParamsWithoutResourceConfig,
+} from "@/k8s/api/hooks/hook-creators";
+import { k8sInterceptorConfig, Interceptor } from "@my-project/shared";
+
+export const useInterceptorPermissions = createUsePermissionsHook(k8sInterceptorConfig);
+export const useInterceptorWatchList = (params?: UseWatchListParamsWithoutResourceConfig<Interceptor>) =>
+  createUseWatchListHook<Interceptor>(k8sInterceptorConfig)(params);
+export const useInterceptorWatchItem = (params: UseWatchItemParamsWithoutResourceConfig<Interceptor>) =>
+  createUseWatchItemHook<Interceptor>(k8sInterceptorConfig)(params);

--- a/apps/client/src/k8s/api/groups/Tekton/Interceptor/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/Interceptor/index.ts
@@ -1,0 +1,1 @@
+export * from "./hooks";

--- a/apps/client/src/k8s/api/groups/Tekton/Trigger/hooks/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/Trigger/hooks/index.ts
@@ -1,0 +1,18 @@
+import {
+  createUsePermissionsHook,
+  createUseWatchListHook,
+  createUseWatchItemHook,
+  createUseWatchListMultipleHook,
+  UseWatchItemParamsWithoutResourceConfig,
+  UseWatchListParamsWithoutResourceConfig,
+  UseWatchListMultipleParamsWithoutResourceConfig,
+} from "@/k8s/api/hooks/hook-creators";
+import { k8sTriggerConfig, Trigger } from "@my-project/shared";
+
+export const useTriggerPermissions = createUsePermissionsHook(k8sTriggerConfig);
+export const useTriggerWatchList = (params?: UseWatchListParamsWithoutResourceConfig<Trigger>) =>
+  createUseWatchListHook<Trigger>(k8sTriggerConfig)(params);
+export const useTriggerWatchItem = (params: UseWatchItemParamsWithoutResourceConfig<Trigger>) =>
+  createUseWatchItemHook<Trigger>(k8sTriggerConfig)(params);
+export const useTriggerWatchListMultiple = (params?: UseWatchListMultipleParamsWithoutResourceConfig<Trigger>) =>
+  createUseWatchListMultipleHook<Trigger>(k8sTriggerConfig)(params);

--- a/apps/client/src/k8s/api/groups/Tekton/Trigger/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/Trigger/index.ts
@@ -1,0 +1,1 @@
+export * from "./hooks";

--- a/apps/client/src/k8s/api/groups/Tekton/TriggerBinding/hooks/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/TriggerBinding/hooks/index.ts
@@ -1,0 +1,14 @@
+import {
+  createUsePermissionsHook,
+  createUseWatchListHook,
+  createUseWatchItemHook,
+  UseWatchItemParamsWithoutResourceConfig,
+  UseWatchListParamsWithoutResourceConfig,
+} from "@/k8s/api/hooks/hook-creators";
+import { k8sTriggerBindingConfig, TriggerBinding } from "@my-project/shared";
+
+export const useTriggerBindingPermissions = createUsePermissionsHook(k8sTriggerBindingConfig);
+export const useTriggerBindingWatchList = (params?: UseWatchListParamsWithoutResourceConfig<TriggerBinding>) =>
+  createUseWatchListHook<TriggerBinding>(k8sTriggerBindingConfig)(params);
+export const useTriggerBindingWatchItem = (params: UseWatchItemParamsWithoutResourceConfig<TriggerBinding>) =>
+  createUseWatchItemHook<TriggerBinding>(k8sTriggerBindingConfig)(params);

--- a/apps/client/src/k8s/api/groups/Tekton/TriggerBinding/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/TriggerBinding/index.ts
@@ -1,0 +1,1 @@
+export * from "./hooks";

--- a/apps/client/src/k8s/constants/tables.ts
+++ b/apps/client/src/k8s/constants/tables.ts
@@ -155,4 +155,28 @@ export const TABLE = {
     id: "branchList",
     name: "Branch List",
   },
+  EVENT_LISTENER_LIST: {
+    id: "eventListenerList",
+    name: "Event Listener List",
+  },
+  TRIGGER_LIST: {
+    id: "triggerList",
+    name: "Trigger List",
+  },
+  TRIGGER_TEMPLATE_LIST: {
+    id: "triggerTemplateList",
+    name: "Trigger Template List",
+  },
+  TRIGGER_BINDING_LIST: {
+    id: "triggerBindingList",
+    name: "Trigger Binding List",
+  },
+  INTERCEPTOR_LIST: {
+    id: "interceptorList",
+    name: "Interceptor List",
+  },
+  CLUSTER_INTERCEPTOR_LIST: {
+    id: "clusterInterceptorList",
+    name: "Cluster Interceptor List",
+  },
 } as const;

--- a/apps/client/src/modules/platform/cdpipelines/pages/create/components/CreateCDPipelineWizard/components/Success/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/create/components/CreateCDPipelineWizard/components/Success/index.tsx
@@ -51,7 +51,7 @@ export const Success: React.FC = () => {
                 <FolderOpen className="text-muted-foreground h-4 w-4" />
                 <div className="flex flex-col">
                   <span className="text-xs">View All Deployments</span>
-                  <span className="text-muted-foreground text-[10px]">Go back to deployments list</span>
+                  <span className="text-muted-foreground text-xs">Go back to deployments list</span>
                 </div>
               </Link>
             </Button>
@@ -68,7 +68,7 @@ export const Success: React.FC = () => {
                 <ExternalLink className="h-4 w-4" />
                 <div className="flex flex-col">
                   <span className="text-xs">Open Deployment</span>
-                  <span className="text-[10px] opacity-80">View deployment details</span>
+                  <span className="text-xs opacity-80">View deployment details</span>
                 </div>
               </Link>
             </Button>
@@ -84,7 +84,7 @@ export const Success: React.FC = () => {
               <Sparkles className="text-muted-foreground h-4 w-4" />
               <div className="flex flex-col">
                 <span className="text-xs">Create Another Deployment</span>
-                <span className="text-muted-foreground text-[10px]">Start new wizard</span>
+                <span className="text-muted-foreground text-xs">Start new wizard</span>
               </div>
             </Button>
           </div>

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/PodPhasePanel/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Monitoring/components/PodPhasePanel/index.tsx
@@ -33,7 +33,7 @@ export function PodPhasePanel({ data, selectedApps }: PodPhasePanelProps) {
                       key={pod.name}
                       variant={POD_PHASE_BADGE_VARIANT[pod.phase]}
                       title={pod.name}
-                      className="text-[11px]"
+                      className="text-xs"
                     >
                       <span className="max-w-[160px] truncate">{pod.name}</span>
                       <span className="ml-1.5 opacity-75">{pod.phase}</span>

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/hooks/index.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/hooks/index.ts
@@ -113,7 +113,9 @@ const useWatchStageTriggerTemplatePipelineRun = (triggerTemplateName: string | u
   return useQuery<TriggerTemplate, Error, PipelineRun>({
     queryKey: ["stageTriggerTemplatePipelineRun", triggerTemplateWatch.resourceVersion],
     queryFn: () => {
-      return triggerTemplateWatch.query.data?.spec.resourcetemplates?.[0] as PipelineRun;
+      // Schema models only `spec.pipelineRef.name` on resourcetemplates; the
+      // runtime payload is a full PipelineRun, which the cast reflects.
+      return triggerTemplateWatch.query.data?.spec?.resourcetemplates?.[0] as unknown as PipelineRun;
     },
     enabled: !!triggerTemplateWatch.query.isSuccess,
   });

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/components/Success/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/components/Success/index.tsx
@@ -55,7 +55,7 @@ export const Success: React.FC = () => {
                 <FolderOpen className="text-muted-foreground h-4 w-4" />
                 <div className="flex flex-col">
                   <span className="text-xs">Back to Deployment</span>
-                  <span className="text-muted-foreground text-[10px]">View deployment details</span>
+                  <span className="text-muted-foreground text-xs">View deployment details</span>
                 </div>
               </Link>
             </Button>
@@ -73,7 +73,7 @@ export const Success: React.FC = () => {
                 <ExternalLink className="h-4 w-4" />
                 <div className="flex flex-col">
                   <span className="text-xs">Open Environment</span>
-                  <span className="text-[10px] opacity-80">View environment details</span>
+                  <span className="text-xs opacity-80">View environment details</span>
                 </div>
               </Link>
             </Button>
@@ -89,7 +89,7 @@ export const Success: React.FC = () => {
               <Sparkles className="text-muted-foreground h-4 w-4" />
               <div className="flex flex-col">
                 <span className="text-xs">Create Another Environment</span>
-                <span className="text-muted-foreground text-[10px]">Start new wizard</span>
+                <span className="text-muted-foreground text-xs">Start new wizard</span>
               </div>
             </Button>
           </div>

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/Success/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/Success/index.tsx
@@ -85,7 +85,7 @@ export const Success: React.FC = () => {
                 <FolderOpen className="text-muted-foreground h-4 w-4" />
                 <div className="flex flex-col">
                   <span className="text-xs">View All Projects</span>
-                  <span className="text-muted-foreground text-[10px]">Go back to projects list</span>
+                  <span className="text-muted-foreground text-xs">Go back to projects list</span>
                 </div>
               </Link>
             </Button>
@@ -102,7 +102,7 @@ export const Success: React.FC = () => {
                 <ExternalLink className="h-4 w-4" />
                 <div className="flex flex-col">
                   <span className="text-xs">Open Project</span>
-                  <span className="text-[10px] opacity-80">View project details</span>
+                  <span className="text-xs opacity-80">View project details</span>
                 </div>
               </Link>
             </Button>
@@ -118,7 +118,7 @@ export const Success: React.FC = () => {
               <Sparkles className="text-muted-foreground h-4 w-4" />
               <div className="flex flex-col">
                 <span className="text-xs">Create Another Project</span>
-                <span className="text-muted-foreground text-[10px]">Start new project wizard</span>
+                <span className="text-muted-foreground text-xs">Start new project wizard</span>
               </div>
             </Button>
 
@@ -127,7 +127,7 @@ export const Success: React.FC = () => {
                 <Globe className="text-muted-foreground h-4 w-4" />
                 <div className="flex flex-col">
                   <span className="text-xs">Create Deployment</span>
-                  <span className="text-muted-foreground text-[10px]">Create deployment for this project</span>
+                  <span className="text-muted-foreground text-xs">Create deployment for this project</span>
                 </div>
               </Link>
             </Button>

--- a/apps/client/src/modules/platform/codebases/pages/details/components/BranchList/components/BranchListItem/components/PipelineActionsGroup/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/details/components/BranchList/components/BranchListItem/components/PipelineActionsGroup/index.tsx
@@ -83,7 +83,9 @@ export function PipelineActionsGroup({
       return;
     }
 
-    const buildPipelineRunTemplateCopy = structuredClone(buildPipelineRunTemplate);
+    // Schema models only `spec.pipelineRef.name` on resourcetemplates; the
+    // runtime payload is a full PipelineRun, which the cast reflects.
+    const buildPipelineRunTemplateCopy = structuredClone(buildPipelineRunTemplate) as unknown as PipelineRun;
 
     return createBuildPipelineRunDraft({
       codebase,
@@ -105,7 +107,7 @@ export function PipelineActionsGroup({
       return;
     }
 
-    const securityPipelineRunTemplateCopy = structuredClone(securityPipelineRunTemplate);
+    const securityPipelineRunTemplateCopy = structuredClone(securityPipelineRunTemplate) as unknown as PipelineRun;
 
     return createSecurityPipelineRunDraft({
       codebase,

--- a/apps/client/src/modules/platform/security/components/dependencytrack/DependencyTrackMetricsWidget/index.tsx
+++ b/apps/client/src/modules/platform/security/components/dependencytrack/DependencyTrackMetricsWidget/index.tsx
@@ -1,7 +1,7 @@
 import { LearnMoreLink } from "@/core/components/LearnMoreLink";
 import { EDP_OPERATOR_GUIDE } from "@/k8s/constants/docs-urls";
 import { Badge } from "@/core/components/ui/badge";
-import { SecurityMetricCard } from "../../shared/SecurityMetricCard";
+import { MetricCard } from "@/core/components/MetricCard";
 import { DependencyTrackMetricsList } from "../DependencyTrackMetricsList";
 import { useDependencyTrackProject } from "./hooks/useDependencyTrackProject";
 import { DependencyTrackMetricsWidgetProps } from "./types";
@@ -43,7 +43,7 @@ export function DependencyTrackMetricsWidget({ projectName, defaultBranch }: Dep
   const projectUuid = data?.uuid;
 
   return (
-    <SecurityMetricCard
+    <MetricCard
       title="Dependencies"
       badge={
         <>
@@ -81,6 +81,6 @@ export function DependencyTrackMetricsWidget({ projectName, defaultBranch }: Dep
       }
     >
       <DependencyTrackMetricsList metrics={data?.metrics} />
-    </SecurityMetricCard>
+    </MetricCard>
   );
 }

--- a/apps/client/src/modules/platform/security/components/sonarqube/SonarQubeMetricsWidget/index.tsx
+++ b/apps/client/src/modules/platform/security/components/sonarqube/SonarQubeMetricsWidget/index.tsx
@@ -1,7 +1,7 @@
 import { LearnMoreLink } from "@/core/components/LearnMoreLink";
 import { EDP_OPERATOR_GUIDE } from "@/k8s/constants/docs-urls";
 import { QualityGateBadge } from "@/modules/platform/security/pages/sast/components/QualityGateBadge";
-import { SecurityMetricCard } from "../../shared/SecurityMetricCard";
+import { MetricCard } from "@/core/components/MetricCard";
 import { SonarQubeMetricsList } from "../SonarQubeMetricsList";
 import { useSonarQubeProject } from "./hooks/useSonarQubeProject";
 import { SonarQubeMetricsWidgetProps } from "./types";
@@ -29,7 +29,7 @@ export function SonarQubeMetricsWidget({ componentKey }: SonarQubeMetricsWidgetP
   const sonarBaseUrl = useClusterStore((state) => state.sonarWebUrl);
 
   return (
-    <SecurityMetricCard
+    <MetricCard
       title="Code Quality"
       badge={
         <>
@@ -62,6 +62,6 @@ export function SonarQubeMetricsWidget({ componentKey }: SonarQubeMetricsWidgetP
       }
     >
       <SonarQubeMetricsList measures={data?.measures} sonarBaseUrl={sonarBaseUrl} projectKey={componentKey} />
-    </SecurityMetricCard>
+    </MetricCard>
   );
 }

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/EventListenerNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/EventListenerNode.tsx
@@ -1,0 +1,36 @@
+import { Handle, Position } from "@xyflow/react";
+import { Webhook } from "lucide-react";
+import { EventListener } from "@my-project/shared";
+import { Badge } from "@/core/components/ui/badge";
+import { cn } from "@/core/utils/classname";
+import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
+
+export const EventListenerNode = ({
+  data,
+}: {
+  data: {
+    eventListener: EventListener;
+    ready: boolean;
+    address: string | null;
+    triggerCount: number;
+  };
+}) => (
+  <div
+    className={cn(
+      "border-border rounded-lg border p-3 text-sm shadow-sm",
+      NODE_KIND_TAILWIND[NODE_KIND.EVENT_LISTENER]
+    )}
+  >
+    <Handle type="target" position={Position.Left} />
+    <Handle type="source" position={Position.Right} />
+    <div className="mb-1 flex items-center gap-2 font-medium">
+      <Webhook size={16} />
+      <span>{data.eventListener.metadata.name}</span>
+      {data.ready ? <Badge variant="success">Ready</Badge> : <Badge variant="destructive">Degraded</Badge>}
+    </div>
+    {data.address && <div className="text-muted-foreground font-mono text-xs">{data.address}</div>}
+    <div className="text-muted-foreground mt-1 text-xs">
+      {data.triggerCount} trigger{data.triggerCount === 1 ? "" : "s"}
+    </div>
+  </div>
+);

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/GitSourceNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/GitSourceNode.tsx
@@ -1,0 +1,37 @@
+import { Handle, Position } from "@xyflow/react";
+import { Github, Gitlab, GitBranch, Globe } from "lucide-react";
+import { GitServer } from "@my-project/shared";
+import { cn } from "@/core/utils/classname";
+import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
+
+const providerIcon = (provider: string | undefined) => {
+  switch (provider) {
+    case "github":
+      return Github;
+    case "gitlab":
+      return Gitlab;
+    case "gerrit":
+    case "bitbucket":
+      return GitBranch;
+    default:
+      return Globe;
+  }
+};
+
+export const GitSourceNode = ({ data }: { data: { gitServer: GitServer | null } }) => {
+  const Icon = providerIcon(data.gitServer?.spec?.gitProvider);
+  return (
+    <div
+      className={cn("border-border rounded-lg border p-3 text-sm shadow-sm", NODE_KIND_TAILWIND[NODE_KIND.GIT_SOURCE])}
+    >
+      <Handle type="source" position={Position.Right} />
+      <div className="flex items-center gap-2 font-medium">
+        <Icon size={16} />
+        <span>{data.gitServer?.metadata?.name ?? "Webhook source"}</span>
+      </div>
+      {data.gitServer?.spec?.gitHost && (
+        <div className="text-muted-foreground mt-1 font-mono text-xs">{data.gitServer.spec.gitHost}</div>
+      )}
+    </div>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/InterceptorNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/InterceptorNode.tsx
@@ -1,0 +1,74 @@
+import { Handle, Position } from "@xyflow/react";
+import { Funnel, KeyRound } from "lucide-react";
+import { Badge } from "@/core/components/ui/badge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { cn } from "@/core/utils/classname";
+import { ResolvedInterceptorRef } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
+import { ResolutionStatusBadge } from "./ResolutionStatusBadge";
+
+const renderParam = (name: string, value: unknown) => {
+  if (name === "filter" && typeof value === "string") {
+    return (
+      <Tooltip title={value}>
+        <code className="inline-block max-w-[180px] truncate text-xs">{value}</code>
+      </Tooltip>
+    );
+  }
+  if (name === "eventTypes" && Array.isArray(value)) {
+    return (
+      <div className="flex flex-wrap gap-1">
+        {value.map((v) => (
+          <Badge key={String(v)} variant="secondary" className="text-xs">
+            {String(v)}
+          </Badge>
+        ))}
+      </div>
+    );
+  }
+  if (name === "secretRef" && typeof value === "object" && value !== null) {
+    const v = value as { secretName?: string; secretKey?: string };
+    return (
+      <span className="flex items-center gap-1 text-xs">
+        <KeyRound size={12} />
+        {v.secretName}/{v.secretKey}
+      </span>
+    );
+  }
+  return (
+    <pre className="text-xs break-words whitespace-pre-wrap">
+      {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
+    </pre>
+  );
+};
+
+export const InterceptorNode = ({ data }: { data: { interceptor: ResolvedInterceptorRef; namespace: string } }) => {
+  const { ref, params, status } = data.interceptor;
+  return (
+    <div
+      className={cn("border-border rounded-lg border p-3 text-sm shadow-sm", NODE_KIND_TAILWIND[NODE_KIND.INTERCEPTOR])}
+    >
+      <Handle type="target" position={Position.Left} />
+      <Handle type="source" position={Position.Right} />
+      <div className="mb-1 flex items-center gap-2 font-medium">
+        <Funnel size={16} />
+        <span>{ref.name}</span>
+        <Badge variant="secondary" className="text-xs">
+          {ref.kind === "ClusterInterceptor" ? "Cluster" : "Namespaced"}
+        </Badge>
+        <ResolutionStatusBadge
+          status={status}
+          resourceLabel={ref.kind === "ClusterInterceptor" ? "ClusterInterceptor" : "Interceptor"}
+        />
+      </div>
+      <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs">
+        {params.map((p, idx) => (
+          <div key={`${p.name}-${idx}`} className="contents">
+            <div className="text-muted-foreground font-mono">{p.name}</div>
+            <div className="min-w-0">{renderParam(p.name, p.value)}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/PipelineNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/PipelineNode.tsx
@@ -1,0 +1,69 @@
+import { Handle, Position } from "@xyflow/react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { AlertTriangle, Activity } from "lucide-react";
+import { ENTITY_ICON } from "@/k8s/constants/entity-icons";
+import { cn } from "@/core/utils/classname";
+import { useClusterStore } from "@/k8s/store";
+import { PipelineRun, getPipelineRunStatus } from "@my-project/shared";
+import { PipelineRefShape } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { routePipelineDetails } from "@/modules/platform/tekton/pages/pipeline-details/route";
+import { routePipelineRunDetails } from "@/modules/platform/tekton/pages/pipelinerun-details/route";
+import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
+
+export const PipelineNode = ({
+  data,
+}: {
+  data: {
+    pipelineRef: PipelineRefShape;
+    latestPipelineRun: PipelineRun | null;
+    namespace: string;
+  };
+}) => {
+  const { clusterName } = useClusterStore(useShallow((s) => ({ clusterName: s.clusterName })));
+  const { pipelineRef, latestPipelineRun, namespace } = data;
+  const PipelineIcon = ENTITY_ICON.pipeline;
+
+  return (
+    <div
+      className={cn(
+        "border-border rounded-lg border p-3 text-sm shadow-sm",
+        pipelineRef.kind === "unknown"
+          ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+          : NODE_KIND_TAILWIND[NODE_KIND.PIPELINE]
+      )}
+    >
+      <Handle type="target" position={Position.Left} />
+      <div className="flex items-center gap-2 font-medium">
+        {pipelineRef.kind === "unknown" ? <AlertTriangle size={16} /> : <PipelineIcon size={16} />}
+        {pipelineRef.kind === "literal" && (
+          <Link
+            to={routePipelineDetails.fullPath}
+            params={{ clusterName, namespace, name: pipelineRef.pipelineName }}
+            className="hover:underline"
+          >
+            {pipelineRef.pipelineName}
+          </Link>
+        )}
+        {pipelineRef.kind === "templated" && <span>Pipeline (dynamic)</span>}
+        {pipelineRef.kind === "unknown" && <span>Pipeline (unknown)</span>}
+      </div>
+      {pipelineRef.kind === "templated" && (
+        <div className="text-muted-foreground mt-1 font-mono text-xs">{pipelineRef.raw}</div>
+      )}
+      {latestPipelineRun && (
+        <div className="mt-1 flex items-center gap-1 text-xs">
+          <Activity size={12} />
+          <span className="text-muted-foreground">latest run:</span>
+          <Link
+            to={routePipelineRunDetails.fullPath}
+            params={{ clusterName, namespace, name: latestPipelineRun.metadata.name }}
+            className="font-medium hover:underline"
+          >
+            {getPipelineRunStatus(latestPipelineRun).reason}
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/ResolutionStatusBadge.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/ResolutionStatusBadge.tsx
@@ -1,0 +1,32 @@
+import { Badge } from "@/core/components/ui/badge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { ResolutionStatus } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+
+const RESTRICTED_HINT =
+  "Couldn't load this resource — your role may lack permission, or the CRD is not installed. The reference may still be valid in the cluster.";
+
+export const ResolutionStatusBadge = ({
+  status,
+  resourceLabel,
+  className = "text-xs",
+}: {
+  status: ResolutionStatus;
+  resourceLabel?: string;
+  className?: string;
+}) => {
+  if (status === "resolved") return null;
+  if (status === "missing") {
+    return (
+      <Badge variant="warning" className={className}>
+        missing
+      </Badge>
+    );
+  }
+  return (
+    <Tooltip title={resourceLabel ? `${RESTRICTED_HINT} (${resourceLabel})` : RESTRICTED_HINT}>
+      <Badge variant="neutral" className={className}>
+        restricted
+      </Badge>
+    </Tooltip>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerBindingNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerBindingNode.tsx
@@ -1,0 +1,36 @@
+import { Handle, Position } from "@xyflow/react";
+import { Link2 } from "lucide-react";
+import { Badge } from "@/core/components/ui/badge";
+import { cn } from "@/core/utils/classname";
+import { ResolvedBindingRef } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
+import { ResolutionStatusBadge } from "./ResolutionStatusBadge";
+
+export const TriggerBindingNode = ({ data }: { data: { binding: ResolvedBindingRef; namespace: string } }) => {
+  const { ref, kind, resolved, status } = data.binding;
+  const params = resolved?.spec?.params ?? [];
+  const isCluster = kind === "ClusterTriggerBinding";
+  return (
+    <div
+      className={cn(
+        "rounded-lg border p-3 text-sm shadow-sm",
+        isCluster ? "border-border border-dashed" : "border-border",
+        NODE_KIND_TAILWIND[NODE_KIND.TRIGGER_BINDING]
+      )}
+    >
+      <Handle type="target" position={Position.Left} />
+      <Handle type="source" position={Position.Right} />
+      <div className="flex items-center gap-2 font-medium">
+        <Link2 size={16} />
+        <span>{ref}</span>
+        <Badge variant="secondary" className="text-xs">
+          {params.length} param{params.length === 1 ? "" : "s"}
+        </Badge>
+        {/* CTB has its own descriptive copy below; the generic status badge
+            would be redundant and confusing. */}
+        {!isCluster && <ResolutionStatusBadge status={status} resourceLabel="TriggerBinding" />}
+      </div>
+      {isCluster && <div className="text-muted-foreground mt-1 text-xs">(unresolved — ClusterTriggerBinding)</div>}
+    </div>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerNode.tsx
@@ -1,0 +1,41 @@
+import { Handle, Position } from "@xyflow/react";
+import { Zap, AlertTriangle, Lock } from "lucide-react";
+import { Trigger } from "@my-project/shared";
+import { cn } from "@/core/utils/classname";
+import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
+import { ResolutionStatusBadge } from "./ResolutionStatusBadge";
+import { ResolutionStatus } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+
+const iconFor = (status: ResolutionStatus) => {
+  if (status === "resolved") return <Zap size={16} />;
+  if (status === "restricted") return <Lock size={16} className="text-muted-foreground" />;
+  return <AlertTriangle size={16} className="text-destructive" />;
+};
+
+const captionFor = (status: ResolutionStatus) => {
+  if (status === "resolved") return "external Trigger CR";
+  if (status === "restricted") return "Trigger CR not visible (RBAC or missing CRD)";
+  return "missing Trigger CR";
+};
+
+export const TriggerNode = ({
+  data,
+}: {
+  data: {
+    triggerRef: string;
+    resolved: Trigger | null;
+    status: ResolutionStatus;
+    namespace: string;
+  };
+}) => (
+  <div className={cn("border-border rounded-lg border p-3 text-sm shadow-sm", NODE_KIND_TAILWIND[NODE_KIND.TRIGGER])}>
+    <Handle type="target" position={Position.Left} />
+    <Handle type="source" position={Position.Right} />
+    <div className="flex items-center gap-2 font-medium">
+      {iconFor(data.status)}
+      <span>{data.triggerRef}</span>
+      <ResolutionStatusBadge status={data.status} resourceLabel="Trigger" />
+    </div>
+    <div className="text-muted-foreground mt-1 text-xs">{captionFor(data.status)}</div>
+  </div>
+);

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerTemplateNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerTemplateNode.tsx
@@ -1,0 +1,45 @@
+import { Handle, Position } from "@xyflow/react";
+import { FileCode } from "lucide-react";
+import { Badge } from "@/core/components/ui/badge";
+import { cn } from "@/core/utils/classname";
+import { ResolvedTriggerNode } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
+import { ResolutionStatusBadge } from "./ResolutionStatusBadge";
+
+export const TriggerTemplateNode = ({
+  data,
+}: {
+  data: { template: ResolvedTriggerNode["template"]; namespace: string };
+}) => {
+  const { ref, pipelineRef, status } = data.template;
+  return (
+    <div
+      className={cn(
+        "border-border rounded-lg border p-3 text-sm shadow-sm",
+        NODE_KIND_TAILWIND[NODE_KIND.TRIGGER_TEMPLATE]
+      )}
+    >
+      <Handle type="target" position={Position.Left} />
+      <Handle type="source" position={Position.Right} />
+      <div className="flex items-center gap-2 font-medium">
+        <FileCode size={16} />
+        <span>{ref || "(no template)"}</span>
+        <ResolutionStatusBadge status={status} resourceLabel="TriggerTemplate" />
+      </div>
+      <div className="text-muted-foreground mt-1 text-xs">
+        {pipelineRef.kind === "literal" && <>creates: PipelineRun → {pipelineRef.pipelineName}</>}
+        {pipelineRef.kind === "templated" && (
+          <>
+            creates: PipelineRun → <code>{pipelineRef.raw}</code>
+            {pipelineRef.sourceParam && (
+              <Badge variant="secondary" className="ml-1 text-xs">
+                ← param: {pipelineRef.sourceParam}
+              </Badge>
+            )}
+          </>
+        )}
+        {pipelineRef.kind === "unknown" && <>pipelineRef: unknown</>}
+      </div>
+    </div>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/constants.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/constants.ts
@@ -1,0 +1,44 @@
+export const NODE_KIND = {
+  GIT_SOURCE: "gitSource",
+  EVENT_LISTENER: "eventListener",
+  TRIGGER: "trigger",
+  INTERCEPTOR: "interceptor",
+  TRIGGER_BINDING: "triggerBinding",
+  TRIGGER_TEMPLATE: "triggerTemplate",
+  PIPELINE: "pipeline",
+} as const;
+
+export type NodeKind = (typeof NODE_KIND)[keyof typeof NODE_KIND];
+
+// Tailwind token classes per spec §8.6. Used by node renderers, legend chip, MiniMap.
+export const NODE_KIND_TAILWIND: Record<NodeKind, string> = {
+  [NODE_KIND.GIT_SOURCE]: "bg-muted text-muted-foreground",
+  [NODE_KIND.EVENT_LISTENER]: "bg-primary/10 text-primary",
+  [NODE_KIND.TRIGGER]: "bg-primary/10 text-primary",
+  [NODE_KIND.INTERCEPTOR]: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  [NODE_KIND.TRIGGER_BINDING]: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
+  [NODE_KIND.TRIGGER_TEMPLATE]: "bg-primary/10 text-primary",
+  [NODE_KIND.PIPELINE]: "bg-status-success/10 text-status-success",
+};
+
+// CSS custom properties consumed by MiniMap nodeColor (must read at render time
+// from getComputedStyle to support dark mode toggling).
+export const NODE_KIND_CSS_VAR: Record<NodeKind, string> = {
+  [NODE_KIND.GIT_SOURCE]: "--muted-foreground",
+  [NODE_KIND.EVENT_LISTENER]: "--primary",
+  [NODE_KIND.TRIGGER]: "--primary",
+  [NODE_KIND.INTERCEPTOR]: "--color-amber-500",
+  [NODE_KIND.TRIGGER_BINDING]: "--color-purple-500",
+  [NODE_KIND.TRIGGER_TEMPLATE]: "--primary",
+  [NODE_KIND.PIPELINE]: "--status-success",
+};
+
+export const LEGEND_LABELS: Record<NodeKind, string> = {
+  [NODE_KIND.GIT_SOURCE]: "Git source",
+  [NODE_KIND.EVENT_LISTENER]: "EventListener",
+  [NODE_KIND.TRIGGER]: "Trigger",
+  [NODE_KIND.INTERCEPTOR]: "Interceptor",
+  [NODE_KIND.TRIGGER_BINDING]: "TriggerBinding",
+  [NODE_KIND.TRIGGER_TEMPLATE]: "TriggerTemplate",
+  [NODE_KIND.PIPELINE]: "Pipeline",
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/hooks/useEventFlowGraphData.test.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/hooks/useEventFlowGraphData.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, test } from "vitest";
+import { eventListenerSchema, gitServerSchema } from "@my-project/shared";
+import { EventListenerTopology, ResolvedTriggerNode } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { NODE_KIND } from "../constants";
+import { buildEdges, buildNodes } from "./useEventFlowGraphData";
+
+const ns = "ns-a";
+const elName = "el-1";
+
+const eventListener = eventListenerSchema.parse({
+  apiVersion: "triggers.tekton.dev/v1beta1",
+  kind: "EventListener",
+  metadata: { name: elName, namespace: ns, uid: "el-uid", creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+  spec: { triggers: [] },
+});
+
+const baseTopology = (overrides: Partial<EventListenerTopology>): EventListenerTopology => ({
+  eventListener,
+  address: null,
+  ready: true,
+  gitServer: null,
+  triggers: [],
+  ...overrides,
+});
+
+const triggerRefNode = (overrides: Partial<ResolvedTriggerNode> = {}): ResolvedTriggerNode => ({
+  source: { kind: "triggerRef", ref: "g", resolved: null, status: "resolved" },
+  interceptors: [],
+  bindings: [],
+  template: { ref: "tt", resolved: null, status: "resolved", pipelineRef: { kind: "unknown" } },
+  latestPipelineRun: null,
+  ...overrides,
+});
+
+const inlineNode = (overrides: Partial<ResolvedTriggerNode> = {}): ResolvedTriggerNode => ({
+  source: { kind: "inline", name: "inline-1" },
+  interceptors: [],
+  bindings: [],
+  template: { ref: "tt", resolved: null, status: "resolved", pipelineRef: { kind: "unknown" } },
+  latestPipelineRun: null,
+  ...overrides,
+});
+
+describe("buildNodes", () => {
+  test("emits EventListener node only when no triggers and no gitServer", () => {
+    const result = buildNodes(baseTopology({}));
+    expect(result.map((n) => n.id)).toEqual(["node::eventListener"]);
+    expect(result[0].type).toBe(NODE_KIND.EVENT_LISTENER);
+  });
+
+  test("prepends a gitSource node when topology.gitServer is set", () => {
+    const gitServer = gitServerSchema.parse({
+      apiVersion: "edp.epam.com/v1",
+      kind: "GitServer",
+      metadata: { name: "gh", namespace: ns, uid: "u-gh", creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+      spec: { gitProvider: "github", gitHost: "github.com", httpsPort: 443, nameSshKeySecret: "git-key", sshPort: 22 },
+      status: {},
+    });
+    const result = buildNodes(baseTopology({ gitServer }));
+    expect(result.map((n) => n.id)).toEqual(["node::gitSource", "node::eventListener"]);
+  });
+
+  test("triggerRef trigger emits trigger + template + pipeline nodes", () => {
+    const result = buildNodes(baseTopology({ triggers: [triggerRefNode()] }));
+    expect(result.map((n) => n.id)).toEqual([
+      "node::eventListener",
+      "node::trigger::g-0",
+      "node::template::g-0",
+      "node::pipeline::g-0",
+    ]);
+  });
+
+  test("inline trigger emits no trigger node — only template + pipeline", () => {
+    const result = buildNodes(baseTopology({ triggers: [inlineNode()] }));
+    expect(result.map((n) => n.id)).toEqual([
+      "node::eventListener",
+      "node::template::inline-1-0",
+      "node::pipeline::inline-1-0",
+    ]);
+  });
+
+  test("interceptors and bindings get unique numbered ids per trigger", () => {
+    const result = buildNodes(
+      baseTopology({
+        triggers: [
+          triggerRefNode({
+            interceptors: [
+              {
+                ref: { name: "i1", kind: "NamespacedInterceptor" },
+                resolved: null,
+                status: "resolved",
+                params: [],
+              },
+              {
+                ref: { name: "i2", kind: "NamespacedInterceptor" },
+                resolved: null,
+                status: "resolved",
+                params: [],
+              },
+            ],
+            bindings: [
+              { ref: "b1", kind: "TriggerBinding", resolved: null, status: "resolved" },
+              { ref: "b2", kind: "TriggerBinding", resolved: null, status: "resolved" },
+            ],
+          }),
+        ],
+      })
+    );
+    const ids = result.map((n) => n.id);
+    expect(ids).toContain("node::interceptor::g-0::0");
+    expect(ids).toContain("node::interceptor::g-0::1");
+    expect(ids).toContain("node::binding::g-0::0");
+    expect(ids).toContain("node::binding::g-0::1");
+  });
+});
+
+describe("buildEdges", () => {
+  test("no triggers → no edges (gitServer absent)", () => {
+    expect(buildEdges(baseTopology({}))).toEqual([]);
+  });
+
+  test("gitServer → eventListener edge added", () => {
+    const gitServer = gitServerSchema.parse({
+      apiVersion: "edp.epam.com/v1",
+      kind: "GitServer",
+      metadata: { name: "gh", namespace: ns, uid: "u-gh", creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+      spec: { gitProvider: "github", gitHost: "github.com", httpsPort: 443, nameSshKeySecret: "git-key", sshPort: 22 },
+      status: {},
+    });
+    const edges = buildEdges(baseTopology({ gitServer }));
+    expect(edges.map((e) => e.id)).toEqual(["edge::git→el"]);
+    expect(edges[0]).toMatchObject({ source: "node::gitSource", target: "node::eventListener" });
+  });
+
+  test("triggerRef with no interceptors and no bindings: EL → trigger → template → pipeline", () => {
+    const edges = buildEdges(baseTopology({ triggers: [triggerRefNode()] }));
+    expect(edges.map((e) => ({ source: e.source, target: e.target }))).toEqual([
+      { source: "node::eventListener", target: "node::trigger::g-0" },
+      { source: "node::trigger::g-0", target: "node::template::g-0" },
+      { source: "node::template::g-0", target: "node::pipeline::g-0" },
+    ]);
+  });
+
+  test("inline trigger with no interceptors and no bindings: EL → template directly (no trigger node)", () => {
+    const edges = buildEdges(baseTopology({ triggers: [inlineNode()] }));
+    expect(edges.map((e) => ({ source: e.source, target: e.target }))).toEqual([
+      { source: "node::eventListener", target: "node::template::inline-1-0" },
+      { source: "node::template::inline-1-0", target: "node::pipeline::inline-1-0" },
+    ]);
+  });
+
+  test("multiple interceptors chain head-to-tail", () => {
+    const edges = buildEdges(
+      baseTopology({
+        triggers: [
+          triggerRefNode({
+            interceptors: [
+              {
+                ref: { name: "i1", kind: "NamespacedInterceptor" },
+                resolved: null,
+                status: "resolved",
+                params: [],
+              },
+              {
+                ref: { name: "i2", kind: "NamespacedInterceptor" },
+                resolved: null,
+                status: "resolved",
+                params: [],
+              },
+              {
+                ref: { name: "i3", kind: "NamespacedInterceptor" },
+                resolved: null,
+                status: "resolved",
+                params: [],
+              },
+            ],
+          }),
+        ],
+      })
+    );
+    const pairs = edges.map((e) => ({ source: e.source, target: e.target }));
+    expect(pairs).toContainEqual({ source: "node::interceptor::g-0::0", target: "node::interceptor::g-0::1" });
+    expect(pairs).toContainEqual({ source: "node::interceptor::g-0::1", target: "node::interceptor::g-0::2" });
+    // last interceptor → template (no bindings)
+    expect(pairs).toContainEqual({ source: "node::interceptor::g-0::2", target: "node::template::g-0" });
+  });
+
+  test("interceptors fan out to every binding, and every binding connects to the template", () => {
+    const edges = buildEdges(
+      baseTopology({
+        triggers: [
+          triggerRefNode({
+            interceptors: [
+              {
+                ref: { name: "i1", kind: "NamespacedInterceptor" },
+                resolved: null,
+                status: "resolved",
+                params: [],
+              },
+            ],
+            bindings: [
+              { ref: "b1", kind: "TriggerBinding", resolved: null, status: "resolved" },
+              { ref: "b2", kind: "TriggerBinding", resolved: null, status: "resolved" },
+            ],
+          }),
+        ],
+      })
+    );
+    const pairs = edges.map((e) => ({ source: e.source, target: e.target }));
+    expect(pairs).toContainEqual({ source: "node::interceptor::g-0::0", target: "node::binding::g-0::0" });
+    expect(pairs).toContainEqual({ source: "node::interceptor::g-0::0", target: "node::binding::g-0::1" });
+    expect(pairs).toContainEqual({ source: "node::binding::g-0::0", target: "node::template::g-0" });
+    expect(pairs).toContainEqual({ source: "node::binding::g-0::1", target: "node::template::g-0" });
+  });
+
+  test("triggerRef with no interceptors but with bindings: trigger → binding → template", () => {
+    const edges = buildEdges(
+      baseTopology({
+        triggers: [
+          triggerRefNode({
+            bindings: [{ ref: "b1", kind: "TriggerBinding", resolved: null, status: "resolved" }],
+          }),
+        ],
+      })
+    );
+    const pairs = edges.map((e) => ({ source: e.source, target: e.target }));
+    expect(pairs).toContainEqual({ source: "node::trigger::g-0", target: "node::binding::g-0::0" });
+    expect(pairs).toContainEqual({ source: "node::binding::g-0::0", target: "node::template::g-0" });
+  });
+
+  test("triggerRef with no interceptors and multiple bindings: every binding has an incoming edge from the trigger", () => {
+    const edges = buildEdges(
+      baseTopology({
+        triggers: [
+          triggerRefNode({
+            bindings: [
+              { ref: "b1", kind: "TriggerBinding", resolved: null, status: "resolved" },
+              { ref: "b2", kind: "TriggerBinding", resolved: null, status: "resolved" },
+              { ref: "b3", kind: "TriggerBinding", resolved: null, status: "resolved" },
+            ],
+          }),
+        ],
+      })
+    );
+    const pairs = edges.map((e) => ({ source: e.source, target: e.target }));
+    expect(pairs).toContainEqual({ source: "node::trigger::g-0", target: "node::binding::g-0::0" });
+    expect(pairs).toContainEqual({ source: "node::trigger::g-0", target: "node::binding::g-0::1" });
+    expect(pairs).toContainEqual({ source: "node::trigger::g-0", target: "node::binding::g-0::2" });
+    expect(pairs).toContainEqual({ source: "node::binding::g-0::0", target: "node::template::g-0" });
+    expect(pairs).toContainEqual({ source: "node::binding::g-0::1", target: "node::template::g-0" });
+    expect(pairs).toContainEqual({ source: "node::binding::g-0::2", target: "node::template::g-0" });
+  });
+
+  test("inline trigger with no interceptors and multiple bindings: every binding has an incoming edge from the EventListener", () => {
+    const edges = buildEdges(
+      baseTopology({
+        triggers: [
+          inlineNode({
+            bindings: [
+              { ref: "b1", kind: "TriggerBinding", resolved: null, status: "resolved" },
+              { ref: "b2", kind: "TriggerBinding", resolved: null, status: "resolved" },
+            ],
+          }),
+        ],
+      })
+    );
+    const pairs = edges.map((e) => ({ source: e.source, target: e.target }));
+    expect(pairs).toContainEqual({ source: "node::eventListener", target: "node::binding::inline-1-0::0" });
+    expect(pairs).toContainEqual({ source: "node::eventListener", target: "node::binding::inline-1-0::1" });
+    expect(pairs).toContainEqual({ source: "node::binding::inline-1-0::0", target: "node::template::inline-1-0" });
+    expect(pairs).toContainEqual({ source: "node::binding::inline-1-0::1", target: "node::template::inline-1-0" });
+  });
+});

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/hooks/useEventFlowGraphData.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/hooks/useEventFlowGraphData.ts
@@ -1,0 +1,247 @@
+import React from "react";
+import { Edge, MarkerType, Node } from "@xyflow/react";
+import type { Trigger, PipelineRun, GitServer } from "@my-project/shared";
+import {
+  EventListenerTopology,
+  ResolvedTriggerNode,
+  ResolutionStatus,
+} from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { NODE_KIND, NodeKind } from "../constants";
+import { getLayoutedElements } from "../utils/layoutUtils";
+
+// Typed data shapes for each node kind
+export type GitSourceNodeData = { gitServer: NonNullable<GitServer> };
+export type EventListenerNodeData = {
+  eventListener: EventListenerTopology["eventListener"];
+  ready: boolean;
+  address: string | null;
+  triggerCount: number;
+};
+export type TriggerNodeData = {
+  triggerRef: string;
+  resolved: Trigger | null;
+  status: ResolutionStatus;
+  namespace: string;
+};
+export type InterceptorNodeData = { interceptor: ResolvedTriggerNode["interceptors"][number]; namespace: string };
+export type TriggerBindingNodeData = { binding: ResolvedTriggerNode["bindings"][number]; namespace: string };
+export type TriggerTemplateNodeData = { template: ResolvedTriggerNode["template"]; namespace: string };
+export type PipelineNodeData = {
+  pipelineRef: ResolvedTriggerNode["template"]["pipelineRef"];
+  latestPipelineRun: PipelineRun | null;
+  namespace: string;
+};
+
+// Typed node variants
+type TypedNode<TData extends Record<string, unknown>, TType extends NodeKind> = Node<TData, TType>;
+
+export type GitSourceFlowNode = TypedNode<GitSourceNodeData, typeof NODE_KIND.GIT_SOURCE>;
+export type EventListenerFlowNode = TypedNode<EventListenerNodeData, typeof NODE_KIND.EVENT_LISTENER>;
+export type TriggerFlowNode = TypedNode<TriggerNodeData, typeof NODE_KIND.TRIGGER>;
+export type InterceptorFlowNode = TypedNode<InterceptorNodeData, typeof NODE_KIND.INTERCEPTOR>;
+export type TriggerBindingFlowNode = TypedNode<TriggerBindingNodeData, typeof NODE_KIND.TRIGGER_BINDING>;
+export type TriggerTemplateFlowNode = TypedNode<TriggerTemplateNodeData, typeof NODE_KIND.TRIGGER_TEMPLATE>;
+export type PipelineFlowNode = TypedNode<PipelineNodeData, typeof NODE_KIND.PIPELINE>;
+
+export type FlowNode =
+  | GitSourceFlowNode
+  | EventListenerFlowNode
+  | TriggerFlowNode
+  | InterceptorFlowNode
+  | TriggerBindingFlowNode
+  | TriggerTemplateFlowNode
+  | PipelineFlowNode;
+
+const triggerKey = (entry: ResolvedTriggerNode, idx: number) => {
+  const base = entry.source.kind === "triggerRef" ? entry.source.ref : entry.source.name || "inline";
+  return `${base}-${idx}`;
+};
+
+export const buildNodes = (topology: EventListenerTopology): FlowNode[] => {
+  const nodes: FlowNode[] = [];
+
+  if (topology.gitServer) {
+    nodes.push({
+      id: "node::gitSource",
+      type: NODE_KIND.GIT_SOURCE,
+      data: { gitServer: topology.gitServer },
+      position: { x: 0, y: 0 },
+    });
+  }
+
+  nodes.push({
+    id: "node::eventListener",
+    type: NODE_KIND.EVENT_LISTENER,
+    data: {
+      eventListener: topology.eventListener,
+      ready: topology.ready,
+      address: topology.address,
+      triggerCount: topology.triggers.length,
+    },
+    position: { x: 0, y: 0 },
+  });
+
+  topology.triggers.forEach((entry, idx) => {
+    const key = triggerKey(entry, idx);
+
+    if (entry.source.kind === "triggerRef") {
+      nodes.push({
+        id: `node::trigger::${key}`,
+        type: NODE_KIND.TRIGGER,
+        data: {
+          triggerRef: entry.source.ref,
+          resolved: entry.source.resolved,
+          status: entry.source.status,
+          namespace: topology.eventListener.metadata.namespace ?? "",
+        },
+        position: { x: 0, y: 0 },
+      });
+    }
+
+    entry.interceptors.forEach((i, iIdx) => {
+      nodes.push({
+        id: `node::interceptor::${key}::${iIdx}`,
+        type: NODE_KIND.INTERCEPTOR,
+        data: { interceptor: i, namespace: topology.eventListener.metadata.namespace ?? "" },
+        position: { x: 0, y: 0 },
+      });
+    });
+
+    entry.bindings.forEach((b, bIdx) => {
+      nodes.push({
+        id: `node::binding::${key}::${bIdx}`,
+        type: NODE_KIND.TRIGGER_BINDING,
+        data: { binding: b, namespace: topology.eventListener.metadata.namespace ?? "" },
+        position: { x: 0, y: 0 },
+      });
+    });
+
+    nodes.push({
+      id: `node::template::${key}`,
+      type: NODE_KIND.TRIGGER_TEMPLATE,
+      data: { template: entry.template, namespace: topology.eventListener.metadata.namespace ?? "" },
+      position: { x: 0, y: 0 },
+    });
+
+    nodes.push({
+      id: `node::pipeline::${key}`,
+      type: NODE_KIND.PIPELINE,
+      data: {
+        pipelineRef: entry.template.pipelineRef,
+        latestPipelineRun: entry.latestPipelineRun,
+        namespace: topology.eventListener.metadata.namespace ?? "",
+      },
+      position: { x: 0, y: 0 },
+    });
+  });
+
+  return nodes;
+};
+
+export const buildEdges = (topology: EventListenerTopology): Edge[] => {
+  const edges: Edge[] = [];
+  const opts = {
+    type: "smoothstep",
+    markerEnd: { type: MarkerType.ArrowClosed, width: 18, height: 18 },
+    style: { strokeWidth: 1.5 },
+  };
+
+  if (topology.gitServer) {
+    edges.push({ id: "edge::git→el", source: "node::gitSource", target: "node::eventListener", ...opts });
+  }
+
+  topology.triggers.forEach((entry, idx) => {
+    const key = triggerKey(entry, idx);
+    const firstInterceptorId = entry.interceptors.length ? `node::interceptor::${key}::0` : null;
+    const templateId = `node::template::${key}`;
+    const pipelineId = `node::pipeline::${key}`;
+
+    if (entry.source.kind === "triggerRef") {
+      edges.push({
+        id: `edge::el→trigger::${key}`,
+        source: "node::eventListener",
+        target: `node::trigger::${key}`,
+        label: entry.source.ref,
+        ...opts,
+      });
+      const tail = firstInterceptorId ?? (entry.bindings.length ? `node::binding::${key}::0` : templateId);
+      edges.push({ id: `edge::trigger→${tail}`, source: `node::trigger::${key}`, target: tail, ...opts });
+    } else {
+      const tail = firstInterceptorId ?? (entry.bindings.length ? `node::binding::${key}::0` : templateId);
+      edges.push({
+        id: `edge::el→${tail}::${key}`,
+        source: "node::eventListener",
+        target: tail,
+        label: entry.source.name || undefined,
+        ...opts,
+      });
+    }
+
+    for (let i = 0; i < entry.interceptors.length - 1; i += 1) {
+      edges.push({
+        id: `edge::interceptor::${key}::${i}→${i + 1}`,
+        source: `node::interceptor::${key}::${i}`,
+        target: `node::interceptor::${key}::${i + 1}`,
+        ...opts,
+      });
+    }
+
+    const lastInterceptorId = entry.interceptors.length
+      ? `node::interceptor::${key}::${entry.interceptors.length - 1}`
+      : null;
+
+    const noInterceptorBindingSourceId = !lastInterceptorId
+      ? entry.source.kind === "triggerRef"
+        ? `node::trigger::${key}`
+        : "node::eventListener"
+      : null;
+
+    entry.bindings.forEach((_, bIdx) => {
+      const bindingId = `node::binding::${key}::${bIdx}`;
+      if (lastInterceptorId) {
+        edges.push({
+          id: `edge::lastInterceptor→binding::${key}::${bIdx}`,
+          source: lastInterceptorId,
+          target: bindingId,
+          ...opts,
+        });
+      } else if (bIdx > 0 && noInterceptorBindingSourceId) {
+        edges.push({
+          id: `edge::source→binding::${key}::${bIdx}`,
+          source: noInterceptorBindingSourceId,
+          target: bindingId,
+          ...opts,
+        });
+      }
+      edges.push({ id: `edge::binding→template::${key}::${bIdx}`, source: bindingId, target: templateId, ...opts });
+    });
+
+    if (!entry.bindings.length && lastInterceptorId) {
+      edges.push({
+        id: `edge::lastInterceptor→template::${key}`,
+        source: lastInterceptorId,
+        target: templateId,
+        ...opts,
+      });
+    }
+
+    edges.push({ id: `edge::template→pipeline::${key}`, source: templateId, target: pipelineId, ...opts });
+  });
+
+  return edges;
+};
+
+export interface UseEventFlowGraphDataResult {
+  nodes: FlowNode[];
+  edges: Edge[];
+}
+
+export function useEventFlowGraphData(
+  topology: EventListenerTopology,
+  direction: "LR" | "TB"
+): UseEventFlowGraphDataResult {
+  return React.useMemo(
+    () => getLayoutedElements(buildNodes(topology), buildEdges(topology), direction),
+    [topology, direction]
+  );
+}

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/index.tsx
@@ -1,0 +1,225 @@
+import React from "react";
+import {
+  Background,
+  ConnectionLineType,
+  Controls,
+  MarkerType,
+  MiniMap,
+  Node,
+  ReactFlow,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesInitialized,
+  useNodesState,
+  useReactFlow,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { Card, CardContent } from "@/core/components/ui/card";
+import { ToggleButton, ToggleButtonGroup } from "@/core/components/ui/toggle-button-group";
+import { Label } from "@/core/components/ui/label";
+import { EventListenerTopology } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { GitSourceNode } from "./components/GitSourceNode";
+import { EventListenerNode } from "./components/EventListenerNode";
+import { TriggerNode } from "./components/TriggerNode";
+import { InterceptorNode } from "./components/InterceptorNode";
+import { TriggerBindingNode } from "./components/TriggerBindingNode";
+import { TriggerTemplateNode } from "./components/TriggerTemplateNode";
+import { PipelineNode } from "./components/PipelineNode";
+import { EventFlowNodeDrawer } from "../EventFlowNodeDrawer";
+import { DrawerSelection } from "../EventFlowNodeDrawer/types";
+import { FlowNode, useEventFlowGraphData } from "./hooks/useEventFlowGraphData";
+import { getLayoutedElements } from "./utils/layoutUtils";
+import { LEGEND_LABELS, NODE_KIND, NODE_KIND_CSS_VAR, NODE_KIND_TAILWIND, NodeKind } from "./constants";
+
+const nodeTypes = {
+  [NODE_KIND.GIT_SOURCE]: GitSourceNode,
+  [NODE_KIND.EVENT_LISTENER]: EventListenerNode,
+  [NODE_KIND.TRIGGER]: TriggerNode,
+  [NODE_KIND.INTERCEPTOR]: InterceptorNode,
+  [NODE_KIND.TRIGGER_BINDING]: TriggerBindingNode,
+  [NODE_KIND.TRIGGER_TEMPLATE]: TriggerTemplateNode,
+  [NODE_KIND.PIPELINE]: PipelineNode,
+};
+
+const readCssVar = (name: string): string => {
+  if (typeof window === "undefined") return "#9ca3af";
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || "#9ca3af";
+};
+
+const isNodeKind = (s: string): s is NodeKind => s in NODE_KIND_CSS_VAR;
+
+const miniMapNodeColor = (node: Node): string => {
+  const t = node.type ?? "";
+  return readCssVar(isNodeKind(t) ? NODE_KIND_CSS_VAR[t] : "--muted-foreground");
+};
+
+const nodeToSelection = (node: FlowNode, topology: EventListenerTopology): DrawerSelection | null => {
+  const ns = topology.eventListener.metadata.namespace ?? "";
+  switch (node.type) {
+    case NODE_KIND.GIT_SOURCE:
+      return { kind: "gitSource", gitServer: topology.gitServer };
+    case NODE_KIND.EVENT_LISTENER:
+      return { kind: "eventListener", eventListener: topology.eventListener };
+    case NODE_KIND.TRIGGER:
+      return {
+        kind: "trigger",
+        triggerRef: node.data.triggerRef,
+        resolved: node.data.resolved,
+        status: node.data.status,
+        namespace: ns,
+      };
+    case NODE_KIND.INTERCEPTOR:
+      return { kind: "interceptor", interceptor: node.data.interceptor, namespace: ns };
+    case NODE_KIND.TRIGGER_BINDING:
+      return { kind: "triggerBinding", binding: node.data.binding, namespace: ns };
+    case NODE_KIND.TRIGGER_TEMPLATE:
+      return { kind: "triggerTemplate", template: node.data.template, namespace: ns };
+    case NODE_KIND.PIPELINE:
+      return {
+        kind: "pipeline",
+        pipelineRef: node.data.pipelineRef,
+        latestPipelineRun: node.data.latestPipelineRun,
+        namespace: ns,
+      };
+    default:
+      return null;
+  }
+};
+
+const Inner: React.FC<{ topology: EventListenerTopology }> = ({ topology }) => {
+  const [direction, setDirection] = React.useState<"LR" | "TB">("LR");
+  const [selection, setSelection] = React.useState<DrawerSelection | null>(null);
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
+
+  const onNodeClick = React.useCallback(
+    (_: React.MouseEvent, node: FlowNode) => {
+      const sel = nodeToSelection(node, topology);
+      if (sel) {
+        setSelection(sel);
+        setDrawerOpen(true);
+      }
+    },
+    [topology]
+  );
+
+  const { nodes, edges } = useEventFlowGraphData(topology, direction);
+  const [flowNodes, setFlowNodes, onNodesChange] = useNodesState<FlowNode>(nodes);
+  const [flowEdges, setFlowEdges, onEdgesChange] = useEdgesState(edges);
+  const { fitView, getNodes } = useReactFlow<FlowNode>();
+  const nodesInitialized = useNodesInitialized();
+  const [layoutPhase, setLayoutPhase] = React.useState<"estimated" | "measured">("estimated");
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const hasVisibleSizeRef = React.useRef(false);
+
+  React.useEffect(() => {
+    setLayoutPhase("estimated");
+    setFlowNodes(nodes);
+    setFlowEdges(edges);
+  }, [nodes, edges, setFlowNodes, setFlowEdges]);
+
+  // Once xyflow has measured every rendered node, re-run dagre using the real
+  // widths/heights. This is the library's automatic measurement path: with
+  // accurate sizes, smoothstep edges enter through the left/right handles
+  // instead of bending into the node body when estimates underreport width.
+  React.useEffect(() => {
+    if (!nodesInitialized || layoutPhase === "measured") return;
+    const measured = getNodes();
+    if (!measured.length) return;
+    if (measured.some((n) => !n.measured?.width || !n.measured?.height)) return;
+    const result = getLayoutedElements(measured, edges, direction);
+    setFlowNodes(result.nodes);
+    setLayoutPhase("measured");
+    const fitTimer = setTimeout(() => fitView({ padding: 0.15, maxZoom: 1, duration: 200 }), 50);
+    return () => clearTimeout(fitTimer);
+  }, [nodesInitialized, layoutPhase, getNodes, edges, direction, setFlowNodes, fitView]);
+
+  React.useEffect(() => {
+    const c = containerRef.current;
+    if (!c) return;
+    const ro = new ResizeObserver((entries) => {
+      const e = entries[0];
+      const ok = !!e && e.contentRect.width > 0 && e.contentRect.height > 0;
+      if (ok && !hasVisibleSizeRef.current) {
+        hasVisibleSizeRef.current = true;
+        setTimeout(() => fitView({ padding: 0.15, maxZoom: 1, duration: 200 }), 50);
+      } else if (!ok) {
+        hasVisibleSizeRef.current = false;
+      }
+    });
+    ro.observe(c);
+    return () => ro.disconnect();
+  }, [fitView]);
+
+  return (
+    <div ref={containerRef} className="relative h-full w-full flex-1">
+      <Card className="absolute top-4 left-4 z-10">
+        <CardContent className="flex flex-wrap gap-2 p-3 text-xs">
+          {(Object.keys(LEGEND_LABELS) as Array<keyof typeof LEGEND_LABELS>).map((kind) => (
+            <span
+              key={kind}
+              className={`inline-flex items-center gap-1 rounded px-2 py-0.5 ${NODE_KIND_TAILWIND[kind]}`}
+            >
+              <span className="inline-block size-2 rounded bg-current" />
+              {LEGEND_LABELS[kind]}
+            </span>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="absolute top-4 right-4 z-10">
+        <CardContent className="flex flex-col gap-3 p-3">
+          <div>
+            <Label className="mb-1 block text-xs">Layout</Label>
+            <ToggleButtonGroup
+              aria-label="Graph layout direction"
+              value={direction}
+              exclusive
+              onChange={(_, v) => v && setDirection(v)}
+              size="sm"
+            >
+              <ToggleButton value="LR">Horizontal</ToggleButton>
+              <ToggleButton value="TB">Vertical</ToggleButton>
+            </ToggleButtonGroup>
+          </div>
+        </CardContent>
+      </Card>
+
+      <ReactFlow
+        nodes={flowNodes}
+        edges={flowEdges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={nodeTypes}
+        connectionLineType={ConnectionLineType.SmoothStep}
+        defaultEdgeOptions={{
+          type: "smoothstep",
+          markerEnd: { type: MarkerType.ArrowClosed, width: 18, height: 18 },
+          style: { strokeWidth: 1.5 },
+          animated: false,
+        }}
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
+        minZoom={0.1}
+        maxZoom={2}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={true}
+        selectNodesOnDrag={false}
+        proOptions={{ hideAttribution: true }}
+        onNodeClick={onNodeClick}
+      >
+        <Background />
+        <Controls />
+        <MiniMap nodeStrokeWidth={3} nodeColor={miniMapNodeColor} pannable zoomable />
+      </ReactFlow>
+
+      <EventFlowNodeDrawer open={drawerOpen} onOpenChange={setDrawerOpen} selection={selection} />
+    </div>
+  );
+};
+
+export const EventFlowDiagram: React.FC<{ topology: EventListenerTopology | null }> = ({ topology }) => (
+  <ReactFlowProvider>
+    <div className="flex h-full w-full flex-1 flex-col">{topology && <Inner topology={topology} />}</div>
+  </ReactFlowProvider>
+);

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/utils/layoutUtils.test.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/utils/layoutUtils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+import { Edge, Node, Position } from "@xyflow/react";
+import { getLayoutedElements } from "./layoutUtils";
+
+describe("getLayoutedElements", () => {
+  test("LR layout assigns Left/Right handles", () => {
+    const nodes: Node[] = [
+      { id: "a", data: {}, position: { x: 0, y: 0 } },
+      { id: "b", data: {}, position: { x: 0, y: 0 } },
+    ];
+    const edges: Edge[] = [{ id: "ab", source: "a", target: "b" }];
+    const result = getLayoutedElements(nodes, edges, "LR");
+    result.nodes.forEach((n) => {
+      expect(n.targetPosition).toBe(Position.Left);
+      expect(n.sourcePosition).toBe(Position.Right);
+      expect(n.draggable).toBe(false);
+    });
+  });
+
+  test("TB layout assigns Top/Bottom handles", () => {
+    const nodes: Node[] = [{ id: "a", data: {}, position: { x: 0, y: 0 } }];
+    const result = getLayoutedElements(nodes, [], "TB");
+    expect(result.nodes[0].targetPosition).toBe(Position.Top);
+    expect(result.nodes[0].sourcePosition).toBe(Position.Bottom);
+  });
+
+  test("assigns non-zero positions to multi-node graph", () => {
+    const nodes: Node[] = [
+      { id: "a", data: {}, position: { x: 0, y: 0 } },
+      { id: "b", data: {}, position: { x: 0, y: 0 } },
+      { id: "c", data: {}, position: { x: 0, y: 0 } },
+    ];
+    const edges: Edge[] = [
+      { id: "ab", source: "a", target: "b" },
+      { id: "bc", source: "b", target: "c" },
+    ];
+    const result = getLayoutedElements(nodes, edges, "LR");
+    const allZero = result.nodes.every((n) => n.position.x === 0 && n.position.y === 0);
+    expect(allZero).toBe(false);
+  });
+
+  test("preserves node data and ids", () => {
+    const nodes: Node[] = [{ id: "x", data: { label: "X", custom: 1 }, position: { x: 0, y: 0 }, type: "custom" }];
+    const result = getLayoutedElements(nodes, [], "LR");
+    expect(result.nodes[0].id).toBe("x");
+    expect(result.nodes[0].data.label).toBe("X");
+    expect(result.nodes[0].type).toBe("custom");
+  });
+
+  test("filters out hidden edges", () => {
+    const nodes: Node[] = [
+      { id: "a", data: {}, position: { x: 0, y: 0 } },
+      { id: "b", data: {}, position: { x: 0, y: 0 } },
+    ];
+    const edges: Edge[] = [
+      { id: "ab", source: "a", target: "b" },
+      { id: "hidden", source: "a", target: "b", hidden: true },
+    ];
+    const result = getLayoutedElements(nodes, edges, "LR");
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].id).toBe("ab");
+  });
+
+  test("handles empty input", () => {
+    const result = getLayoutedElements([], [], "LR");
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/utils/layoutUtils.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/utils/layoutUtils.ts
@@ -1,0 +1,73 @@
+import { Edge, Node, Position } from "@xyflow/react";
+import dagre from "dagre";
+import { NODE_KIND, NodeKind } from "../constants";
+
+interface NodeSize {
+  width: number;
+  height: number;
+}
+
+const DEFAULT_SIZE: NodeSize = { width: 220, height: 90 };
+
+// Approximate rendered node sizes per kind. Dagre uses these to allocate
+// inter-rank spacing; if they are smaller than the actual rendered width,
+// adjacent columns overlap (notably TriggerTemplate ↔ Pipeline where the
+// "creates: PipelineRun → ..." and "${tt.params...}" lines push the box
+// well past 220px).
+const NODE_SIZE_BY_KIND: Record<NodeKind, NodeSize> = {
+  [NODE_KIND.GIT_SOURCE]: { width: 220, height: 72 },
+  [NODE_KIND.EVENT_LISTENER]: { width: 360, height: 100 },
+  [NODE_KIND.TRIGGER]: { width: 260, height: 80 },
+  [NODE_KIND.INTERCEPTOR]: { width: 360, height: 130 },
+  [NODE_KIND.TRIGGER_BINDING]: { width: 260, height: 80 },
+  [NODE_KIND.TRIGGER_TEMPLATE]: { width: 360, height: 92 },
+  [NODE_KIND.PIPELINE]: { width: 320, height: 110 },
+};
+
+const sizeOf = (node: Node): NodeSize => {
+  // Once xyflow has measured the rendered DOM, prefer the actual size — that is
+  // what makes handles line up exactly at the visible node edges so smoothstep
+  // edges enter cleanly through the left/right handle instead of clipping the
+  // box. Falls back to per-kind estimates on the first pass (before measure).
+  const measuredW = node.measured?.width;
+  const measuredH = node.measured?.height;
+  if (measuredW && measuredH) return { width: measuredW, height: measuredH };
+
+  const kind = node.type;
+  if (!kind || !(kind in NODE_SIZE_BY_KIND)) return DEFAULT_SIZE;
+  return NODE_SIZE_BY_KIND[kind as NodeKind];
+};
+
+export const getLayoutedElements = <T extends Node>(
+  nodes: T[],
+  edges: Edge[],
+  direction: "TB" | "LR" = "LR"
+): { nodes: T[]; edges: Edge[] } => {
+  const isHorizontal = direction === "LR";
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({ rankdir: direction, nodesep: 50, ranksep: 110, marginx: 30, marginy: 30 });
+
+  const visibleEdges = edges.filter((e) => !e.hidden);
+  nodes.forEach((node) => {
+    const { width, height } = sizeOf(node);
+    dagreGraph.setNode(node.id, { width, height });
+  });
+  visibleEdges.forEach((edge) => dagreGraph.setEdge(edge.source, edge.target));
+
+  dagre.layout(dagreGraph);
+
+  const layoutedNodes = nodes.map((node) => {
+    const pos = dagreGraph.node(node.id);
+    const { width, height } = sizeOf(node);
+    return {
+      ...node,
+      targetPosition: isHorizontal ? Position.Left : Position.Top,
+      sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
+      position: { x: pos.x - width / 2, y: pos.y - height / 2 },
+      draggable: false,
+    };
+  });
+
+  return { nodes: layoutedNodes, edges: visibleEdges };
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowNodeDrawer/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowNodeDrawer/index.tsx
@@ -1,0 +1,270 @@
+import React from "react";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/core/components/ui/sheet";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/core/components/ui/tabs";
+import { Button } from "@/core/components/ui/button";
+import { Badge } from "@/core/components/ui/badge";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { ExternalLink } from "lucide-react";
+import { useClusterStore } from "@/k8s/store";
+import CodeEditor from "@/core/components/CodeEditor";
+import { routeTriggerDetails } from "@/modules/platform/tekton/pages/trigger-details/route";
+import { routeTriggerBindingDetails } from "@/modules/platform/tekton/pages/trigger-binding-details/route";
+import { routeTriggerTemplateDetails } from "@/modules/platform/tekton/pages/trigger-template-details/route";
+import { routeInterceptorDetails } from "@/modules/platform/tekton/pages/interceptor-details/route";
+import { routeClusterInterceptorDetails } from "@/modules/platform/tekton/pages/cluster-interceptor-details/route";
+import { PATH_CONFIG_GITSERVERS_FULL } from "@/modules/platform/configuration/modules/gitservers/route";
+import { ResolutionStatusBadge } from "../EventFlowDiagram/components/ResolutionStatusBadge";
+import { DrawerSelection } from "./types";
+
+export interface EventFlowNodeDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selection: DrawerSelection | null;
+}
+
+const titleFor = (s: DrawerSelection): string => {
+  switch (s.kind) {
+    case "gitSource":
+      return s.gitServer?.metadata.name ?? "Webhook source";
+    case "eventListener":
+      return s.eventListener.metadata.name;
+    case "trigger":
+      return s.triggerRef;
+    case "interceptor":
+      return s.interceptor.ref.name;
+    case "triggerBinding":
+      return s.binding.ref;
+    case "triggerTemplate":
+      return s.template.ref || "(no template)";
+    case "pipeline":
+      if (s.pipelineRef.kind === "literal") return s.pipelineRef.pipelineName;
+      if (s.pipelineRef.kind === "templated") return "Pipeline (dynamic)";
+      return "Pipeline (unknown)";
+  }
+};
+
+const yamlFor = (s: DrawerSelection): object | null => {
+  switch (s.kind) {
+    case "gitSource":
+      return s.gitServer;
+    case "eventListener":
+      return s.eventListener;
+    case "trigger":
+      return s.resolved;
+    case "interceptor":
+      return s.interceptor.resolved ?? { ref: s.interceptor.ref, params: s.interceptor.params };
+    case "triggerBinding":
+      return s.binding.resolved ?? { ref: s.binding.ref, kind: s.binding.kind };
+    case "triggerTemplate":
+      return s.template.resolved;
+    case "pipeline":
+      return s.latestPipelineRun;
+  }
+};
+
+export const EventFlowNodeDrawer: React.FC<EventFlowNodeDrawerProps> = ({ open, onOpenChange, selection }) => {
+  const { clusterName } = useClusterStore(useShallow((s) => ({ clusterName: s.clusterName })));
+
+  if (!selection) return null;
+
+  const renderDetailsTab = () => {
+    switch (selection.kind) {
+      case "gitSource":
+        return (
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Provider:</span> {selection.gitServer?.spec?.gitProvider ?? "—"}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Host:</span>{" "}
+              <code>{selection.gitServer?.spec?.gitHost ?? "—"}</code>
+            </div>
+            {selection.gitServer && (
+              <Button variant="link" asChild className="p-0">
+                <Link to={PATH_CONFIG_GITSERVERS_FULL} params={{ clusterName }}>
+                  View Git servers <ExternalLink size={14} className="ml-1" />
+                </Link>
+              </Button>
+            )}
+          </div>
+        );
+      case "eventListener":
+        return (
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Address:</span>{" "}
+              <code>{selection.eventListener.status?.address?.url ?? "—"}</code>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Triggers:</span>{" "}
+              {(selection.eventListener.spec?.triggers ?? []).length}
+            </div>
+          </div>
+        );
+      case "trigger":
+        return (
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Ref:</span> {selection.triggerRef}
+            </div>
+            {selection.resolved ? (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={routeTriggerDetails.fullPath}
+                  params={{ clusterName, namespace: selection.namespace, name: selection.triggerRef }}
+                >
+                  Open Trigger detail <ExternalLink size={14} className="ml-1" />
+                </Link>
+              </Button>
+            ) : (
+              <ResolutionStatusBadge
+                status={selection.status}
+                resourceLabel="Trigger"
+                className="px-2 py-0.5 text-xs"
+              />
+            )}
+          </div>
+        );
+      case "interceptor": {
+        const isCluster = selection.interceptor.ref.kind === "ClusterInterceptor";
+        return (
+          <div className="space-y-3 text-sm">
+            <div>
+              <span className="text-muted-foreground">Kind:</span>{" "}
+              {isCluster ? "ClusterInterceptor" : "NamespacedInterceptor"}
+            </div>
+            {selection.interceptor.resolved ? (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={isCluster ? routeClusterInterceptorDetails.fullPath : routeInterceptorDetails.fullPath}
+                  params={
+                    isCluster
+                      ? { clusterName, name: selection.interceptor.ref.name }
+                      : { clusterName, namespace: selection.namespace, name: selection.interceptor.ref.name }
+                  }
+                >
+                  Open detail <ExternalLink size={14} className="ml-1" />
+                </Link>
+              </Button>
+            ) : (
+              <ResolutionStatusBadge
+                status={selection.interceptor.status}
+                resourceLabel={isCluster ? "ClusterInterceptor" : "Interceptor"}
+                className="px-2 py-0.5 text-xs"
+              />
+            )}
+            <div>
+              <h4 className="text-muted-foreground mb-1 text-xs uppercase">Params</h4>
+              <pre className="bg-muted rounded p-2 text-xs break-words whitespace-pre-wrap">
+                {JSON.stringify(selection.interceptor.params, null, 2)}
+              </pre>
+            </div>
+          </div>
+        );
+      }
+      case "triggerBinding":
+        return (
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Kind:</span> {selection.binding.kind}
+            </div>
+            {selection.binding.kind === "TriggerBinding" && selection.binding.resolved ? (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={routeTriggerBindingDetails.fullPath}
+                  params={{ clusterName, namespace: selection.namespace, name: selection.binding.ref }}
+                >
+                  Open binding detail <ExternalLink size={14} className="ml-1" />
+                </Link>
+              </Button>
+            ) : selection.binding.kind === "ClusterTriggerBinding" ? (
+              <Badge variant="secondary">ClusterTriggerBinding (unresolved in MVP)</Badge>
+            ) : (
+              <ResolutionStatusBadge
+                status={selection.binding.status}
+                resourceLabel="TriggerBinding"
+                className="px-2 py-0.5 text-xs"
+              />
+            )}
+          </div>
+        );
+      case "triggerTemplate":
+        return (
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Ref:</span> {selection.template.ref || "—"}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Pipeline:</span>{" "}
+              {selection.template.pipelineRef.kind === "literal" ? (
+                selection.template.pipelineRef.pipelineName
+              ) : selection.template.pipelineRef.kind === "templated" ? (
+                <code>{selection.template.pipelineRef.raw}</code>
+              ) : (
+                "(unknown)"
+              )}
+            </div>
+            {selection.template.resolved ? (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={routeTriggerTemplateDetails.fullPath}
+                  params={{ clusterName, namespace: selection.namespace, name: selection.template.ref }}
+                >
+                  Open template detail <ExternalLink size={14} className="ml-1" />
+                </Link>
+              </Button>
+            ) : selection.template.ref ? (
+              <ResolutionStatusBadge
+                status={selection.template.status}
+                resourceLabel="TriggerTemplate"
+                className="px-2 py-0.5 text-xs"
+              />
+            ) : null}
+          </div>
+        );
+      case "pipeline":
+        return (
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Ref kind:</span> {selection.pipelineRef.kind}
+            </div>
+            {selection.latestPipelineRun && (
+              <div>
+                <span className="text-muted-foreground">Latest run:</span> {selection.latestPipelineRun.metadata.name}
+              </div>
+            )}
+          </div>
+        );
+    }
+  };
+
+  const yaml = yamlFor(selection);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-[480px] sm:max-w-[480px]">
+        <SheetHeader>
+          <SheetTitle>{titleFor(selection)}</SheetTitle>
+          <SheetDescription className="sr-only">{titleFor(selection)} details</SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 overflow-hidden p-4 pt-0">
+          <Tabs key={`${selection.kind}:${titleFor(selection)}`} defaultValue="details" className="h-full">
+            <TabsList>
+              <TabsTrigger value="details">Details</TabsTrigger>
+              <TabsTrigger value="yaml" disabled={!yaml}>
+                YAML
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="details" className="mt-3">
+              {renderDetailsTab()}
+            </TabsContent>
+            <TabsContent value="yaml" className="mt-3 h-[calc(100vh-160px)] overflow-hidden">
+              {yaml && <CodeEditor language="yaml" content={yaml} />}
+            </TabsContent>
+          </Tabs>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowNodeDrawer/types.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowNodeDrawer/types.ts
@@ -1,0 +1,16 @@
+import { EventListener, Trigger, GitServer, PipelineRun } from "@my-project/shared";
+import { ResolutionStatus, ResolvedTriggerNode } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+
+export type DrawerSelection =
+  | { kind: "gitSource"; gitServer: GitServer | null }
+  | { kind: "eventListener"; eventListener: EventListener }
+  | { kind: "trigger"; triggerRef: string; resolved: Trigger | null; status: ResolutionStatus; namespace: string }
+  | { kind: "interceptor"; interceptor: ResolvedTriggerNode["interceptors"][number]; namespace: string }
+  | { kind: "triggerBinding"; binding: ResolvedTriggerNode["bindings"][number]; namespace: string }
+  | { kind: "triggerTemplate"; template: ResolvedTriggerNode["template"]; namespace: string }
+  | {
+      kind: "pipeline";
+      pipelineRef: ResolvedTriggerNode["template"]["pipelineRef"];
+      latestPipelineRun: PipelineRun | null;
+      namespace: string;
+    };

--- a/apps/client/src/modules/platform/tekton/components/InterceptorOverview/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/InterceptorOverview/index.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { Interceptor, ClusterInterceptor } from "@my-project/shared";
+import { Card } from "@/core/components/ui/card";
+import { Badge } from "@/core/components/ui/badge";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+
+export interface InterceptorOverviewProps {
+  resource: Interceptor | ClusterInterceptor | null | undefined;
+  isLoading: boolean;
+}
+
+export const InterceptorOverview: React.FC<InterceptorOverviewProps> = ({ resource, isLoading }) => {
+  return (
+    <Card className="p-6">
+      <LoadingWrapper isLoading={isLoading || !resource}>
+        {resource && <InterceptorOverviewContent resource={resource} />}
+      </LoadingWrapper>
+    </Card>
+  );
+};
+
+const InterceptorOverviewContent: React.FC<{ resource: Interceptor | ClusterInterceptor }> = ({ resource }) => {
+  const spec = resource.spec;
+  const labels = Object.entries(resource.metadata.labels ?? {});
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section>
+        <h3 className="text-foreground mb-2 text-lg font-semibold">Metadata</h3>
+        <dl className="grid grid-cols-4 gap-x-6 gap-y-3 text-sm">
+          <div>
+            <dt className="text-muted-foreground">Created</dt>
+            <dd>{formatTimestamp(resource.metadata.creationTimestamp)}</dd>
+          </div>
+          <div className="col-span-3">
+            <dt className="text-muted-foreground">Labels</dt>
+            <dd className="flex flex-wrap gap-1">
+              {labels.length === 0 ? (
+                <span className="text-muted-foreground">No labels</span>
+              ) : (
+                labels.map(([k, v]) => (
+                  <Badge key={k} variant="secondary">
+                    {k}:{v}
+                  </Badge>
+                ))
+              )}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section>
+        <h3 className="text-foreground mb-3 text-lg font-semibold">Client config</h3>
+        {spec?.clientConfig?.url && (
+          <div className="text-sm">
+            URL: <code className="font-mono text-xs">{spec.clientConfig.url}</code>
+          </div>
+        )}
+        {spec?.clientConfig?.service && (
+          <dl className="grid grid-cols-3 gap-3 text-sm">
+            <div>
+              <dt className="text-muted-foreground">Service</dt>
+              <dd>{spec.clientConfig.service.name}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Namespace</dt>
+              <dd>{spec.clientConfig.service.namespace}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Port</dt>
+              <dd>{spec.clientConfig.service.port ?? "—"}</dd>
+            </div>
+          </dl>
+        )}
+        {!spec?.clientConfig?.url && !spec?.clientConfig?.service && (
+          <p className="text-muted-foreground text-sm">No client config defined.</p>
+        )}
+        {spec?.description && <p className="text-muted-foreground mt-3 text-sm">{spec.description}</p>}
+      </section>
+    </div>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/hooks/useDetailTabs/index.tsx
+++ b/apps/client/src/modules/platform/tekton/hooks/useDetailTabs/index.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Info, FileCode } from "lucide-react";
+import { router } from "@/core/router";
+import { Tab } from "@/core/providers/Tabs/components/Tabs/types";
+
+export const detailTabIds = { overview: "overview", yaml: "yaml" } as const;
+export type DetailTabId = (typeof detailTabIds)[keyof typeof detailTabIds];
+
+interface RouteWithParams {
+  useParams: () => Record<string, string>;
+}
+
+export interface UseDetailTabsArgs {
+  route: RouteWithParams;
+  path: string;
+  Overview: React.ComponentType;
+  UsedBy?: React.ComponentType;
+  ViewYaml: React.ComponentType;
+}
+
+export const useDetailTabs = ({ route, path, Overview, UsedBy, ViewYaml }: UseDetailTabsArgs): Tab[] => {
+  const params = route.useParams();
+  // TanStack Router's useParams returns a fresh object identity each render
+  // even when values are unchanged. Read via a ref keyed on a value-derived
+  // string so the callback (and the memoized tabs array below) only rebuild
+  // when the params actually change.
+  const paramsRef = React.useRef(params);
+  paramsRef.current = params;
+  const paramsKey = JSON.stringify(params);
+
+  const handleTabNavigate = React.useCallback(
+    (tab: DetailTabId) => {
+      router.navigate({ to: path, params: paramsRef.current, search: (prev) => ({ ...prev, tab }) });
+    },
+    // paramsKey is intentional: it is a value-derived stabilization key for
+    // the ref-based read above. The linter can't see that we never read
+    // `params` directly here, only through `paramsRef.current`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [paramsKey, path]
+  );
+
+  return React.useMemo(
+    () => [
+      {
+        id: detailTabIds.overview,
+        label: "Overview",
+        icon: <Info className="size-4" />,
+        onClick: () => handleTabNavigate(detailTabIds.overview),
+        component: (
+          <div className="flex flex-col gap-6 pt-6">
+            <Overview />
+            {UsedBy ? <UsedBy /> : null}
+          </div>
+        ),
+      },
+      {
+        id: detailTabIds.yaml,
+        label: "View YAML",
+        icon: <FileCode className="size-4" />,
+        onClick: () => handleTabNavigate(detailTabIds.yaml),
+        component: (
+          <div className="h-full overflow-hidden pt-6">
+            <ViewYaml />
+          </div>
+        ),
+      },
+    ],
+    [handleTabNavigate, Overview, UsedBy, ViewYaml]
+  );
+};

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/build.test.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/build.test.ts
@@ -1,0 +1,548 @@
+import { describe, expect, test } from "vitest";
+import {
+  type PipelineRun,
+  eventListenerSchema,
+  triggerSchema,
+  triggerBindingSchema,
+  triggerTemplateSchema,
+  interceptorSchema,
+  clusterInterceptorSchema,
+  pipelineRunSchema,
+  gitServerSchema,
+} from "@my-project/shared";
+import { buildTopology } from "./build";
+
+const ns = "edp-delivery";
+const elName = "github-listener";
+
+const baseEL = (overrides: object = {}) =>
+  eventListenerSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "EventListener",
+    metadata: { name: elName, namespace: ns, uid: "u-el", creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+    spec: { triggers: [] },
+    status: {
+      address: { url: `http://el-${elName}.${ns}.svc:8080` },
+      conditions: [{ type: "Ready", status: "True" }],
+    },
+    ...overrides,
+  });
+
+const triggerCR = (name: string, spec: object) =>
+  triggerSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "Trigger",
+    metadata: { name, namespace: ns, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+    spec,
+  });
+
+const tb = (name: string) =>
+  triggerBindingSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "TriggerBinding",
+    metadata: { name, namespace: ns, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z" },
+    spec: {},
+  });
+
+const tt = (name: string, pipelineName: string | undefined, withResourceTemplate = true) =>
+  triggerTemplateSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "TriggerTemplate",
+    metadata: { name, namespace: ns, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+    spec: withResourceTemplate
+      ? { resourcetemplates: [{ spec: pipelineName !== undefined ? { pipelineRef: { name: pipelineName } } : {} }] }
+      : {},
+  });
+
+const interceptor = (name: string) =>
+  interceptorSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1alpha1",
+    kind: "Interceptor",
+    metadata: { name, namespace: ns, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z" },
+  });
+
+const ci = (name: string) =>
+  clusterInterceptorSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1alpha1",
+    kind: "ClusterInterceptor",
+    metadata: { name, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z" },
+  });
+
+const makePR = (name: string, creationTimestamp: string, labels: Record<string, string>, status?: object) =>
+  pipelineRunSchema.parse({
+    apiVersion: "tekton.dev/v1",
+    kind: "PipelineRun",
+    metadata: {
+      name,
+      namespace: ns,
+      uid: `u-${name}`,
+      creationTimestamp,
+      labels: { "app.edp.epam.com/pipelinetype": "build", ...labels },
+    },
+    spec: {},
+    ...(status ? { status } : {}),
+  });
+
+const makeGS = (name: string, extraLabels: Record<string, string> = {}) =>
+  gitServerSchema.parse({
+    apiVersion: "edp.epam.com/v1",
+    kind: "GitServer",
+    metadata: { name, namespace: ns, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z", labels: extraLabels },
+    spec: { gitProvider: "github", gitHost: "github.com", httpsPort: 443, nameSshKeySecret: "git-key", sshPort: 22 },
+    status: {},
+  });
+
+const args = (overrides: Partial<Parameters<typeof buildTopology>[0]> = {}) => ({
+  eventListener: baseEL(),
+  triggersByName: new Map(),
+  triggerBindingsByName: new Map(),
+  triggerTemplatesByName: new Map(),
+  interceptorsByName: new Map(),
+  clusterInterceptorsByName: new Map(),
+  gitServersByName: new Map(),
+  recentRuns: [] as PipelineRun[],
+  ...overrides,
+});
+
+describe("buildTopology — production triggerRef shape", () => {
+  test("resolves Trigger CR and downstream refs", () => {
+    const trig = triggerCR("github-build", {
+      interceptors: [
+        { ref: { name: "cel", kind: "ClusterInterceptor" }, params: [{ name: "filter", value: "body.x" }] },
+      ],
+      bindings: [{ ref: "common-binding" }],
+      template: { ref: "build-template" },
+    });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: { triggers: [{ triggerRef: "github-build" }] },
+        }),
+        triggersByName: new Map([["github-build", trig]]),
+        triggerBindingsByName: new Map([["common-binding", tb("common-binding")]]),
+        triggerTemplatesByName: new Map([["build-template", tt("build-template", "build-pipeline")]]),
+        clusterInterceptorsByName: new Map([["cel", ci("cel")]]),
+      })
+    );
+    expect(result.triggers).toHaveLength(1);
+    const t = result.triggers[0];
+    expect(t.source).toEqual({ kind: "triggerRef", ref: "github-build", resolved: trig, status: "resolved" });
+    expect(t.interceptors[0].resolved?.metadata.name).toBe("cel");
+    expect(t.interceptors[0].status).toBe("resolved");
+    expect(t.bindings[0].resolved?.metadata.name).toBe("common-binding");
+    expect(t.bindings[0].status).toBe("resolved");
+    expect(t.template.resolved?.metadata.name).toBe("build-template");
+    expect(t.template.status).toBe("resolved");
+    expect(t.template.pipelineRef).toEqual({ kind: "literal", pipelineName: "build-pipeline" });
+  });
+});
+
+describe("buildTopology — inline shape", () => {
+  test("derives refs directly from EL spec", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: {
+            triggers: [
+              {
+                name: "x",
+                interceptors: [{ ref: { name: "i1", kind: "NamespacedInterceptor" }, params: [] }],
+                bindings: [{ ref: "b1" }],
+                template: { ref: "t1" },
+              },
+            ],
+          },
+        }),
+        interceptorsByName: new Map([["i1", interceptor("i1")]]),
+        triggerBindingsByName: new Map([["b1", tb("b1")]]),
+        triggerTemplatesByName: new Map([["t1", tt("t1", "p1")]]),
+      })
+    );
+    expect(result.triggers[0].source).toEqual({ kind: "inline", name: "x" });
+    expect(result.triggers[0].interceptors[0].resolved?.metadata.name).toBe("i1");
+  });
+});
+
+describe("buildTopology — dangling triggerRef", () => {
+  test("renders entry with all refs unresolved, no crash", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "missing" }] } }),
+      })
+    );
+    expect(result.triggers[0].source).toEqual({
+      kind: "triggerRef",
+      ref: "missing",
+      resolved: null,
+      status: "missing",
+    });
+    expect(result.triggers[0].interceptors).toHaveLength(0);
+    expect(result.triggers[0].bindings).toHaveLength(0);
+    expect(result.triggers[0].template.ref).toBe("");
+    expect(result.triggers[0].template.resolved).toBeNull();
+    expect(result.triggers[0].template.pipelineRef).toEqual({ kind: "unknown" });
+  });
+});
+
+describe("buildTopology — triggerRef resolves but template ref is missing", () => {
+  test("template.status is missing when Trigger CR exists but its template.ref points to an absent TriggerTemplate", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "gone" } });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+      })
+    );
+    expect(result.triggers[0].source).toMatchObject({ kind: "triggerRef", ref: "g", status: "resolved" });
+    expect(result.triggers[0].template.ref).toBe("gone");
+    expect(result.triggers[0].template.resolved).toBeNull();
+    expect(result.triggers[0].template.status).toBe("missing");
+    expect(result.triggers[0].template.pipelineRef).toEqual({ kind: "unknown" });
+  });
+});
+
+describe("buildTopology — mixed interceptor kinds", () => {
+  test("ClusterInterceptor and NamespacedInterceptor resolve from correct watch", () => {
+    const trig = triggerCR("g", {
+      interceptors: [
+        { ref: { name: "cel", kind: "ClusterInterceptor" } },
+        { ref: { name: "edp", kind: "NamespacedInterceptor" } },
+      ],
+      bindings: [],
+      template: { ref: "" },
+    });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        clusterInterceptorsByName: new Map([["cel", ci("cel")]]),
+        interceptorsByName: new Map([["edp", interceptor("edp")]]),
+      })
+    );
+    expect(result.triggers[0].interceptors[0].resolved?.metadata.name).toBe("cel");
+    expect(result.triggers[0].interceptors[1].resolved?.metadata.name).toBe("edp");
+  });
+});
+
+describe("buildTopology — ClusterTriggerBinding ref", () => {
+  test("gracefully sets resolved=null without crashing", () => {
+    const trig = triggerCR("g", {
+      interceptors: [],
+      bindings: [{ ref: "ctb-x", kind: "ClusterTriggerBinding" }],
+      template: { ref: "" },
+    });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+      })
+    );
+    expect(result.triggers[0].bindings[0]).toEqual({
+      ref: "ctb-x",
+      kind: "ClusterTriggerBinding",
+      resolved: null,
+      status: "restricted",
+    });
+  });
+});
+
+describe("buildTopology — restricted (watch unavailable)", () => {
+  test("ClusterInterceptor ref reports status=restricted when its watch errored", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: {
+            triggers: [
+              {
+                name: "inline",
+                interceptors: [{ ref: { name: "cel", kind: "ClusterInterceptor" } }],
+                bindings: [],
+                template: { ref: "" },
+              },
+            ],
+          },
+        }),
+        availability: { clusterInterceptors: false },
+      })
+    );
+    const i = result.triggers[0].interceptors[0];
+    expect(i.resolved).toBeNull();
+    expect(i.status).toBe("restricted");
+  });
+
+  test("Namespaced Interceptor / TriggerBinding / TriggerTemplate report restricted independently", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: {
+            triggers: [
+              {
+                name: "inline",
+                interceptors: [{ ref: { name: "edp", kind: "NamespacedInterceptor" } }],
+                bindings: [{ ref: "b1" }],
+                template: { ref: "t1" },
+              },
+            ],
+          },
+        }),
+        availability: { interceptors: false, triggerBindings: false, triggerTemplates: false },
+      })
+    );
+    const t = result.triggers[0];
+    expect(t.interceptors[0].status).toBe("restricted");
+    expect(t.bindings[0].status).toBe("restricted");
+    expect(t.template.status).toBe("restricted");
+  });
+
+  test("triggerRef reports restricted when Trigger watch errored, vs missing when it succeeded but ref is dangling", () => {
+    // Watch errored → restricted
+    const restricted = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        availability: { triggers: false },
+      })
+    );
+    expect(restricted.triggers[0].source).toEqual({
+      kind: "triggerRef",
+      ref: "g",
+      resolved: null,
+      status: "restricted",
+    });
+
+    // Watch succeeded but ref is genuinely absent → missing
+    const missing = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+      })
+    );
+    expect(missing.triggers[0].source).toEqual({ kind: "triggerRef", ref: "g", resolved: null, status: "missing" });
+  });
+
+  test("inline trigger without a template keeps template.status=resolved (no false missing badge)", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: {
+            triggers: [{ name: "inline", interceptors: [], bindings: [], template: { ref: "" } }],
+          },
+        }),
+        availability: { triggerTemplates: false },
+      })
+    );
+    expect(result.triggers[0].template.ref).toBe("");
+    expect(result.triggers[0].template.status).toBe("resolved");
+  });
+});
+
+describe("buildTopology — pipelineRef classification", () => {
+  test("templated with $(tt.params.X) extracts sourceParam", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "tpl" } });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        triggerTemplatesByName: new Map([["tpl", tt("tpl", "$(tt.params.pipelineName)")]]),
+      })
+    );
+    expect(result.triggers[0].template.pipelineRef).toEqual({
+      kind: "templated",
+      raw: "$(tt.params.pipelineName)",
+      sourceParam: "pipelineName",
+    });
+  });
+  test("body interpolation has sourceParam=null", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "tpl" } });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        triggerTemplatesByName: new Map([["tpl", tt("tpl", "$(body.repository.name)-build")]]),
+      })
+    );
+    expect(result.triggers[0].template.pipelineRef).toEqual({
+      kind: "templated",
+      raw: "$(body.repository.name)-build",
+      sourceParam: null,
+    });
+  });
+  test("missing resourcetemplates yields unknown", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "tpl" } });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        triggerTemplatesByName: new Map([["tpl", tt("tpl", undefined, false)]]),
+      })
+    );
+    expect(result.triggers[0].template.pipelineRef).toEqual({ kind: "unknown" });
+  });
+});
+
+describe("buildTopology — GitServer resolution", () => {
+  test("absent label → gitServer=null", () => {
+    const result = buildTopology(args());
+    expect(result.gitServer).toBeNull();
+  });
+  test("label present but no matching CR → gitServer=null", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          metadata: {
+            name: elName,
+            namespace: ns,
+            uid: "u",
+            creationTimestamp: "2025-01-01T00:00:00Z",
+            labels: { "app.edp.epam.com/gitServer": "github-1" },
+          },
+        }),
+      })
+    );
+    expect(result.gitServer).toBeNull();
+  });
+  test("label + matching CR in same namespace → resolved", () => {
+    const gs = makeGS("github-1");
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          metadata: {
+            name: elName,
+            namespace: ns,
+            uid: "u",
+            creationTimestamp: "2025-01-01T00:00:00Z",
+            labels: { "app.edp.epam.com/gitServer": "github-1" },
+          },
+        }),
+        gitServersByName: new Map([["github-1", gs]]),
+      })
+    );
+    expect(result.gitServer?.metadata.name).toBe("github-1");
+  });
+});
+
+describe("buildTopology — latestPipelineRun selection", () => {
+  test("no labeled runs → null", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+      })
+    );
+    expect(result.triggers[0].latestPipelineRun).toBeNull();
+  });
+  test("returns the labeled run when one exists", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });
+    const olderRun = makePR("old", "2025-01-01T00:00:00Z", {
+      "triggers.tekton.dev/eventlistener": elName,
+      "triggers.tekton.dev/trigger": "g",
+    });
+    const newerRun = makePR("new", "2025-01-02T00:00:00Z", {
+      "triggers.tekton.dev/eventlistener": elName,
+      "triggers.tekton.dev/trigger": "g",
+    });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        recentRuns: [olderRun, newerRun],
+      })
+    );
+    expect(result.triggers[0].latestPipelineRun?.metadata.name).toBe("new");
+  });
+  test("returns null when no run is labeled for this trigger (no cross-trigger leak)", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });
+    const otherTriggerRun = makePR("other", "2025-01-02T00:00:00Z", {
+      "triggers.tekton.dev/eventlistener": elName,
+      "triggers.tekton.dev/trigger": "h",
+    });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        recentRuns: [otherTriggerRun],
+      })
+    );
+    expect(result.triggers[0].latestPipelineRun).toBeNull();
+  });
+  test("picks the most recent labeled run when multiple match", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });
+    const older = makePR("old", "2025-01-01T00:00:00Z", { "triggers.tekton.dev/trigger": "g" });
+    const newer = makePR("new", "2025-01-03T00:00:00Z", { "triggers.tekton.dev/trigger": "g" });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        recentRuns: [older, newer],
+      })
+    );
+    expect(result.triggers[0].latestPipelineRun?.metadata.name).toBe("new");
+  });
+
+  test("orders by completionTime, not creationTimestamp", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });
+    // The "new-creation" run was queued later (creationTimestamp newer) but
+    // finished earlier; the older-queued "completed-later" run actually finished
+    // most recently and must win.
+    const completedLater = makePR(
+      "completed-later",
+      "2025-01-01T00:00:00Z",
+      { "triggers.tekton.dev/trigger": "g" },
+      { startTime: "2025-01-01T00:01:00Z", completionTime: "2025-01-03T00:10:00Z" }
+    );
+    const newCreation = makePR(
+      "new-creation",
+      "2025-01-02T00:00:00Z",
+      { "triggers.tekton.dev/trigger": "g" },
+      { startTime: "2025-01-02T00:01:00Z", completionTime: "2025-01-02T00:02:00Z" }
+    );
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        recentRuns: [newCreation, completedLater],
+      })
+    );
+    expect(result.triggers[0].latestPipelineRun?.metadata.name).toBe("completed-later");
+  });
+
+  test("falls back to startTime for in-progress runs (no completionTime)", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });
+    // Both runs are in-progress (no completionTime). The one that started later
+    // wins, even when its creationTimestamp is identical.
+    const startedEarlier = makePR(
+      "started-earlier",
+      "2025-01-01T00:00:00Z",
+      { "triggers.tekton.dev/trigger": "g" },
+      { startTime: "2025-01-01T00:01:00Z" }
+    );
+    const startedLater = makePR(
+      "started-later",
+      "2025-01-01T00:00:00Z",
+      { "triggers.tekton.dev/trigger": "g" },
+      { startTime: "2025-01-01T05:00:00Z" }
+    );
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        recentRuns: [startedEarlier, startedLater],
+      })
+    );
+    expect(result.triggers[0].latestPipelineRun?.metadata.name).toBe("started-later");
+  });
+
+  test("falls back to creationTimestamp when neither startTime nor completionTime is set", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });
+    // Pending runs (PipelineRunPending) carry no startTime — fall back to creation order.
+    const earlierPending = makePR("earlier-pending", "2025-01-01T00:00:00Z", { "triggers.tekton.dev/trigger": "g" });
+    const laterPending = makePR("later-pending", "2025-01-02T00:00:00Z", { "triggers.tekton.dev/trigger": "g" });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+        recentRuns: [laterPending, earlierPending],
+      })
+    );
+    expect(result.triggers[0].latestPipelineRun?.metadata.name).toBe("later-pending");
+  });
+});

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/build.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/build.ts
@@ -1,0 +1,188 @@
+import {
+  Trigger,
+  TriggerBinding,
+  TriggerTemplate,
+  Interceptor,
+  ClusterInterceptor,
+  GitServer,
+  PipelineRun,
+  eventListenerLabels,
+} from "@my-project/shared";
+import {
+  BuildTopologyArgs,
+  EventListenerTopology,
+  PipelineRefShape,
+  ResolutionStatus,
+  ResolvedBindingRef,
+  ResolvedInterceptorRef,
+  ResolvedTriggerNode,
+} from "./types";
+
+const PR_TRIGGER_LABEL = "triggers.tekton.dev/trigger";
+
+type TriggerEntry = NonNullable<Trigger["spec"]>;
+
+export const classifyPipelineRef = (raw: string | undefined): PipelineRefShape => {
+  if (!raw) return { kind: "unknown" };
+  const ttParam = raw.match(/^\$\(tt\.params\.([^)]+)\)$/);
+  if (ttParam) return { kind: "templated", raw, sourceParam: ttParam[1] };
+  if (/\$\(.+?\)/.test(raw)) return { kind: "templated", raw, sourceParam: null };
+  return { kind: "literal", pipelineName: raw };
+};
+
+const readPipelineRefName = (template: TriggerTemplate | null): string | undefined =>
+  template?.spec?.resourcetemplates?.[0]?.spec?.pipelineRef?.name;
+
+const statusFor = (resolved: object | null, available: boolean): ResolutionStatus =>
+  resolved ? "resolved" : available ? "missing" : "restricted";
+
+const resolveInterceptors = (
+  raw: TriggerEntry["interceptors"] = [],
+  interceptorsByName: Map<string, Interceptor>,
+  clusterInterceptorsByName: Map<string, ClusterInterceptor>,
+  interceptorsAvailable: boolean,
+  clusterInterceptorsAvailable: boolean
+): ResolvedInterceptorRef[] =>
+  raw.map((i) => {
+    const kind = i.ref?.kind === "ClusterInterceptor" ? "ClusterInterceptor" : "NamespacedInterceptor";
+    const name = i.ref?.name ?? "";
+    const resolved =
+      kind === "ClusterInterceptor"
+        ? (clusterInterceptorsByName.get(name) ?? null)
+        : (interceptorsByName.get(name) ?? null);
+    const available = kind === "ClusterInterceptor" ? clusterInterceptorsAvailable : interceptorsAvailable;
+    return {
+      ref: { name, kind },
+      resolved,
+      status: statusFor(resolved, available),
+      params: (i.params ?? []) as { name: string; value: unknown }[],
+    };
+  });
+
+const resolveBindings = (
+  raw: TriggerEntry["bindings"] = [],
+  triggerBindingsByName: Map<string, TriggerBinding>,
+  triggerBindingsAvailable: boolean
+): ResolvedBindingRef[] =>
+  raw.map((b) => {
+    const kind = b.kind === "ClusterTriggerBinding" ? "ClusterTriggerBinding" : "TriggerBinding";
+    const ref = b.ref ?? "";
+    // ClusterTriggerBinding is intentionally not watched in MVP. We cannot
+    // prove absence, so report "restricted" (= "we cannot determine presence")
+    // rather than "missing". The binding node still renders a CTB-specific
+    // copy that takes precedence over the generic restricted badge.
+    if (kind === "ClusterTriggerBinding") {
+      return { ref, kind, resolved: null, status: "restricted" };
+    }
+    const resolved = triggerBindingsByName.get(ref) ?? null;
+    return { ref, kind, resolved, status: statusFor(resolved, triggerBindingsAvailable) };
+  });
+
+// "Latest" prefers the most relevant timestamp the run actually has:
+//   completionTime > startTime > creationTimestamp.
+// This avoids a fast re-trigger surfacing the older run (which would happen
+// if we sorted purely by creationTimestamp), and keeps in-progress runs ranked
+// by when they actually started rather than when the CR landed in etcd.
+const runOrderTime = (run: PipelineRun): number => {
+  const t = run.status?.completionTime ?? run.status?.startTime ?? run.metadata?.creationTimestamp ?? 0;
+  return new Date(t).getTime();
+};
+
+const pickLatestRun = (recentRuns: PipelineRun[], triggerName: string | undefined): PipelineRun | null => {
+  if (!triggerName) return null;
+  const labeled = recentRuns.filter((r) => r.metadata?.labels?.[PR_TRIGGER_LABEL] === triggerName);
+  if (labeled.length === 0) return null;
+  return labeled.reduce((latest, r) => (runOrderTime(r) > runOrderTime(latest) ? r : latest), labeled[0]);
+};
+
+export const buildTopology = ({
+  eventListener,
+  triggersByName,
+  triggerBindingsByName,
+  triggerTemplatesByName,
+  interceptorsByName,
+  clusterInterceptorsByName,
+  gitServersByName,
+  recentRuns,
+  availability,
+}: BuildTopologyArgs): EventListenerTopology => {
+  // Default every source to "available" so existing callers that pre-date the
+  // restricted-aware UI keep their resolution semantics.
+  const triggersAvailable = availability?.triggers ?? true;
+  const triggerBindingsAvailable = availability?.triggerBindings ?? true;
+  const triggerTemplatesAvailable = availability?.triggerTemplates ?? true;
+  const interceptorsAvailable = availability?.interceptors ?? true;
+  const clusterInterceptorsAvailable = availability?.clusterInterceptors ?? true;
+  // GitSource status isn't surfaced today: the diagram only renders that node
+  // when a GitServer actually resolves. `availability.gitServers` is accepted
+  // for forward-compat with a future restricted-aware GitSource treatment.
+
+  const status = eventListener.status;
+  const address = status?.address?.url ?? null;
+  const ready = status?.conditions?.find((c) => c.type === "Ready")?.status === "True";
+
+  const gitServerName = eventListener.metadata.labels?.[eventListenerLabels.gitServer];
+  const gitServer: GitServer | null = gitServerName ? (gitServersByName.get(gitServerName) ?? null) : null;
+
+  const rawTriggers = eventListener.spec?.triggers ?? [];
+
+  const resolveTemplate = (templateRef: string) => {
+    const resolved = templateRef ? (triggerTemplatesByName.get(templateRef) ?? null) : null;
+    return {
+      ref: templateRef,
+      resolved,
+      // An empty templateRef is a structural "no template here", not an
+      // unresolved cross-reference — keep it as "resolved" so the UI doesn't
+      // light up a misleading badge for inline triggers without a template.
+      status: !templateRef ? ("resolved" as const) : statusFor(resolved, triggerTemplatesAvailable),
+      pipelineRef: classifyPipelineRef(readPipelineRefName(resolved)),
+    };
+  };
+
+  const triggers: ResolvedTriggerNode[] = rawTriggers.map((entry) => {
+    if (entry.triggerRef) {
+      const resolvedTrigger = triggersByName.get(entry.triggerRef) ?? null;
+      const triggerSpec = resolvedTrigger?.spec;
+      const interceptors = resolveInterceptors(
+        triggerSpec?.interceptors,
+        interceptorsByName,
+        clusterInterceptorsByName,
+        interceptorsAvailable,
+        clusterInterceptorsAvailable
+      );
+      const bindings = resolveBindings(triggerSpec?.bindings, triggerBindingsByName, triggerBindingsAvailable);
+      const templateRef = triggerSpec?.template?.ref ?? "";
+      return {
+        source: {
+          kind: "triggerRef" as const,
+          ref: entry.triggerRef,
+          resolved: resolvedTrigger,
+          status: statusFor(resolvedTrigger, triggersAvailable),
+        },
+        interceptors,
+        bindings,
+        template: resolveTemplate(templateRef),
+        latestPipelineRun: pickLatestRun(recentRuns, entry.triggerRef),
+      };
+    }
+    const inlineName = entry.name ?? "";
+    const interceptors = resolveInterceptors(
+      entry.interceptors,
+      interceptorsByName,
+      clusterInterceptorsByName,
+      interceptorsAvailable,
+      clusterInterceptorsAvailable
+    );
+    const bindings = resolveBindings(entry.bindings, triggerBindingsByName, triggerBindingsAvailable);
+    const templateRef = entry.template?.ref ?? "";
+    return {
+      source: { kind: "inline" as const, name: inlineName },
+      interceptors,
+      bindings,
+      template: resolveTemplate(templateRef),
+      latestPipelineRun: pickLatestRun(recentRuns, inlineName),
+    };
+  });
+
+  return { eventListener, address, ready, gitServer, triggers };
+};

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/index.test.tsx
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/index.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestQueryClient } from "@/test/utils";
+
+const mocks = {
+  el: vi.fn(),
+  triggers: vi.fn(),
+  bindings: vi.fn(),
+  templates: vi.fn(),
+  interceptors: vi.fn(),
+  clusterInterceptors: vi.fn(),
+  gitServers: vi.fn(),
+  pipelineRuns: vi.fn(),
+};
+
+vi.mock("@/k8s/api/groups/Tekton/EventListener", () => ({
+  useEventListenerWatchItem: (p: unknown) => mocks.el(p),
+}));
+vi.mock("@/k8s/api/groups/Tekton/Trigger", () => ({
+  useTriggerWatchList: (p: unknown) => mocks.triggers(p),
+}));
+vi.mock("@/k8s/api/groups/Tekton/TriggerBinding", () => ({
+  useTriggerBindingWatchList: (p: unknown) => mocks.bindings(p),
+}));
+vi.mock("@/k8s/api/groups/Tekton/TriggerTemplate", () => ({
+  useTriggerTemplateWatchList: (p: unknown) => mocks.templates(p),
+}));
+vi.mock("@/k8s/api/groups/Tekton/Interceptor", () => ({
+  useInterceptorWatchList: (p: unknown) => mocks.interceptors(p),
+}));
+vi.mock("@/k8s/api/groups/Tekton/ClusterInterceptor", () => ({
+  useClusterInterceptorWatchList: (p: unknown) => mocks.clusterInterceptors(p),
+}));
+vi.mock("@/k8s/api/groups/KRCI/GitServer", () => ({
+  useGitServerWatchList: (p: unknown) => mocks.gitServers(p),
+}));
+vi.mock("@/k8s/api/groups/Tekton/PipelineRun", () => ({
+  usePipelineRunWatchList: (p: unknown) => mocks.pipelineRuns(p),
+}));
+
+import { useEventListenerTopology } from "./index";
+
+const wrap =
+  (qc: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+
+const okList = (arr: Array<{ metadata: { name: string } }>) => ({
+  data: {
+    array: arr,
+    map: new Map(arr.map((a) => [a.metadata.name, a])),
+  },
+  isReady: true,
+  query: { isSuccess: true, isError: false },
+});
+
+const erroredList = () => ({
+  data: { array: [], map: new Map() },
+  isReady: false,
+  query: { isSuccess: false, isError: true },
+});
+
+describe("useEventListenerTopology", () => {
+  let qc: QueryClient;
+  beforeEach(() => {
+    qc = createTestQueryClient();
+    Object.values(mocks).forEach((m) => m.mockReset());
+  });
+
+  it("returns isReady=false while any underlying watch is still loading (not yet settled)", () => {
+    // EL watch still pending — isReady=false AND no error means "loading".
+    mocks.el.mockReturnValue({ data: undefined, isReady: false, query: { isSuccess: false, isError: false } });
+    [
+      mocks.triggers,
+      mocks.bindings,
+      mocks.templates,
+      mocks.interceptors,
+      mocks.clusterInterceptors,
+      mocks.gitServers,
+      mocks.pipelineRuns,
+    ].forEach((m) =>
+      m.mockReturnValue({
+        data: { array: [], map: new Map() },
+        isReady: true,
+        query: { isSuccess: true, isError: false },
+      })
+    );
+    const { result } = renderHook(() => useEventListenerTopology({ name: "el", namespace: "ns" }), {
+      wrapper: wrap(qc),
+    });
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("forwards EL labels (e.g. triggers.tekton.dev/eventlistener) to PipelineRun watch", () => {
+    mocks.el.mockReturnValue({
+      data: {
+        metadata: {
+          name: "el",
+          namespace: "ns",
+          labels: {},
+          uid: "x",
+          creationTimestamp: "2025-01-01T00:00:00Z",
+        },
+        spec: { triggers: [] },
+      },
+      isReady: true,
+      query: { isSuccess: true, isError: false },
+    });
+    [
+      mocks.triggers,
+      mocks.bindings,
+      mocks.templates,
+      mocks.interceptors,
+      mocks.clusterInterceptors,
+      mocks.gitServers,
+      mocks.pipelineRuns,
+    ].forEach((m) => m.mockReturnValue(okList([])));
+    renderHook(() => useEventListenerTopology({ name: "el", namespace: "ns" }), { wrapper: wrap(qc) });
+    expect(mocks.pipelineRuns).toHaveBeenCalledWith({
+      namespace: "ns",
+      labels: { "triggers.tekton.dev/eventlistener": "el" },
+    });
+  });
+
+  it("invokes buildTopology and returns its result when everything is ready", () => {
+    mocks.el.mockReturnValue({
+      data: {
+        metadata: {
+          name: "el",
+          namespace: "ns",
+          labels: {},
+          uid: "x",
+          creationTimestamp: "2025-01-01T00:00:00Z",
+        },
+        spec: { triggers: [] },
+        status: { address: { url: "http://x" }, conditions: [{ type: "Ready", status: "True" }] },
+      },
+      isReady: true,
+      query: { isSuccess: true, isError: false },
+    });
+    [
+      mocks.triggers,
+      mocks.bindings,
+      mocks.templates,
+      mocks.interceptors,
+      mocks.clusterInterceptors,
+      mocks.gitServers,
+      mocks.pipelineRuns,
+    ].forEach((m) => m.mockReturnValue(okList([])));
+    const { result } = renderHook(() => useEventListenerTopology({ name: "el", namespace: "ns" }), {
+      wrapper: wrap(qc),
+    });
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.data?.address).toBe("http://x");
+    expect(result.current.data?.ready).toBe(true);
+  });
+
+  // Regression: a non-admin portal user often lacks RBAC for cluster-scoped
+  // resources (ClusterInterceptor) and may also lack list permission on
+  // namespaced Trigger CRDs. The strict AND-of-isReady previously deadlocked
+  // the page on such failures and rendered an infinite spinner.
+  it("becomes ready and produces a partial topology when secondary watches error (e.g. 403)", () => {
+    mocks.el.mockReturnValue({
+      data: {
+        metadata: {
+          name: "el",
+          namespace: "ns",
+          labels: {},
+          uid: "x",
+          creationTimestamp: "2025-01-01T00:00:00Z",
+        },
+        spec: {
+          // Inline trigger so its interceptors live on the EL spec directly,
+          // exercising the cluster-interceptor lookup against the errored
+          // ClusterInterceptor watch (empty fallback map).
+          triggers: [
+            {
+              name: "inline-tr",
+              interceptors: [{ ref: { name: "missing-cluster-i", kind: "ClusterInterceptor" } }],
+              bindings: [],
+              template: { ref: "" },
+            },
+          ],
+        },
+        status: { address: { url: "http://x" }, conditions: [{ type: "Ready", status: "True" }] },
+      },
+      isReady: true,
+      query: { isSuccess: true, isError: false },
+    });
+    // Trigger and ClusterInterceptor watches errored (403 / missing CRD).
+    mocks.triggers.mockReturnValue(erroredList());
+    mocks.clusterInterceptors.mockReturnValue(erroredList());
+    // The rest succeeded.
+    [mocks.bindings, mocks.templates, mocks.interceptors, mocks.gitServers, mocks.pipelineRuns].forEach((m) =>
+      m.mockReturnValue(okList([]))
+    );
+
+    const { result } = renderHook(() => useEventListenerTopology({ name: "el", namespace: "ns" }), {
+      wrapper: wrap(qc),
+    });
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data?.triggers).toHaveLength(1);
+    expect(result.current.data?.triggers[0]?.source).toEqual({ kind: "inline", name: "inline-tr" });
+    // The ClusterInterceptor watch errored — the ref is reported as
+    // "restricted" (not "missing"), so the UI can tell the user the
+    // resource may exist but isn't visible to them.
+    const interceptor = result.current.data?.triggers[0]?.interceptors[0];
+    expect(interceptor?.resolved).toBeNull();
+    expect(interceptor?.status).toBe("restricted");
+  });
+});

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/index.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/index.ts
@@ -1,0 +1,123 @@
+import React from "react";
+import { PipelineRun } from "@my-project/shared";
+import { useEventListenerWatchItem } from "@/k8s/api/groups/Tekton/EventListener";
+import { useTriggerWatchList } from "@/k8s/api/groups/Tekton/Trigger";
+import { useTriggerBindingWatchList } from "@/k8s/api/groups/Tekton/TriggerBinding";
+import { useTriggerTemplateWatchList } from "@/k8s/api/groups/Tekton/TriggerTemplate";
+import { useInterceptorWatchList } from "@/k8s/api/groups/Tekton/Interceptor";
+import { useClusterInterceptorWatchList } from "@/k8s/api/groups/Tekton/ClusterInterceptor";
+import { useGitServerWatchList } from "@/k8s/api/groups/KRCI/GitServer";
+import { usePipelineRunWatchList } from "@/k8s/api/groups/Tekton/PipelineRun";
+import { buildTopology } from "./build";
+import { EventListenerTopology } from "./types";
+
+export { classifyPipelineRef } from "./build";
+
+export type {
+  EventListenerTopology,
+  ResolvedTriggerNode,
+  ResolvedInterceptorRef,
+  ResolvedBindingRef,
+  ResolutionStatus,
+  PipelineRefShape,
+} from "./types";
+
+export interface UseEventListenerTopologyResult {
+  isReady: boolean;
+  data: EventListenerTopology | null;
+  // Raw EL-scoped PipelineRuns surfaced for metrics (e.g. 24h run count).
+  // The topology only retains the per-trigger latest run, so the full array
+  // is exposed here to avoid a duplicate watch in consumers.
+  recentRuns: PipelineRun[];
+  recentRunsReady: boolean;
+}
+
+// A watch is "settled" once it has a definitive answer — success OR error. Treating
+// permission denials / missing CRDs as settled (with empty data) keeps the page
+// usable for users whose RBAC is narrower than cluster-admin: missing cross-refs
+// resolve to null and render via the diagram's missing-ref fallback. Strict
+// AND-of-isReady would deadlock the spinner on the first 4xx.
+const isSettled = (w: { isReady: boolean; query: { isError: boolean } }): boolean => w.isReady || w.query.isError;
+
+export function useEventListenerTopology({
+  name,
+  namespace,
+}: {
+  name: string;
+  namespace: string;
+}): UseEventListenerTopologyResult {
+  const elWatch = useEventListenerWatchItem({ name, namespace });
+  const triggersWatch = useTriggerWatchList({ namespace });
+  const triggerBindingsWatch = useTriggerBindingWatchList({ namespace });
+  const triggerTemplatesWatch = useTriggerTemplateWatchList({ namespace });
+  const interceptorsWatch = useInterceptorWatchList({ namespace });
+  const clusterInterceptorsWatch = useClusterInterceptorWatchList();
+  const gitServersWatch = useGitServerWatchList({ namespace });
+  const recentRunsWatch = usePipelineRunWatchList({
+    namespace,
+    labels: { "triggers.tekton.dev/eventlistener": name },
+  });
+
+  const allSettled =
+    isSettled(elWatch) &&
+    isSettled(triggersWatch) &&
+    isSettled(triggerBindingsWatch) &&
+    isSettled(triggerTemplatesWatch) &&
+    isSettled(interceptorsWatch) &&
+    isSettled(clusterInterceptorsWatch) &&
+    isSettled(gitServersWatch) &&
+    isSettled(recentRunsWatch);
+
+  const isReady = allSettled && !!elWatch.data;
+
+  // Per-watch availability flags — `false` when the underlying list/get
+  // errored. The build step uses these to mark unresolved cross-refs as
+  // "restricted" instead of the misleading "missing", so a non-admin user
+  // isn't told that ClusterInterceptors they can't see don't exist.
+  const triggersAvailable = !triggersWatch.query.isError;
+  const triggerBindingsAvailable = !triggerBindingsWatch.query.isError;
+  const triggerTemplatesAvailable = !triggerTemplatesWatch.query.isError;
+  const interceptorsAvailable = !interceptorsWatch.query.isError;
+  const clusterInterceptorsAvailable = !clusterInterceptorsWatch.query.isError;
+  const gitServersAvailable = !gitServersWatch.query.isError;
+
+  const data = React.useMemo<EventListenerTopology | null>(() => {
+    if (!isReady || !elWatch.data) return null;
+    return buildTopology({
+      eventListener: elWatch.data,
+      triggersByName: triggersWatch.data.map,
+      triggerBindingsByName: triggerBindingsWatch.data.map,
+      triggerTemplatesByName: triggerTemplatesWatch.data.map,
+      interceptorsByName: interceptorsWatch.data.map,
+      clusterInterceptorsByName: clusterInterceptorsWatch.data.map,
+      gitServersByName: gitServersWatch.data.map,
+      recentRuns: recentRunsWatch.data.array,
+      availability: {
+        triggers: triggersAvailable,
+        triggerBindings: triggerBindingsAvailable,
+        triggerTemplates: triggerTemplatesAvailable,
+        interceptors: interceptorsAvailable,
+        clusterInterceptors: clusterInterceptorsAvailable,
+        gitServers: gitServersAvailable,
+      },
+    });
+  }, [
+    isReady,
+    elWatch.data,
+    triggersWatch.data.map,
+    triggerBindingsWatch.data.map,
+    triggerTemplatesWatch.data.map,
+    interceptorsWatch.data.map,
+    clusterInterceptorsWatch.data.map,
+    gitServersWatch.data.map,
+    recentRunsWatch.data.array,
+    triggersAvailable,
+    triggerBindingsAvailable,
+    triggerTemplatesAvailable,
+    interceptorsAvailable,
+    clusterInterceptorsAvailable,
+    gitServersAvailable,
+  ]);
+
+  return { isReady, data, recentRuns: recentRunsWatch.data.array, recentRunsReady: recentRunsWatch.isReady };
+}

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/types.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/types.ts
@@ -1,0 +1,93 @@
+import {
+  EventListener,
+  Trigger,
+  TriggerBinding,
+  TriggerTemplate,
+  Interceptor,
+  ClusterInterceptor,
+  GitServer,
+  PipelineRun,
+} from "@my-project/shared";
+
+/**
+ * Tri-state for cross-resource references in the topology:
+ *   - "resolved":   the lookup succeeded and the target was found
+ *   - "missing":    the lookup succeeded but the target does not exist (broken ref)
+ *   - "restricted": the underlying watch errored (RBAC denial, missing CRD,
+ *                   network) — we can't tell whether the target exists
+ *
+ * UI surfaces "restricted" with a different label/tooltip from "missing" so
+ * non-admin users aren't told a perfectly valid resource is broken.
+ */
+export type ResolutionStatus = "resolved" | "missing" | "restricted";
+
+export type ResolvedInterceptorRef = {
+  ref: { name: string; kind: "NamespacedInterceptor" | "ClusterInterceptor" };
+  resolved: Interceptor | ClusterInterceptor | null;
+  status: ResolutionStatus;
+  params: Array<{ name: string; value: unknown }>;
+};
+
+export type ResolvedBindingRef = {
+  ref: string;
+  kind: "TriggerBinding" | "ClusterTriggerBinding";
+  resolved: TriggerBinding | null;
+  status: ResolutionStatus;
+};
+
+export type PipelineRefShape =
+  | { kind: "literal"; pipelineName: string }
+  | { kind: "templated"; raw: string; sourceParam: string | null }
+  | { kind: "unknown" };
+
+export type ResolvedTriggerNode = {
+  source:
+    | { kind: "triggerRef"; ref: string; resolved: Trigger | null; status: ResolutionStatus }
+    | { kind: "inline"; name: string };
+  interceptors: ResolvedInterceptorRef[];
+  bindings: ResolvedBindingRef[];
+  template: {
+    ref: string;
+    resolved: TriggerTemplate | null;
+    status: ResolutionStatus;
+    pipelineRef: PipelineRefShape;
+  };
+  latestPipelineRun: PipelineRun | null;
+};
+
+export type EventListenerTopology = {
+  eventListener: EventListener;
+  address: string | null;
+  ready: boolean;
+  gitServer: GitServer | null;
+  triggers: ResolvedTriggerNode[];
+};
+
+/**
+ * Per-watch availability — `false` means the underlying list/get errored, so
+ * an empty `*ByName` Map signals "couldn't load" rather than "the cluster
+ * really has no such resources".
+ *
+ * Optional with a default of `true` per source so existing call sites and
+ * tests that don't care about restricted state stay correct.
+ */
+export interface TopologyAvailability {
+  triggers?: boolean;
+  triggerBindings?: boolean;
+  triggerTemplates?: boolean;
+  interceptors?: boolean;
+  clusterInterceptors?: boolean;
+  gitServers?: boolean;
+}
+
+export interface BuildTopologyArgs {
+  eventListener: EventListener;
+  triggersByName: Map<string, Trigger>;
+  triggerBindingsByName: Map<string, TriggerBinding>;
+  triggerTemplatesByName: Map<string, TriggerTemplate>;
+  interceptorsByName: Map<string, Interceptor>;
+  clusterInterceptorsByName: Map<string, ClusterInterceptor>;
+  gitServersByName: Map<string, GitServer>;
+  recentRuns: PipelineRun[];
+  availability?: TopologyAvailability;
+}

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/components/Overview/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/components/Overview/index.tsx
@@ -1,0 +1,7 @@
+import { InterceptorOverview } from "@/modules/platform/tekton/components/InterceptorOverview";
+import { useClusterInterceptorWatch } from "../../hooks/data";
+
+export const Overview = () => {
+  const watch = useClusterInterceptorWatch();
+  return <InterceptorOverview resource={watch.query.data} isLoading={watch.isLoading} />;
+};

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/components/UsedBy/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/components/UsedBy/index.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "@/core/components/ui/card";
+import { Button } from "@/core/components/ui/button";
+import { Badge } from "@/core/components/ui/badge";
+import { useClusterStore } from "@/k8s/store";
+import { useTriggerWatchListMultiple } from "@/k8s/api/groups/Tekton/Trigger";
+import { useEventListenerWatchListMultiple } from "@/k8s/api/groups/Tekton/EventListener";
+import { useClusterInterceptorWatch } from "../../hooks/data";
+import { routeTriggerDetails } from "@/modules/platform/tekton/pages/trigger-details/route";
+import { routeEventListenerDetails } from "@/modules/platform/tekton/pages/event-listener-details/route";
+
+export const UsedBy = () => {
+  const watch = useClusterInterceptorWatch();
+  const ci = watch.query.data;
+  const triggers = useTriggerWatchListMultiple().data.array;
+  const els = useEventListenerWatchListMultiple().data.array;
+  const { clusterName, namespace: defaultNamespace } = useClusterStore(
+    useShallow((s) => ({ clusterName: s.clusterName, namespace: s.defaultNamespace }))
+  );
+
+  const matches = (ref: { name?: string; kind?: string } | undefined, name: string) =>
+    ref?.name === name && ref?.kind === "ClusterInterceptor";
+
+  const referencingTriggers = React.useMemo(() => {
+    if (!ci) return [];
+    return triggers.filter((t) => (t.spec?.interceptors ?? []).some((i) => matches(i.ref, ci.metadata.name)));
+  }, [triggers, ci]);
+
+  const referencingEls = React.useMemo(() => {
+    if (!ci) return [];
+    return els.filter((el) =>
+      (el.spec?.triggers ?? []).some((entry) =>
+        (entry.interceptors ?? []).some((i) => matches(i.ref, ci.metadata.name))
+      )
+    );
+  }, [els, ci]);
+
+  return (
+    <Card className="p-6">
+      <h3 className="text-foreground mb-3 text-lg font-semibold">Used by</h3>
+      {referencingTriggers.length === 0 && referencingEls.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          No Triggers or EventListeners reference this ClusterInterceptor.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {referencingTriggers.length > 0 && (
+            <div>
+              <h4 className="text-muted-foreground mb-2 text-xs uppercase">Triggers</h4>
+              <ul className="flex flex-col gap-2">
+                {referencingTriggers.map((t) => (
+                  <li key={t.metadata.uid} className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">{t.metadata.namespace}</Badge>
+                    <Button variant="link" asChild className="h-auto p-0">
+                      <Link
+                        to={routeTriggerDetails.fullPath}
+                        params={{
+                          clusterName,
+                          namespace: t.metadata.namespace || defaultNamespace,
+                          name: t.metadata.name,
+                        }}
+                      >
+                        {t.metadata.name}
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {referencingEls.length > 0 && (
+            <div>
+              <h4 className="text-muted-foreground mb-2 text-xs uppercase">EventListeners (inline)</h4>
+              <ul className="flex flex-col gap-2">
+                {referencingEls.map((el) => (
+                  <li key={el.metadata.uid} className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">{el.metadata.namespace}</Badge>
+                    <Button variant="link" asChild className="h-auto p-0">
+                      <Link
+                        to={routeEventListenerDetails.fullPath}
+                        params={{
+                          clusterName,
+                          namespace: el.metadata.namespace || defaultNamespace,
+                          name: el.metadata.name,
+                        }}
+                      >
+                        {el.metadata.name}
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/components/ViewYaml/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/components/ViewYaml/index.tsx
@@ -1,0 +1,9 @@
+import CodeEditor from "@/core/components/CodeEditor";
+import { useClusterInterceptorWatch } from "../../hooks/data";
+
+export const ViewYaml = () => {
+  const watch = useClusterInterceptorWatch();
+  const ci = watch.query.data;
+  if (!ci) return null;
+  return <CodeEditor language="yaml" content={ci} />;
+};

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/constants.ts
@@ -1,0 +1,6 @@
+import { RouteSearchTab, routeSearchTabName } from "./route";
+
+export const tabNameToIndexMap: Record<RouteSearchTab, number> = {
+  [routeSearchTabName.overview]: 0,
+  [routeSearchTabName.yaml]: 1,
+};

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/hooks/data.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/hooks/data.ts
@@ -1,0 +1,7 @@
+import { useClusterInterceptorWatchItem } from "@/k8s/api/groups/Tekton/ClusterInterceptor";
+import { routeClusterInterceptorDetails } from "../route";
+
+export const useClusterInterceptorWatch = () => {
+  const params = routeClusterInterceptorDetails.useParams();
+  return useClusterInterceptorWatchItem({ name: params.name });
+};

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/hooks/useTabs.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/hooks/useTabs.tsx
@@ -1,0 +1,15 @@
+import { useDetailTabs } from "@/modules/platform/tekton/hooks/useDetailTabs";
+import { Tab } from "@/core/providers/Tabs/components/Tabs/types";
+import { Overview } from "../components/Overview";
+import { UsedBy } from "../components/UsedBy";
+import { ViewYaml } from "../components/ViewYaml";
+import { routeClusterInterceptorDetails, PATH_CLUSTER_INTERCEPTOR_DETAILS_FULL } from "../route";
+
+export const useTabs = (): Tab[] =>
+  useDetailTabs({
+    route: routeClusterInterceptorDetails,
+    path: PATH_CLUSTER_INTERCEPTOR_DETAILS_FULL,
+    Overview,
+    UsedBy,
+    ViewYaml,
+  });

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/page.tsx
@@ -1,0 +1,14 @@
+import { TabsContextProvider } from "@/core/providers/Tabs/provider";
+import { tabNameToIndexMap } from "./constants";
+import { routeClusterInterceptorDetails } from "./route";
+import ClusterInterceptorDetailsView from "./view";
+
+export default function ClusterInterceptorDetailsPage() {
+  const search = routeClusterInterceptorDetails.useSearch();
+  const initialTabIdx = search.tab ? tabNameToIndexMap[search.tab] : 0;
+  return (
+    <TabsContextProvider id="cluster-interceptor-details-page" initialTabIdx={initialTabIdx}>
+      <ClusterInterceptorDetailsView searchTabIdx={initialTabIdx} />
+    </TabsContextProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/route.lazy.ts
@@ -1,0 +1,8 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_CLUSTER_INTERCEPTOR_DETAILS } from "./route";
+import ClusterInterceptorDetailsPage from "./page";
+
+const ClusterInterceptorDetailsRoute = createLazyRoute(ROUTE_ID_CLUSTER_INTERCEPTOR_DETAILS)({
+  component: ClusterInterceptorDetailsPage,
+});
+export default ClusterInterceptorDetailsRoute;

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/route.ts
@@ -1,0 +1,27 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+export const PATH_CLUSTER_INTERCEPTOR_DETAILS = "webhook-triggers/cluster-interceptors/$name" as const;
+export const PATH_CLUSTER_INTERCEPTOR_DETAILS_FULL =
+  "/c/$clusterName/cicd/webhook-triggers/cluster-interceptors/$name" as const;
+export const ROUTE_ID_CLUSTER_INTERCEPTOR_DETAILS =
+  "/_layout/c/$clusterName/cicd/webhook-triggers/cluster-interceptors/$name" as const;
+
+export const routeSearchTabSchema = z.enum(["overview", "yaml"]);
+export const routeSearchTabName = routeSearchTabSchema.enum;
+export type RouteSearchTab = z.infer<typeof routeSearchTabSchema>;
+
+export interface Search {
+  tab?: RouteSearchTab;
+}
+
+export const routeClusterInterceptorDetails = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_CLUSTER_INTERCEPTOR_DETAILS,
+  validateSearch: (search: Record<string, unknown>): Search => {
+    const parsed = z.object({ tab: routeSearchTabSchema.optional() }).parse(search);
+    return { tab: parsed.tab ?? "overview" };
+  },
+  head: ({ params }) => ({ meta: [{ title: `${params.name} — Cluster Interceptors | KRCI` }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-details/view.tsx
@@ -1,0 +1,41 @@
+import { Globe } from "lucide-react";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { useTabsContext } from "@/core/providers/Tabs/hooks";
+import { PATH_CLUSTER_INTERCEPTORS_FULL } from "../cluster-interceptor-list/route";
+import { useClusterInterceptorWatch } from "./hooks/data";
+import { useTabs } from "./hooks/useTabs";
+import { routeClusterInterceptorDetails } from "./route";
+
+export default function ClusterInterceptorDetailsView({ searchTabIdx }: { searchTabIdx: number }) {
+  const params = routeClusterInterceptorDetails.useParams();
+  const watch = useClusterInterceptorWatch();
+  const tabs = useTabs();
+  const { handleChangeTab } = useTabsContext();
+  const showTabs = !watch.query.error && !watch.query.isLoading;
+
+  return (
+    <PageWrapper
+      breadcrumbs={[
+        { label: "Webhook Triggers" },
+        { label: "Cluster Interceptors", route: { to: PATH_CLUSTER_INTERCEPTORS_FULL } },
+        { label: params.name },
+      ]}
+    >
+      <PageContentWrapper
+        icon={Globe}
+        title={params.name}
+        enableCopyTitle
+        description="Cluster-scoped interceptor implementation."
+        tabs={showTabs ? tabs : undefined}
+        activeTab={searchTabIdx}
+        onTabChange={handleChangeTab}
+      >
+        {watch.query.error && <ErrorContent error={watch.query.error} />}
+        {watch.query.isLoading && <LoadingWrapper isLoading>{null}</LoadingWrapper>}
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/constants.test.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/constants.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { clusterInterceptorSchema } from "@my-project/shared";
+import { matchFunctions, CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES } from "./constants";
+
+const searchMatch = matchFunctions[CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES.SEARCH]!;
+
+const make = (name: string) =>
+  clusterInterceptorSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1alpha1",
+    kind: "ClusterInterceptor",
+    metadata: { name, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z" },
+  });
+
+describe("ClusterInterceptor matchFunctions.search", () => {
+  test("empty search passes everything", () => {
+    expect(searchMatch(make("github"), "")).toBe(true);
+  });
+  test("name substring match", () => {
+    expect(searchMatch(make("github-build"), "build")).toBe(true);
+  });
+  test("non-matching name dropped", () => {
+    expect(searchMatch(make("github-build"), "gitlab")).toBe(false);
+  });
+});
+
+// Cluster-scoped invariant: ClusterInterceptor lives outside any namespace, so
+// the filter MUST NOT expose a namespace match (regression-guard against
+// copy-paste from the namespaced sibling filters).
+describe("ClusterInterceptor matchFunctions — cluster-scoped invariant", () => {
+  test("matchFunctions does not expose a namespace key", () => {
+    expect(matchFunctions).not.toHaveProperty("namespace");
+    expect(matchFunctions).not.toHaveProperty("namespaces");
+  });
+  test("CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES does not declare a namespace filter", () => {
+    expect(Object.values(CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES)).not.toContain("namespace");
+    expect(Object.values(CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES)).not.toContain("namespaces");
+  });
+});

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/constants.ts
@@ -1,0 +1,13 @@
+import { MatchFunctions, createSearchMatchFunction } from "@/core/providers/Filter";
+import { ClusterInterceptor } from "@my-project/shared";
+import { ClusterInterceptorListFilterValues } from "./types";
+
+export const CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES = { SEARCH: "search" } as const;
+
+export const clusterInterceptorFilterDefaultValues: ClusterInterceptorListFilterValues = {
+  [CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES.SEARCH]: "",
+};
+
+export const matchFunctions: MatchFunctions<ClusterInterceptor, ClusterInterceptorListFilterValues> = {
+  [CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES.SEARCH]: createSearchMatchFunction<ClusterInterceptor>(),
+};

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/hooks/useFilter.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/hooks/useFilter.tsx
@@ -1,0 +1,7 @@
+import { useFilterContext } from "@/core/providers/Filter";
+import { ClusterInterceptor } from "@my-project/shared";
+import { ClusterInterceptorListFilterValues } from "../types";
+
+export function useClusterInterceptorFilter() {
+  return useFilterContext<ClusterInterceptor, ClusterInterceptorListFilterValues>();
+}

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/index.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/core/components/ui/button";
+import { Label } from "@/core/components/ui/label";
+import { X } from "lucide-react";
+import { CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES } from "./constants";
+import { useClusterInterceptorFilter } from "./hooks/useFilter";
+
+export function ClusterInterceptorFilter() {
+  const { form, reset, isDefaultValue } = useClusterInterceptorFilter();
+  return (
+    <>
+      <div className="col-span-3">
+        <form.AppField name={CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES.SEARCH}>
+          {(field) => <field.FormTextField label="Search" placeholder="Search cluster interceptors" />}
+        </form.AppField>
+      </div>
+      {!isDefaultValue && (
+        <div className="col-span-1 flex flex-col gap-2">
+          <Label> </Label>
+          <Button variant="secondary" onClick={reset} size="sm" className="mt-0.5">
+            <X size={16} />
+            Clear
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/types.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorFilter/types.ts
@@ -1,0 +1,5 @@
+import { CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES } from "./constants";
+
+export type ClusterInterceptorListFilterValues = {
+  [CLUSTER_INTERCEPTOR_LIST_FILTER_NAMES.SEARCH]: string;
+};

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorList/hooks/useColumns.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Globe } from "lucide-react";
+import { ClusterInterceptor, EventListener, Trigger } from "@my-project/shared";
+import { TableColumn } from "@/core/components/Table/types";
+import { Button } from "@/core/components/ui/button";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { useTableSettings } from "@/core/components/Table/components/TableSettings/hooks/useTableSettings";
+import { getSyncedColumnData } from "@/core/components/Table/components/TableSettings/utils";
+import { TABLE } from "@/k8s/constants/tables";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { useClusterStore } from "@/k8s/store";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { useTriggerWatchList } from "@/k8s/api/groups/Tekton/Trigger";
+import { routeClusterInterceptorDetails } from "@/modules/platform/tekton/pages/cluster-interceptor-details/route";
+
+const formatAddress = (ci: ClusterInterceptor): string => {
+  const cc = ci.spec?.clientConfig;
+  if (cc?.url) return cc.url;
+  if (cc?.service?.name) {
+    const port = cc.service.port ? `:${cc.service.port}` : "";
+    return `${cc.service.namespace ?? ""}/${cc.service.name}${port}`;
+  }
+  return "—";
+};
+
+type InterceptorRefHolder = { ref?: { name?: string; kind?: string } };
+
+const usedByCount = (ci: ClusterInterceptor, els: EventListener[], triggers: Trigger[]): number => {
+  const matches = (ref: { name?: string; kind?: string } | undefined) =>
+    ref?.name === ci.metadata.name && ref?.kind === "ClusterInterceptor";
+  let count = 0;
+  for (const el of els) {
+    const elTriggers = el.spec?.triggers ?? [];
+    count += elTriggers.filter(
+      (entry) => entry.interceptors?.some((i: InterceptorRefHolder) => matches(i.ref)) ?? false
+    ).length;
+  }
+  for (const t of triggers) {
+    if (t.spec?.interceptors?.some((i: InterceptorRefHolder) => matches(i.ref))) count += 1;
+  }
+  return count;
+};
+
+export function useColumns(): TableColumn<ClusterInterceptor>[] {
+  const { loadSettings } = useTableSettings(TABLE.CLUSTER_INTERCEPTOR_LIST.id);
+  const tableSettings = loadSettings();
+  const { clusterName } = useClusterStore(useShallow((s) => ({ clusterName: s.clusterName })));
+  const els = useEventListenerWatchList().data.array;
+  const triggers = useTriggerWatchList().data.array;
+
+  return React.useMemo(
+    () => [
+      {
+        id: "name",
+        label: "Name",
+        data: {
+          columnSortableValuePath: "metadata.name",
+          render: ({ data }) => {
+            const { name } = data.metadata;
+            return (
+              <Button variant="link" asChild className="p-0">
+                <Link to={routeClusterInterceptorDetails.fullPath} params={{ clusterName, name }}>
+                  <Globe className="text-muted-foreground/70 size-4" />
+                  <TextWithTooltip text={name} />
+                </Link>
+              </Button>
+            );
+          },
+        },
+        cell: { isFixed: true, baseWidth: 30, ...getSyncedColumnData(tableSettings, "name") },
+      },
+      {
+        id: "address",
+        label: "Address",
+        data: { render: ({ data }) => <TextWithTooltip text={formatAddress(data)} /> },
+        cell: { baseWidth: 40, ...getSyncedColumnData(tableSettings, "address") },
+      },
+      {
+        id: "usedBy",
+        label: "Used by",
+        data: { render: ({ data }) => <span>{usedByCount(data, els, triggers)}</span> },
+        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "usedBy") },
+      },
+      {
+        id: "createdAt",
+        label: "Age",
+        data: {
+          render: ({ data }) => formatTimestamp(data.metadata.creationTimestamp),
+        },
+        cell: { isFixed: true, baseWidth: 15, ...getSyncedColumnData(tableSettings, "createdAt") },
+      },
+    ],
+    [tableSettings, clusterName, els, triggers]
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorList/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/components/ClusterInterceptorList/index.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { DataTable } from "@/core/components/Table";
+import { EmptyList } from "@/core/components/EmptyList";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { TABLE } from "@/k8s/constants/tables";
+import {
+  useClusterInterceptorWatchList,
+  useClusterInterceptorPermissions,
+} from "@/k8s/api/groups/Tekton/ClusterInterceptor";
+import { getForbiddenError } from "@/k8s/api/utils/get-forbidden-error";
+import { useColumns } from "./hooks/useColumns";
+import { ClusterInterceptorFilter } from "../ClusterInterceptorFilter";
+import { useClusterInterceptorFilter } from "../ClusterInterceptorFilter/hooks/useFilter";
+
+export const ClusterInterceptorList = () => {
+  const columns = useColumns();
+  // permissions.isFetched is used as a loading-state synchronizer to align
+  // with the rest of the resource lists (e.g. PipelineList). The data is not
+  // consumed yet — reserved for future row actions / create button gating.
+  const permissions = useClusterInterceptorPermissions();
+  const watch = useClusterInterceptorWatchList();
+  const { filterFunction } = useClusterInterceptorFilter();
+
+  const renderEmptyList = React.useMemo(() => {
+    if (!permissions.isFetched || !watch.query.isFetched) return null;
+    const forbiddenError = watch.query.error && getForbiddenError(watch.query.error);
+    if (forbiddenError) return <ErrorContent error={forbiddenError} outlined />;
+    return <EmptyList missingItemName="Cluster Interceptors" description="No Tekton ClusterInterceptors found." />;
+  }, [permissions.isFetched, watch.query.isFetched, watch.query.error]);
+
+  const tableSlots = React.useMemo(() => ({ header: { component: <ClusterInterceptorFilter /> } }), []);
+
+  return (
+    <DataTable
+      id={TABLE.CLUSTER_INTERCEPTOR_LIST.id}
+      name={TABLE.CLUSTER_INTERCEPTOR_LIST.name}
+      isLoading={!watch.query.isFetched || !permissions.isFetched}
+      data={watch.data.array}
+      errors={[]}
+      columns={columns}
+      emptyListComponent={renderEmptyList}
+      filterFunction={filterFunction}
+      slots={tableSlots}
+    />
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/page.tsx
@@ -1,0 +1,17 @@
+import { FilterProvider } from "@/core/providers/Filter";
+import { ClusterInterceptor } from "@my-project/shared";
+import { ClusterInterceptorListFilterValues } from "./components/ClusterInterceptorFilter/types";
+import { clusterInterceptorFilterDefaultValues, matchFunctions } from "./components/ClusterInterceptorFilter/constants";
+import PageView from "./view";
+
+export default function ClusterInterceptorListPage() {
+  return (
+    <FilterProvider<ClusterInterceptor, ClusterInterceptorListFilterValues>
+      defaultValues={clusterInterceptorFilterDefaultValues}
+      matchFunctions={matchFunctions}
+      syncWithUrl
+    >
+      <PageView />
+    </FilterProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_CLUSTER_INTERCEPTORS } from "./route";
+import ClusterInterceptorListPage from "./page";
+
+const ClusterInterceptorListRoute = createLazyRoute(ROUTE_ID_CLUSTER_INTERCEPTORS)({
+  component: ClusterInterceptorListPage,
+});
+
+export default ClusterInterceptorListRoute;

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/route.ts
@@ -1,0 +1,16 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+
+export const PATH_CLUSTER_INTERCEPTORS = "webhook-triggers/cluster-interceptors" as const;
+export const PATH_CLUSTER_INTERCEPTORS_FULL = "/c/$clusterName/cicd/webhook-triggers/cluster-interceptors" as const;
+export const ROUTE_ID_CLUSTER_INTERCEPTORS =
+  "/_layout/c/$clusterName/cicd/webhook-triggers/cluster-interceptors" as const;
+
+export type Search = Record<string, unknown>;
+
+export const routeClusterInterceptorList = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_CLUSTER_INTERCEPTORS,
+  validateSearch: (search: Record<string, unknown>): Search => search,
+  head: () => ({ meta: [{ title: "Cluster Interceptors | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/cluster-interceptor-list/view.tsx
@@ -1,0 +1,20 @@
+import { Globe } from "lucide-react";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { ClusterInterceptorList } from "./components/ClusterInterceptorList";
+
+export default function ClusterInterceptorListView() {
+  return (
+    <PageWrapper breadcrumbs={[{ label: "Webhook Triggers" }, { label: "Cluster Interceptors" }]}>
+      <PageContentWrapper
+        icon={Globe}
+        title="Cluster Interceptors"
+        description="Cluster-scoped interceptor implementations (e.g. CEL, GitHub, GitLab) shipped by Tekton Triggers."
+      >
+        <div className="flex flex-grow flex-col gap-6">
+          <ClusterInterceptorList />
+        </div>
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-details/hooks/data.ts
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-details/hooks/data.ts
@@ -1,0 +1,8 @@
+import { useEventListenerTopology } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { routeEventListenerDetails } from "../route";
+
+export const useEventListenerDetailsData = () => {
+  const { name, namespace } = routeEventListenerDetails.useParams();
+  const topology = useEventListenerTopology({ name, namespace });
+  return { topology, params: { name, namespace } };
+};

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-details/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-details/page.tsx
@@ -1,0 +1,5 @@
+import EventListenerDetailsView from "./view";
+
+export default function EventListenerDetailsPage() {
+  return <EventListenerDetailsView />;
+}

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-details/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-details/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_EVENT_LISTENER_DETAILS } from "./route";
+import EventListenerDetailsPage from "./page";
+
+const EventListenerDetailsRoute = createLazyRoute(ROUTE_ID_EVENT_LISTENER_DETAILS)({
+  component: EventListenerDetailsPage,
+});
+
+export default EventListenerDetailsRoute;

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-details/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-details/route.ts
@@ -1,0 +1,17 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+
+export const PATH_EVENT_LISTENER_DETAILS = "webhook-triggers/event-listeners/$namespace/$name" as const;
+export const PATH_EVENT_LISTENER_DETAILS_FULL =
+  "/c/$clusterName/cicd/webhook-triggers/event-listeners/$namespace/$name" as const;
+export const ROUTE_ID_EVENT_LISTENER_DETAILS =
+  "/_layout/c/$clusterName/cicd/webhook-triggers/event-listeners/$namespace/$name" as const;
+
+export type Search = Record<string, unknown>;
+
+export const routeEventListenerDetails = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_EVENT_LISTENER_DETAILS,
+  validateSearch: (search: Record<string, unknown>): Search => search,
+  head: ({ params }) => ({ meta: [{ title: `${params.name} [${params.namespace}] — Event Listeners | KRCI` }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-details/view.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { Webhook } from "lucide-react";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { Badge } from "@/core/components/ui/badge";
+import { MetricCard } from "@/core/components/MetricCard";
+import { EventFlowDiagram } from "@/modules/platform/tekton/components/EventFlowDiagram";
+import { PATH_EVENT_LISTENERS_FULL } from "../event-listener-list/route";
+import { useEventListenerDetailsData } from "./hooks/data";
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+export default function EventListenerDetailsView() {
+  const { topology, params } = useEventListenerDetailsData();
+
+  const triggersConfigured = topology.data ? topology.data.triggers.length : 0;
+  const runs24h = React.useMemo(() => {
+    const cutoff = Date.now() - TWENTY_FOUR_HOURS_MS;
+
+    return topology.recentRuns.filter((pr) => {
+      const ts = new Date(pr.metadata?.creationTimestamp ?? 0).getTime();
+      return ts >= cutoff;
+    }).length;
+  }, [topology.recentRuns]);
+
+  const subHeader = (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        {topology.data?.ready ? <Badge variant="success">Ready</Badge> : <Badge variant="destructive">Degraded</Badge>}
+        {topology.data?.address && (
+          <span className="text-muted-foreground">
+            Address: <code className="font-mono text-xs">{topology.data.address}</code>
+          </span>
+        )}
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <MetricCard title="Triggers configured" hasData={topology.isReady} isLoading={!topology.isReady}>
+          <div className="text-3xl font-semibold">{triggersConfigured}</div>
+        </MetricCard>
+        <MetricCard
+          title="Triggered runs · 24h"
+          hasData={topology.recentRunsReady}
+          isLoading={!topology.recentRunsReady}
+        >
+          <div className="text-3xl font-semibold">{runs24h}</div>
+        </MetricCard>
+      </div>
+    </div>
+  );
+
+  return (
+    <PageWrapper
+      breadcrumbs={[
+        { label: "Webhook Triggers" },
+        { label: "Event Listeners", route: { to: PATH_EVENT_LISTENERS_FULL } },
+        { label: params.name },
+      ]}
+    >
+      <PageContentWrapper icon={Webhook} title={params.name} enableCopyTitle subHeader={subHeader}>
+        <div className="flex flex-grow flex-col">
+          <LoadingWrapper isLoading={!topology.isReady}>
+            <EventFlowDiagram topology={topology.data} />
+          </LoadingWrapper>
+        </div>
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/constants.test.ts
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/constants.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { eventListenerSchema } from "@my-project/shared";
+import { matchFunctions, EVENT_LISTENER_LIST_FILTER_NAMES } from "./constants";
+
+const searchMatch = matchFunctions[EVENT_LISTENER_LIST_FILTER_NAMES.SEARCH]!;
+const namespaceMatch = matchFunctions[EVENT_LISTENER_LIST_FILTER_NAMES.NAMESPACES]!;
+
+const make = (name: string, namespace = "ns") =>
+  eventListenerSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "EventListener",
+    metadata: { name, namespace, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+    spec: { triggers: [] },
+  });
+
+describe("matchFunctions.search", () => {
+  test("empty search passes everything", () => {
+    expect(searchMatch(make("github-build"), "")).toBe(true);
+  });
+  test("name substring match is case-insensitive", () => {
+    expect(searchMatch(make("Github-Build"), "github")).toBe(true);
+  });
+  test("non-matching name is filtered out", () => {
+    expect(searchMatch(make("github-build"), "gitlab")).toBe(false);
+  });
+});
+
+describe("matchFunctions.namespaces", () => {
+  test("empty selection passes everything", () => {
+    expect(namespaceMatch(make("x", "ns1"), [])).toBe(true);
+  });
+  test("matching namespace is kept", () => {
+    expect(namespaceMatch(make("x", "ns1"), ["ns1"])).toBe(true);
+  });
+  test("non-matching namespace is dropped", () => {
+    expect(namespaceMatch(make("x", "ns1"), ["ns2"])).toBe(false);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/constants.ts
@@ -1,0 +1,18 @@
+import { MatchFunctions, createSearchMatchFunction, createNamespaceMatchFunction } from "@/core/providers/Filter";
+import { EventListener } from "@my-project/shared";
+import { EventListenerListFilterValues } from "./types";
+
+export const EVENT_LISTENER_LIST_FILTER_NAMES = {
+  SEARCH: "search",
+  NAMESPACES: "namespaces",
+} as const;
+
+export const eventListenerFilterDefaultValues: EventListenerListFilterValues = {
+  [EVENT_LISTENER_LIST_FILTER_NAMES.SEARCH]: "",
+  [EVENT_LISTENER_LIST_FILTER_NAMES.NAMESPACES]: [],
+};
+
+export const matchFunctions: MatchFunctions<EventListener, EventListenerListFilterValues> = {
+  [EVENT_LISTENER_LIST_FILTER_NAMES.SEARCH]: createSearchMatchFunction<EventListener>(),
+  [EVENT_LISTENER_LIST_FILTER_NAMES.NAMESPACES]: createNamespaceMatchFunction<EventListener>(),
+};

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/hooks/useFilter.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/hooks/useFilter.tsx
@@ -1,0 +1,7 @@
+import { useFilterContext } from "@/core/providers/Filter";
+import { EventListener } from "@my-project/shared";
+import { EventListenerListFilterValues } from "../types";
+
+export function useEventListenerFilter() {
+  return useFilterContext<EventListener, EventListenerListFilterValues>();
+}

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/index.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Button } from "@/core/components/ui/button";
+import { Label } from "@/core/components/ui/label";
+import { useClusterStore } from "@/k8s/store";
+import { useShallow } from "zustand/react/shallow";
+import { X } from "lucide-react";
+import { EVENT_LISTENER_LIST_FILTER_NAMES } from "./constants";
+import { useEventListenerFilter } from "./hooks/useFilter";
+
+export function EventListenerFilter() {
+  const { form, reset, isDefaultValue } = useEventListenerFilter();
+  const allowedNamespaces = useClusterStore(useShallow((state) => state.allowedNamespaces));
+  const showNamespaceFilter = allowedNamespaces.length > 1;
+  const namespaceOptions = React.useMemo(
+    () => allowedNamespaces.map((value) => ({ label: value, value })),
+    [allowedNamespaces]
+  );
+
+  return (
+    <>
+      <div className="col-span-3">
+        <form.AppField name={EVENT_LISTENER_LIST_FILTER_NAMES.SEARCH}>
+          {(field) => <field.FormTextField label="Search" placeholder="Search event listeners" />}
+        </form.AppField>
+      </div>
+
+      {showNamespaceFilter && (
+        <div className="col-span-4">
+          <form.AppField name={EVENT_LISTENER_LIST_FILTER_NAMES.NAMESPACES}>
+            {(field) => (
+              <field.FormCombobox
+                options={namespaceOptions}
+                label="Namespaces"
+                placeholder="Select namespaces"
+                multiple
+              />
+            )}
+          </form.AppField>
+        </div>
+      )}
+
+      {!isDefaultValue && (
+        <div className="col-span-1 flex flex-col gap-2">
+          <Label> </Label>
+          <Button variant="secondary" onClick={reset} size="sm" className="mt-0.5">
+            <X size={16} />
+            Clear
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/types.ts
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerFilter/types.ts
@@ -1,0 +1,6 @@
+import { EVENT_LISTENER_LIST_FILTER_NAMES } from "./constants";
+
+export type EventListenerListFilterValues = {
+  [EVENT_LISTENER_LIST_FILTER_NAMES.SEARCH]: string;
+  [EVENT_LISTENER_LIST_FILTER_NAMES.NAMESPACES]: string[];
+};

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerList/hooks/useColumns.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Webhook } from "lucide-react";
+import { EventListener } from "@my-project/shared";
+import { TableColumn } from "@/core/components/Table/types";
+import { Button } from "@/core/components/ui/button";
+import { Badge } from "@/core/components/ui/badge";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { useTableSettings } from "@/core/components/Table/components/TableSettings/hooks/useTableSettings";
+import { getSyncedColumnData } from "@/core/components/Table/components/TableSettings/utils";
+import { TABLE } from "@/k8s/constants/tables";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { useClusterStore } from "@/k8s/store";
+import { routeEventListenerDetails } from "@/modules/platform/tekton/pages/event-listener-details/route";
+
+const isReady = (el: EventListener): boolean =>
+  el.status?.conditions?.find((c) => c.type === "Ready")?.status === "True";
+
+const triggerCount = (el: EventListener): number => el.spec?.triggers?.length ?? 0;
+
+const address = (el: EventListener): string => el.status?.address?.url ?? "";
+
+export function useColumns(): TableColumn<EventListener>[] {
+  const { loadSettings } = useTableSettings(TABLE.EVENT_LISTENER_LIST.id);
+  const tableSettings = loadSettings();
+  const { namespace: defaultNamespace, clusterName } = useClusterStore(
+    useShallow((state) => ({ namespace: state.defaultNamespace, clusterName: state.clusterName }))
+  );
+
+  return React.useMemo(
+    () => [
+      {
+        id: "name",
+        label: "Name",
+        data: {
+          columnSortableValuePath: "metadata.name",
+          render: ({ data }) => {
+            const { name, namespace } = data.metadata;
+            return (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={routeEventListenerDetails.fullPath}
+                  params={{ clusterName, namespace: namespace || defaultNamespace, name }}
+                >
+                  <Webhook className="text-muted-foreground/70 size-4" />
+                  <TextWithTooltip text={name} />
+                </Link>
+              </Button>
+            );
+          },
+        },
+        cell: { isFixed: true, baseWidth: 30, ...getSyncedColumnData(tableSettings, "name") },
+      },
+      {
+        id: "namespace",
+        label: "Namespace",
+        data: { render: ({ data }) => <span>{data.metadata.namespace}</span> },
+        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "namespace") },
+      },
+      {
+        id: "status",
+        label: "Status",
+        data: {
+          render: ({ data }) =>
+            isReady(data) ? (
+              <Badge className="bg-primary/10 text-primary">Ready</Badge>
+            ) : (
+              <Badge className="bg-destructive/10 text-destructive">Degraded</Badge>
+            ),
+        },
+        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "status") },
+      },
+      {
+        id: "triggers",
+        label: "Triggers",
+        data: { render: ({ data }) => <span>{triggerCount(data)}</span> },
+        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "triggers") },
+      },
+      {
+        id: "address",
+        label: "Address",
+        data: {
+          render: ({ data }) => <TextWithTooltip text={address(data) || "—"} />,
+        },
+        cell: { baseWidth: 25, ...getSyncedColumnData(tableSettings, "address") },
+      },
+      {
+        id: "createdAt",
+        label: "Age",
+        data: {
+          render: ({ data }) => formatTimestamp(data.metadata.creationTimestamp),
+        },
+        cell: { isFixed: true, baseWidth: 10, ...getSyncedColumnData(tableSettings, "createdAt") },
+      },
+    ],
+    [tableSettings, clusterName, defaultNamespace]
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerList/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerList/index.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { DataTable } from "@/core/components/Table";
+import { EmptyList } from "@/core/components/EmptyList";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { TABLE } from "@/k8s/constants/tables";
+import { useEventListenerWatchList, useEventListenerPermissions } from "@/k8s/api/groups/Tekton/EventListener";
+import { getForbiddenError } from "@/k8s/api/utils/get-forbidden-error";
+import { useColumns } from "./hooks/useColumns";
+import { EventListenerFilter } from "../EventListenerFilter";
+import { useEventListenerFilter } from "../EventListenerFilter/hooks/useFilter";
+
+export const EventListenerList = () => {
+  const columns = useColumns();
+  // permissions.isFetched is used as a loading-state synchronizer to align
+  // with the rest of the resource lists (e.g. PipelineList). The data is not
+  // consumed yet — reserved for future row actions / create button gating.
+  const permissions = useEventListenerPermissions();
+  const watch = useEventListenerWatchList();
+  const { filterFunction } = useEventListenerFilter();
+
+  const renderEmptyList = React.useMemo(() => {
+    if (!permissions.isFetched || !watch.query.isFetched) return null;
+    const forbiddenError = watch.query.error && getForbiddenError(watch.query.error);
+    if (forbiddenError) return <ErrorContent error={forbiddenError} outlined />;
+    return (
+      <EmptyList
+        missingItemName="Event Listeners"
+        description="No Tekton EventListeners found in the current namespace."
+      />
+    );
+  }, [permissions.isFetched, watch.query.isFetched, watch.query.error]);
+
+  const tableSlots = React.useMemo(() => ({ header: { component: <EventListenerFilter /> } }), []);
+
+  return (
+    <DataTable
+      id={TABLE.EVENT_LISTENER_LIST.id}
+      name={TABLE.EVENT_LISTENER_LIST.name}
+      isLoading={!watch.query.isFetched || !permissions.isFetched}
+      data={watch.data.array}
+      errors={[]}
+      columns={columns}
+      emptyListComponent={renderEmptyList}
+      filterFunction={filterFunction}
+      slots={tableSlots}
+    />
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/page.tsx
@@ -1,0 +1,17 @@
+import { FilterProvider } from "@/core/providers/Filter";
+import { EventListener } from "@my-project/shared";
+import { EventListenerListFilterValues } from "./components/EventListenerFilter/types";
+import { eventListenerFilterDefaultValues, matchFunctions } from "./components/EventListenerFilter/constants";
+import PageView from "./view";
+
+export default function EventListenerListPage() {
+  return (
+    <FilterProvider<EventListener, EventListenerListFilterValues>
+      defaultValues={eventListenerFilterDefaultValues}
+      matchFunctions={matchFunctions}
+      syncWithUrl
+    >
+      <PageView />
+    </FilterProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_EVENT_LISTENERS } from "./route";
+import EventListenerListPage from "./page";
+
+const EventListenerListRoute = createLazyRoute(ROUTE_ID_EVENT_LISTENERS)({
+  component: EventListenerListPage,
+});
+
+export default EventListenerListRoute;

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/route.ts
@@ -1,0 +1,15 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+
+export const PATH_EVENT_LISTENERS = "webhook-triggers/event-listeners" as const;
+export const PATH_EVENT_LISTENERS_FULL = "/c/$clusterName/cicd/webhook-triggers/event-listeners" as const;
+export const ROUTE_ID_EVENT_LISTENERS = "/_layout/c/$clusterName/cicd/webhook-triggers/event-listeners" as const;
+
+export type Search = Record<string, unknown>;
+
+export const routeEventListenerList = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_EVENT_LISTENERS,
+  validateSearch: (search: Record<string, unknown>): Search => search,
+  head: () => ({ meta: [{ title: "Event Listeners | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/view.tsx
@@ -1,0 +1,20 @@
+import { Webhook } from "lucide-react";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { EventListenerList } from "./components/EventListenerList";
+
+export default function EventListenerListView() {
+  return (
+    <PageWrapper breadcrumbs={[{ label: "Webhook Triggers" }, { label: "Event Listeners" }]}>
+      <PageContentWrapper
+        icon={Webhook}
+        title="Event Listeners"
+        description="Webhook entrypoints. Each EventListener exposes an HTTP endpoint that fans incoming events out to its configured triggers."
+      >
+        <div className="flex flex-grow flex-col gap-6">
+          <EventListenerList />
+        </div>
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/components/Overview/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/components/Overview/index.tsx
@@ -1,0 +1,7 @@
+import { InterceptorOverview } from "@/modules/platform/tekton/components/InterceptorOverview";
+import { useInterceptorWatch } from "../../hooks/data";
+
+export const Overview = () => {
+  const watch = useInterceptorWatch();
+  return <InterceptorOverview resource={watch.query.data} isLoading={watch.isLoading} />;
+};

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/components/UsedBy/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/components/UsedBy/index.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "@/core/components/ui/card";
+import { Button } from "@/core/components/ui/button";
+import { Badge } from "@/core/components/ui/badge";
+import { useClusterStore } from "@/k8s/store";
+import { useTriggerWatchList } from "@/k8s/api/groups/Tekton/Trigger";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { useInterceptorWatch } from "../../hooks/data";
+import { routeTriggerDetails } from "@/modules/platform/tekton/pages/trigger-details/route";
+import { routeEventListenerDetails } from "@/modules/platform/tekton/pages/event-listener-details/route";
+
+export const UsedBy = () => {
+  const watch = useInterceptorWatch();
+  const it = watch.query.data;
+  const triggers = useTriggerWatchList().data.array;
+  const els = useEventListenerWatchList().data.array;
+  const { clusterName, namespace: defaultNamespace } = useClusterStore(
+    useShallow((s) => ({ clusterName: s.clusterName, namespace: s.defaultNamespace }))
+  );
+
+  // Raw Tekton specs use kind "Interceptor" for namespaced refs (or omit it,
+  // since "Interceptor" is the default). "NamespacedInterceptor" is an
+  // internal alias used only by useEventListenerTopology.
+  const matches = (ref: { name?: string; kind?: string } | undefined, name: string) =>
+    ref?.name === name && ref?.kind !== "ClusterInterceptor";
+
+  const referencingTriggers = React.useMemo(() => {
+    if (!it) return [];
+    return triggers.filter((t) => {
+      if (t.metadata.namespace !== it.metadata.namespace) return false;
+      return (t.spec?.interceptors ?? []).some((i) => matches(i.ref, it.metadata.name));
+    });
+  }, [triggers, it]);
+
+  const referencingEls = React.useMemo(() => {
+    if (!it) return [];
+    return els.filter((el) => {
+      if (el.metadata.namespace !== it.metadata.namespace) return false;
+      return (el.spec?.triggers ?? []).some((entry) =>
+        (entry.interceptors ?? []).some((i) => matches(i.ref, it.metadata.name))
+      );
+    });
+  }, [els, it]);
+
+  return (
+    <Card className="p-6">
+      <h3 className="text-foreground mb-3 text-lg font-semibold">Used by</h3>
+      {referencingTriggers.length === 0 && referencingEls.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No Triggers or EventListeners reference this Interceptor.</p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {referencingTriggers.length > 0 && (
+            <div>
+              <h4 className="text-muted-foreground mb-2 text-xs uppercase">Triggers</h4>
+              <ul className="flex flex-col gap-2">
+                {referencingTriggers.map((t) => (
+                  <li key={t.metadata.uid} className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">Trigger</Badge>
+                    <Button variant="link" asChild className="h-auto p-0">
+                      <Link
+                        to={routeTriggerDetails.fullPath}
+                        params={{
+                          clusterName,
+                          namespace: t.metadata.namespace || defaultNamespace,
+                          name: t.metadata.name,
+                        }}
+                      >
+                        {t.metadata.name}
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {referencingEls.length > 0 && (
+            <div>
+              <h4 className="text-muted-foreground mb-2 text-xs uppercase">EventListeners (inline)</h4>
+              <ul className="flex flex-col gap-2">
+                {referencingEls.map((el) => (
+                  <li key={el.metadata.uid} className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">EventListener</Badge>
+                    <Button variant="link" asChild className="h-auto p-0">
+                      <Link
+                        to={routeEventListenerDetails.fullPath}
+                        params={{
+                          clusterName,
+                          namespace: el.metadata.namespace || defaultNamespace,
+                          name: el.metadata.name,
+                        }}
+                      >
+                        {el.metadata.name}
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/components/ViewYaml/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/components/ViewYaml/index.tsx
@@ -1,0 +1,9 @@
+import CodeEditor from "@/core/components/CodeEditor";
+import { useInterceptorWatch } from "../../hooks/data";
+
+export const ViewYaml = () => {
+  const watch = useInterceptorWatch();
+  const it = watch.query.data;
+  if (!it) return null;
+  return <CodeEditor language="yaml" content={it} />;
+};

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/constants.ts
@@ -1,0 +1,6 @@
+import { RouteSearchTab, routeSearchTabName } from "./route";
+
+export const tabNameToIndexMap: Record<RouteSearchTab, number> = {
+  [routeSearchTabName.overview]: 0,
+  [routeSearchTabName.yaml]: 1,
+};

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/hooks/data.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/hooks/data.ts
@@ -1,0 +1,7 @@
+import { useInterceptorWatchItem } from "@/k8s/api/groups/Tekton/Interceptor";
+import { routeInterceptorDetails } from "../route";
+
+export const useInterceptorWatch = () => {
+  const params = routeInterceptorDetails.useParams();
+  return useInterceptorWatchItem({ namespace: params.namespace, name: params.name });
+};

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/hooks/useTabs.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/hooks/useTabs.tsx
@@ -1,0 +1,15 @@
+import { useDetailTabs } from "@/modules/platform/tekton/hooks/useDetailTabs";
+import { Tab } from "@/core/providers/Tabs/components/Tabs/types";
+import { Overview } from "../components/Overview";
+import { UsedBy } from "../components/UsedBy";
+import { ViewYaml } from "../components/ViewYaml";
+import { routeInterceptorDetails, PATH_INTERCEPTOR_DETAILS_FULL } from "../route";
+
+export const useTabs = (): Tab[] =>
+  useDetailTabs({
+    route: routeInterceptorDetails,
+    path: PATH_INTERCEPTOR_DETAILS_FULL,
+    Overview,
+    UsedBy,
+    ViewYaml,
+  });

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/page.tsx
@@ -1,0 +1,14 @@
+import { TabsContextProvider } from "@/core/providers/Tabs/provider";
+import { tabNameToIndexMap } from "./constants";
+import { routeInterceptorDetails } from "./route";
+import InterceptorDetailsView from "./view";
+
+export default function InterceptorDetailsPage() {
+  const search = routeInterceptorDetails.useSearch();
+  const initialTabIdx = search.tab ? tabNameToIndexMap[search.tab] : 0;
+  return (
+    <TabsContextProvider id="interceptor-details-page" initialTabIdx={initialTabIdx}>
+      <InterceptorDetailsView searchTabIdx={initialTabIdx} />
+    </TabsContextProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/route.lazy.ts
@@ -1,0 +1,6 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_INTERCEPTOR_DETAILS } from "./route";
+import InterceptorDetailsPage from "./page";
+
+const InterceptorDetailsRoute = createLazyRoute(ROUTE_ID_INTERCEPTOR_DETAILS)({ component: InterceptorDetailsPage });
+export default InterceptorDetailsRoute;

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/route.ts
@@ -1,0 +1,27 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+export const PATH_INTERCEPTOR_DETAILS = "webhook-triggers/interceptors/$namespace/$name" as const;
+export const PATH_INTERCEPTOR_DETAILS_FULL =
+  "/c/$clusterName/cicd/webhook-triggers/interceptors/$namespace/$name" as const;
+export const ROUTE_ID_INTERCEPTOR_DETAILS =
+  "/_layout/c/$clusterName/cicd/webhook-triggers/interceptors/$namespace/$name" as const;
+
+export const routeSearchTabSchema = z.enum(["overview", "yaml"]);
+export const routeSearchTabName = routeSearchTabSchema.enum;
+export type RouteSearchTab = z.infer<typeof routeSearchTabSchema>;
+
+export interface Search {
+  tab?: RouteSearchTab;
+}
+
+export const routeInterceptorDetails = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_INTERCEPTOR_DETAILS,
+  validateSearch: (search: Record<string, unknown>): Search => {
+    const parsed = z.object({ tab: routeSearchTabSchema.optional() }).parse(search);
+    return { tab: parsed.tab ?? "overview" };
+  },
+  head: ({ params }) => ({ meta: [{ title: `${params.name} [${params.namespace}] — Interceptors | KRCI` }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-details/view.tsx
@@ -1,0 +1,41 @@
+import { Funnel } from "lucide-react";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { useTabsContext } from "@/core/providers/Tabs/hooks";
+import { PATH_INTERCEPTORS_FULL } from "../interceptor-list/route";
+import { useInterceptorWatch } from "./hooks/data";
+import { useTabs } from "./hooks/useTabs";
+import { routeInterceptorDetails } from "./route";
+
+export default function InterceptorDetailsView({ searchTabIdx }: { searchTabIdx: number }) {
+  const params = routeInterceptorDetails.useParams();
+  const watch = useInterceptorWatch();
+  const tabs = useTabs();
+  const { handleChangeTab } = useTabsContext();
+  const showTabs = !watch.query.error && !watch.query.isLoading;
+
+  return (
+    <PageWrapper
+      breadcrumbs={[
+        { label: "Webhook Triggers" },
+        { label: "Interceptors", route: { to: PATH_INTERCEPTORS_FULL } },
+        { label: params.name },
+      ]}
+    >
+      <PageContentWrapper
+        icon={Funnel}
+        title={params.name}
+        enableCopyTitle
+        description="Namespace-scoped CEL/HTTP webhook filter."
+        tabs={showTabs ? tabs : undefined}
+        activeTab={searchTabIdx}
+        onTabChange={handleChangeTab}
+      >
+        {watch.query.error && <ErrorContent error={watch.query.error} />}
+        {watch.query.isLoading && <LoadingWrapper isLoading>{null}</LoadingWrapper>}
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/constants.test.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/constants.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { interceptorSchema } from "@my-project/shared";
+import { matchFunctions, INTERCEPTOR_LIST_FILTER_NAMES } from "./constants";
+
+const searchMatch = matchFunctions[INTERCEPTOR_LIST_FILTER_NAMES.SEARCH]!;
+const namespaceMatch = matchFunctions[INTERCEPTOR_LIST_FILTER_NAMES.NAMESPACES]!;
+
+const make = (name: string, namespace = "ns") =>
+  interceptorSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1alpha1",
+    kind: "Interceptor",
+    metadata: { name, namespace, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z" },
+  });
+
+describe("Interceptor matchFunctions.search", () => {
+  test("empty search passes everything", () => {
+    expect(searchMatch(make("github"), "")).toBe(true);
+  });
+  test("name substring match", () => {
+    expect(searchMatch(make("github-build"), "build")).toBe(true);
+  });
+  test("name substring match is case-insensitive", () => {
+    expect(searchMatch(make("Github-Build"), "github")).toBe(true);
+  });
+  test("non-matching name dropped", () => {
+    expect(searchMatch(make("github-build"), "gitlab")).toBe(false);
+  });
+});
+
+describe("Interceptor matchFunctions.namespaces", () => {
+  test("empty selection passes everything", () => {
+    expect(namespaceMatch(make("x", "a"), [])).toBe(true);
+  });
+  test("matching namespace kept", () => {
+    expect(namespaceMatch(make("x", "a"), ["a"])).toBe(true);
+  });
+  test("non-matching namespace dropped", () => {
+    expect(namespaceMatch(make("x", "a"), ["b"])).toBe(false);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/constants.ts
@@ -1,0 +1,18 @@
+import { MatchFunctions, createSearchMatchFunction, createNamespaceMatchFunction } from "@/core/providers/Filter";
+import { Interceptor } from "@my-project/shared";
+import { InterceptorListFilterValues } from "./types";
+
+export const INTERCEPTOR_LIST_FILTER_NAMES = {
+  SEARCH: "search",
+  NAMESPACES: "namespaces",
+} as const;
+
+export const interceptorFilterDefaultValues: InterceptorListFilterValues = {
+  [INTERCEPTOR_LIST_FILTER_NAMES.SEARCH]: "",
+  [INTERCEPTOR_LIST_FILTER_NAMES.NAMESPACES]: [],
+};
+
+export const matchFunctions: MatchFunctions<Interceptor, InterceptorListFilterValues> = {
+  [INTERCEPTOR_LIST_FILTER_NAMES.SEARCH]: createSearchMatchFunction<Interceptor>(),
+  [INTERCEPTOR_LIST_FILTER_NAMES.NAMESPACES]: createNamespaceMatchFunction<Interceptor>(),
+};

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/hooks/useFilter.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/hooks/useFilter.tsx
@@ -1,0 +1,7 @@
+import { useFilterContext } from "@/core/providers/Filter";
+import { Interceptor } from "@my-project/shared";
+import { InterceptorListFilterValues } from "../types";
+
+export function useInterceptorFilter() {
+  return useFilterContext<Interceptor, InterceptorListFilterValues>();
+}

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/index.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Button } from "@/core/components/ui/button";
+import { Label } from "@/core/components/ui/label";
+import { useClusterStore } from "@/k8s/store";
+import { useShallow } from "zustand/react/shallow";
+import { X } from "lucide-react";
+import { INTERCEPTOR_LIST_FILTER_NAMES } from "./constants";
+import { useInterceptorFilter } from "./hooks/useFilter";
+
+export function InterceptorFilter() {
+  const { form, reset, isDefaultValue } = useInterceptorFilter();
+  const allowedNamespaces = useClusterStore(useShallow((s) => s.allowedNamespaces));
+  const showNamespaceFilter = allowedNamespaces.length > 1;
+  const namespaceOptions = React.useMemo(
+    () => allowedNamespaces.map((value) => ({ label: value, value })),
+    [allowedNamespaces]
+  );
+
+  return (
+    <>
+      <div className="col-span-3">
+        <form.AppField name={INTERCEPTOR_LIST_FILTER_NAMES.SEARCH}>
+          {(field) => <field.FormTextField label="Search" placeholder="Search interceptors" />}
+        </form.AppField>
+      </div>
+      {showNamespaceFilter && (
+        <div className="col-span-4">
+          <form.AppField name={INTERCEPTOR_LIST_FILTER_NAMES.NAMESPACES}>
+            {(field) => (
+              <field.FormCombobox
+                options={namespaceOptions}
+                label="Namespaces"
+                placeholder="Select namespaces"
+                multiple
+              />
+            )}
+          </form.AppField>
+        </div>
+      )}
+      {!isDefaultValue && (
+        <div className="col-span-1 flex flex-col gap-2">
+          <Label> </Label>
+          <Button variant="secondary" onClick={reset} size="sm" className="mt-0.5">
+            <X size={16} />
+            Clear
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/types.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorFilter/types.ts
@@ -1,0 +1,6 @@
+import { INTERCEPTOR_LIST_FILTER_NAMES } from "./constants";
+
+export type InterceptorListFilterValues = {
+  [INTERCEPTOR_LIST_FILTER_NAMES.SEARCH]: string;
+  [INTERCEPTOR_LIST_FILTER_NAMES.NAMESPACES]: string[];
+};

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorList/hooks/useColumns.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Funnel } from "lucide-react";
+import { Interceptor, EventListener, Trigger } from "@my-project/shared";
+import { TableColumn } from "@/core/components/Table/types";
+import { Button } from "@/core/components/ui/button";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { useTableSettings } from "@/core/components/Table/components/TableSettings/hooks/useTableSettings";
+import { getSyncedColumnData } from "@/core/components/Table/components/TableSettings/utils";
+import { TABLE } from "@/k8s/constants/tables";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { useClusterStore } from "@/k8s/store";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { useTriggerWatchList } from "@/k8s/api/groups/Tekton/Trigger";
+import { routeInterceptorDetails } from "@/modules/platform/tekton/pages/interceptor-details/route";
+
+const formatAddress = (it: Interceptor): string => {
+  const cc = it.spec?.clientConfig;
+  if (cc?.url) return cc.url;
+  if (cc?.service?.name) {
+    const port = cc.service.port ? `:${cc.service.port}` : "";
+    return `${cc.service.namespace ?? ""}/${cc.service.name}${port}`;
+  }
+  return "—";
+};
+
+type InterceptorRefHolder = { ref?: { name?: string; kind?: string } };
+
+const usedByCount = (it: Interceptor, els: EventListener[], triggers: Trigger[]): number => {
+  const name = it.metadata.name;
+  const ns = it.metadata.namespace;
+  // Raw Tekton specs use kind "Interceptor" for namespaced refs (or omit it,
+  // since "Interceptor" is the default). "NamespacedInterceptor" is an
+  // internal alias used only by useEventListenerTopology, so we must not
+  // match against it here.
+  const matches = (ref: { name?: string; kind?: string } | undefined) =>
+    ref?.name === name && ref?.kind !== "ClusterInterceptor";
+  let count = 0;
+  for (const el of els) {
+    if (el.metadata.namespace !== ns) continue;
+    const elTriggers = el.spec?.triggers ?? [];
+    count += elTriggers.filter(
+      (entry) => entry.interceptors?.some((i: InterceptorRefHolder) => matches(i.ref)) ?? false
+    ).length;
+  }
+  for (const t of triggers) {
+    if (t.metadata.namespace !== ns) continue;
+    if (t.spec?.interceptors?.some((i: InterceptorRefHolder) => matches(i.ref))) count += 1;
+  }
+  return count;
+};
+
+export function useColumns(): TableColumn<Interceptor>[] {
+  const { loadSettings } = useTableSettings(TABLE.INTERCEPTOR_LIST.id);
+  const tableSettings = loadSettings();
+  const { namespace: defaultNamespace, clusterName } = useClusterStore(
+    useShallow((s) => ({ namespace: s.defaultNamespace, clusterName: s.clusterName }))
+  );
+  const els = useEventListenerWatchList().data.array;
+  const triggers = useTriggerWatchList().data.array;
+
+  return React.useMemo(
+    () => [
+      {
+        id: "name",
+        label: "Name",
+        data: {
+          columnSortableValuePath: "metadata.name",
+          render: ({ data }) => {
+            const { name, namespace } = data.metadata;
+            return (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={routeInterceptorDetails.fullPath}
+                  params={{ clusterName, namespace: namespace || defaultNamespace, name }}
+                >
+                  <Funnel className="text-muted-foreground/70 size-4" />
+                  <TextWithTooltip text={name} />
+                </Link>
+              </Button>
+            );
+          },
+        },
+        cell: { isFixed: true, baseWidth: 25, ...getSyncedColumnData(tableSettings, "name") },
+      },
+      {
+        id: "namespace",
+        label: "Namespace",
+        data: { render: ({ data }) => <span>{data.metadata.namespace}</span> },
+        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "namespace") },
+      },
+      {
+        id: "address",
+        label: "Address",
+        data: { render: ({ data }) => <TextWithTooltip text={formatAddress(data)} /> },
+        cell: { baseWidth: 35, ...getSyncedColumnData(tableSettings, "address") },
+      },
+      {
+        id: "usedBy",
+        label: "Used by",
+        data: { render: ({ data }) => <span>{usedByCount(data, els, triggers)}</span> },
+        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "usedBy") },
+      },
+      {
+        id: "createdAt",
+        label: "Age",
+        data: {
+          render: ({ data }) => formatTimestamp(data.metadata.creationTimestamp),
+        },
+        cell: { isFixed: true, baseWidth: 15, ...getSyncedColumnData(tableSettings, "createdAt") },
+      },
+    ],
+    [tableSettings, clusterName, defaultNamespace, els, triggers]
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorList/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/components/InterceptorList/index.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { DataTable } from "@/core/components/Table";
+import { EmptyList } from "@/core/components/EmptyList";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { TABLE } from "@/k8s/constants/tables";
+import { useInterceptorWatchList, useInterceptorPermissions } from "@/k8s/api/groups/Tekton/Interceptor";
+import { getForbiddenError } from "@/k8s/api/utils/get-forbidden-error";
+import { useColumns } from "./hooks/useColumns";
+import { InterceptorFilter } from "../InterceptorFilter";
+import { useInterceptorFilter } from "../InterceptorFilter/hooks/useFilter";
+
+export const InterceptorList = () => {
+  const columns = useColumns();
+  // permissions.isFetched is used as a loading-state synchronizer to align
+  // with the rest of the resource lists (e.g. PipelineList). The data is not
+  // consumed yet — reserved for future row actions / create button gating.
+  const permissions = useInterceptorPermissions();
+  const watch = useInterceptorWatchList();
+  const { filterFunction } = useInterceptorFilter();
+
+  const renderEmptyList = React.useMemo(() => {
+    if (!permissions.isFetched || !watch.query.isFetched) return null;
+    const forbiddenError = watch.query.error && getForbiddenError(watch.query.error);
+    if (forbiddenError) return <ErrorContent error={forbiddenError} outlined />;
+    return (
+      <EmptyList missingItemName="Interceptors" description="No Tekton Interceptors found in the current namespace." />
+    );
+  }, [permissions.isFetched, watch.query.isFetched, watch.query.error]);
+
+  const tableSlots = React.useMemo(() => ({ header: { component: <InterceptorFilter /> } }), []);
+
+  return (
+    <DataTable
+      id={TABLE.INTERCEPTOR_LIST.id}
+      name={TABLE.INTERCEPTOR_LIST.name}
+      isLoading={!watch.query.isFetched || !permissions.isFetched}
+      data={watch.data.array}
+      errors={[]}
+      columns={columns}
+      emptyListComponent={renderEmptyList}
+      filterFunction={filterFunction}
+      slots={tableSlots}
+    />
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/page.tsx
@@ -1,0 +1,17 @@
+import { FilterProvider } from "@/core/providers/Filter";
+import { Interceptor } from "@my-project/shared";
+import { InterceptorListFilterValues } from "./components/InterceptorFilter/types";
+import { interceptorFilterDefaultValues, matchFunctions } from "./components/InterceptorFilter/constants";
+import PageView from "./view";
+
+export default function InterceptorListPage() {
+  return (
+    <FilterProvider<Interceptor, InterceptorListFilterValues>
+      defaultValues={interceptorFilterDefaultValues}
+      matchFunctions={matchFunctions}
+      syncWithUrl
+    >
+      <PageView />
+    </FilterProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_INTERCEPTORS } from "./route";
+import InterceptorListPage from "./page";
+
+const InterceptorListRoute = createLazyRoute(ROUTE_ID_INTERCEPTORS)({
+  component: InterceptorListPage,
+});
+
+export default InterceptorListRoute;

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/route.ts
@@ -1,0 +1,15 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+
+export const PATH_INTERCEPTORS = "webhook-triggers/interceptors" as const;
+export const PATH_INTERCEPTORS_FULL = "/c/$clusterName/cicd/webhook-triggers/interceptors" as const;
+export const ROUTE_ID_INTERCEPTORS = "/_layout/c/$clusterName/cicd/webhook-triggers/interceptors" as const;
+
+export type Search = Record<string, unknown>;
+
+export const routeInterceptorList = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_INTERCEPTORS,
+  validateSearch: (search: Record<string, unknown>): Search => search,
+  head: () => ({ meta: [{ title: "Interceptors | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/interceptor-list/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/interceptor-list/view.tsx
@@ -1,0 +1,20 @@
+import { Funnel } from "lucide-react";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { InterceptorList } from "./components/InterceptorList";
+
+export default function InterceptorListView() {
+  return (
+    <PageWrapper breadcrumbs={[{ label: "Webhook Triggers" }, { label: "Interceptors" }]}>
+      <PageContentWrapper
+        icon={Funnel}
+        title="Interceptors"
+        description="Namespace-scoped CEL/HTTP filters that decide whether a webhook event proceeds to its trigger."
+      >
+        <div className="flex flex-grow flex-col gap-6">
+          <InterceptorList />
+        </div>
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/pipeline-list/components/PipelineFilter/hooks/useFilter.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipeline-list/components/PipelineFilter/hooks/useFilter.tsx
@@ -2,4 +2,6 @@ import { useFilterContext } from "@/core/providers/Filter";
 import { Pipeline } from "@my-project/shared";
 import { PipelineListFilterValues } from "../types";
 
-export const usePipelineFilter = () => useFilterContext<Pipeline, PipelineListFilterValues>();
+export function usePipelineFilter() {
+  return useFilterContext<Pipeline, PipelineListFilterValues>();
+}

--- a/apps/client/src/modules/platform/tekton/pages/pipeline-list/components/PipelineFilter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipeline-list/components/PipelineFilter/index.tsx
@@ -10,7 +10,7 @@ import { pipelineLabels, PipelineType } from "@my-project/shared";
 import { Label } from "@/core/components/ui/label";
 import { X } from "lucide-react";
 
-export const PipelineFilter = () => {
+export function PipelineFilter() {
   const { form, reset, isDefaultValue } = usePipelineFilter();
 
   const pipelineListWatch = usePipelineWatchList();
@@ -77,4 +77,4 @@ export const PipelineFilter = () => {
       )}
     </>
   );
-};
+}

--- a/apps/client/src/modules/platform/tekton/pages/pipeline-list/components/PipelineList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipeline-list/components/PipelineList/hooks/useColumns.tsx
@@ -17,7 +17,7 @@ import { routePipelineDetails } from "@/modules/platform/tekton/pages/pipeline-d
 import { Link } from "@tanstack/react-router";
 import { Actions } from "../components/Actions";
 
-export const useColumns = (): TableColumn<Pipeline>[] => {
+export function useColumns(): TableColumn<Pipeline>[] {
   const openPipelineGraphDialog = useDialogOpener(PipelineGraphDialog);
 
   const { loadSettings } = useTableSettings(TABLE.PIPELINE_LIST.id);
@@ -125,4 +125,4 @@ export const useColumns = (): TableColumn<Pipeline>[] => {
     ],
     [openPipelineGraphDialog, tableSettings, clusterName, defaultNamespace]
   );
-};
+}

--- a/apps/client/src/modules/platform/tekton/pages/task-list/components/TaskFilter/hooks/useFilter.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/task-list/components/TaskFilter/hooks/useFilter.tsx
@@ -2,4 +2,6 @@ import { useFilterContext } from "@/core/providers/Filter";
 import { Task } from "@my-project/shared";
 import { TaskListFilterValues } from "../types";
 
-export const useTaskFilter = () => useFilterContext<Task, TaskListFilterValues>();
+export function useTaskFilter() {
+  return useFilterContext<Task, TaskListFilterValues>();
+}

--- a/apps/client/src/modules/platform/tekton/pages/task-list/components/TaskFilter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/task-list/components/TaskFilter/index.tsx
@@ -7,7 +7,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Label } from "@/core/components/ui/label";
 import { X } from "lucide-react";
 
-export const TaskFilter = () => {
+export function TaskFilter() {
   const { form, reset, isDefaultValue } = useTaskFilter();
 
   const allowedNamespaces = useClusterStore(useShallow((state) => state.allowedNamespaces));
@@ -52,4 +52,4 @@ export const TaskFilter = () => {
       )}
     </>
   );
-};
+}

--- a/apps/client/src/modules/platform/tekton/pages/task-list/components/TaskList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/task-list/components/TaskList/hooks/useColumns.tsx
@@ -12,7 +12,7 @@ import { TABLE } from "@/k8s/constants/tables";
 import { Actions } from "../components/Actions";
 import { Button } from "@/core/components/ui/button";
 
-export const useColumns = (): TableColumn<Task>[] => {
+export function useColumns(): TableColumn<Task>[] {
   const { namespace: defaultNamespace, clusterName } = useClusterStore(
     useShallow((state) => ({
       namespace: state.defaultNamespace,
@@ -104,4 +104,4 @@ export const useColumns = (): TableColumn<Task>[] => {
     ],
     [clusterName, defaultNamespace, tableSettings]
   );
-};
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/components/Overview/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/components/Overview/index.tsx
@@ -1,0 +1,81 @@
+import { Card } from "@/core/components/ui/card";
+import { Badge } from "@/core/components/ui/badge";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { useTriggerBindingWatch } from "../../hooks/data";
+
+interface ParamSpec {
+  name: string;
+  value: unknown;
+}
+
+export const Overview = () => {
+  const watch = useTriggerBindingWatch();
+  const tb = watch.query.data;
+
+  return (
+    <Card className="p-6">
+      <LoadingWrapper isLoading={watch.isLoading || !tb}>
+        {tb && (
+          <div className="flex flex-col gap-6">
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Metadata</h3>
+              <dl className="grid grid-cols-4 gap-x-6 gap-y-3 text-sm">
+                <div>
+                  <dt className="text-muted-foreground">Created</dt>
+                  <dd>{formatTimestamp(tb.metadata.creationTimestamp)}</dd>
+                </div>
+                <div className="col-span-3">
+                  <dt className="text-muted-foreground">Labels</dt>
+                  <dd className="flex flex-wrap gap-1">
+                    {(() => {
+                      const labels = Object.entries(tb.metadata.labels ?? {});
+                      if (labels.length === 0) {
+                        return <span className="text-muted-foreground">No labels</span>;
+                      }
+                      return labels.map(([k, v]) => (
+                        <Badge key={k} variant="secondary">
+                          {k}:{v}
+                        </Badge>
+                      ));
+                    })()}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Param mapping</h3>
+              {(() => {
+                const params = (tb.spec?.params ?? []) as ParamSpec[];
+                if (params.length === 0) {
+                  return <p className="text-muted-foreground text-sm">No params declared.</p>;
+                }
+                return (
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-muted-foreground border-b text-left">
+                        <th className="py-2 pr-4 font-medium">Name</th>
+                        <th className="py-2 font-medium">Value</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {params.map((p) => (
+                        <tr key={p.name} className="border-b last:border-b-0">
+                          <td className="text-muted-foreground py-1 pr-4 align-top font-mono">{p.name}</td>
+                          <td className="py-1 font-mono text-xs">
+                            <code className="break-all">{String(p.value ?? "")}</code>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                );
+              })()}
+            </section>
+          </div>
+        )}
+      </LoadingWrapper>
+    </Card>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/components/UsedBy/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/components/UsedBy/index.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "@/core/components/ui/card";
+import { Button } from "@/core/components/ui/button";
+import { Badge } from "@/core/components/ui/badge";
+import { useClusterStore } from "@/k8s/store";
+import { useTriggerWatchList } from "@/k8s/api/groups/Tekton/Trigger";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { useTriggerBindingWatch } from "../../hooks/data";
+import { routeTriggerDetails } from "@/modules/platform/tekton/pages/trigger-details/route";
+import { routeEventListenerDetails } from "@/modules/platform/tekton/pages/event-listener-details/route";
+
+export const UsedBy = () => {
+  const watch = useTriggerBindingWatch();
+  const tb = watch.query.data;
+  const triggers = useTriggerWatchList().data.array;
+  const els = useEventListenerWatchList().data.array;
+  const { clusterName, namespace: defaultNamespace } = useClusterStore(
+    useShallow((s) => ({ clusterName: s.clusterName, namespace: s.defaultNamespace }))
+  );
+
+  const referencingTriggers = React.useMemo(() => {
+    if (!tb) return [];
+    return triggers.filter((t) => {
+      if (t.metadata.namespace !== tb.metadata.namespace) return false;
+      return (t.spec?.bindings ?? []).some(
+        (b) => b.ref === tb.metadata.name && (b.kind ?? "TriggerBinding") === "TriggerBinding"
+      );
+    });
+  }, [triggers, tb]);
+
+  const referencingEls = React.useMemo(() => {
+    if (!tb) return [];
+    return els.filter((el) => {
+      if (el.metadata.namespace !== tb.metadata.namespace) return false;
+      return (el.spec?.triggers ?? []).some((entry) =>
+        (entry.bindings ?? []).some(
+          (b) => b.ref === tb.metadata.name && (b.kind ?? "TriggerBinding") === "TriggerBinding"
+        )
+      );
+    });
+  }, [els, tb]);
+
+  return (
+    <Card className="p-6">
+      <h3 className="text-foreground mb-3 text-lg font-semibold">Used by</h3>
+      {referencingTriggers.length === 0 && referencingEls.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No Triggers or EventListeners reference this TriggerBinding.</p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {referencingTriggers.length > 0 && (
+            <div>
+              <h4 className="text-muted-foreground mb-2 text-xs uppercase">Triggers</h4>
+              <ul className="flex flex-col gap-2">
+                {referencingTriggers.map((t) => (
+                  <li key={t.metadata.uid} className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">Trigger</Badge>
+                    <Button variant="link" asChild className="h-auto p-0">
+                      <Link
+                        to={routeTriggerDetails.fullPath}
+                        params={{
+                          clusterName,
+                          namespace: t.metadata.namespace || defaultNamespace,
+                          name: t.metadata.name,
+                        }}
+                      >
+                        {t.metadata.name}
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {referencingEls.length > 0 && (
+            <div>
+              <h4 className="text-muted-foreground mb-2 text-xs uppercase">EventListeners (inline)</h4>
+              <ul className="flex flex-col gap-2">
+                {referencingEls.map((el) => (
+                  <li key={el.metadata.uid} className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">EventListener</Badge>
+                    <Button variant="link" asChild className="h-auto p-0">
+                      <Link
+                        to={routeEventListenerDetails.fullPath}
+                        params={{
+                          clusterName,
+                          namespace: el.metadata.namespace || defaultNamespace,
+                          name: el.metadata.name,
+                        }}
+                      >
+                        {el.metadata.name}
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/components/ViewYaml/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/components/ViewYaml/index.tsx
@@ -1,0 +1,9 @@
+import CodeEditor from "@/core/components/CodeEditor";
+import { useTriggerBindingWatch } from "../../hooks/data";
+
+export const ViewYaml = () => {
+  const watch = useTriggerBindingWatch();
+  const tb = watch.query.data;
+  if (!tb) return null;
+  return <CodeEditor language="yaml" content={tb} />;
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/constants.ts
@@ -1,0 +1,6 @@
+import { RouteSearchTab, routeSearchTabName } from "./route";
+
+export const tabNameToIndexMap: Record<RouteSearchTab, number> = {
+  [routeSearchTabName.overview]: 0,
+  [routeSearchTabName.yaml]: 1,
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/hooks/data.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/hooks/data.ts
@@ -1,0 +1,7 @@
+import { useTriggerBindingWatchItem } from "@/k8s/api/groups/Tekton/TriggerBinding";
+import { routeTriggerBindingDetails } from "../route";
+
+export const useTriggerBindingWatch = () => {
+  const params = routeTriggerBindingDetails.useParams();
+  return useTriggerBindingWatchItem({ namespace: params.namespace, name: params.name });
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/hooks/useTabs.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/hooks/useTabs.tsx
@@ -1,0 +1,15 @@
+import { useDetailTabs } from "@/modules/platform/tekton/hooks/useDetailTabs";
+import { Tab } from "@/core/providers/Tabs/components/Tabs/types";
+import { Overview } from "../components/Overview";
+import { UsedBy } from "../components/UsedBy";
+import { ViewYaml } from "../components/ViewYaml";
+import { routeTriggerBindingDetails, PATH_TRIGGER_BINDING_DETAILS_FULL } from "../route";
+
+export const useTabs = (): Tab[] =>
+  useDetailTabs({
+    route: routeTriggerBindingDetails,
+    path: PATH_TRIGGER_BINDING_DETAILS_FULL,
+    Overview,
+    UsedBy,
+    ViewYaml,
+  });

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/page.tsx
@@ -1,0 +1,14 @@
+import { TabsContextProvider } from "@/core/providers/Tabs/provider";
+import { tabNameToIndexMap } from "./constants";
+import { routeTriggerBindingDetails } from "./route";
+import TriggerBindingDetailsView from "./view";
+
+export default function TriggerBindingDetailsPage() {
+  const search = routeTriggerBindingDetails.useSearch();
+  const initialTabIdx = search.tab ? tabNameToIndexMap[search.tab] : 0;
+  return (
+    <TabsContextProvider id="trigger-binding-details-page" initialTabIdx={initialTabIdx}>
+      <TriggerBindingDetailsView searchTabIdx={initialTabIdx} />
+    </TabsContextProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/route.lazy.ts
@@ -1,0 +1,8 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_TRIGGER_BINDING_DETAILS } from "./route";
+import TriggerBindingDetailsPage from "./page";
+
+const TriggerBindingDetailsRoute = createLazyRoute(ROUTE_ID_TRIGGER_BINDING_DETAILS)({
+  component: TriggerBindingDetailsPage,
+});
+export default TriggerBindingDetailsRoute;

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/route.ts
@@ -1,0 +1,27 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+export const PATH_TRIGGER_BINDING_DETAILS = "webhook-triggers/trigger-bindings/$namespace/$name" as const;
+export const PATH_TRIGGER_BINDING_DETAILS_FULL =
+  "/c/$clusterName/cicd/webhook-triggers/trigger-bindings/$namespace/$name" as const;
+export const ROUTE_ID_TRIGGER_BINDING_DETAILS =
+  "/_layout/c/$clusterName/cicd/webhook-triggers/trigger-bindings/$namespace/$name" as const;
+
+export const routeSearchTabSchema = z.enum(["overview", "yaml"]);
+export const routeSearchTabName = routeSearchTabSchema.enum;
+export type RouteSearchTab = z.infer<typeof routeSearchTabSchema>;
+
+export interface Search {
+  tab?: RouteSearchTab;
+}
+
+export const routeTriggerBindingDetails = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_TRIGGER_BINDING_DETAILS,
+  validateSearch: (search: Record<string, unknown>): Search => {
+    const parsed = z.object({ tab: routeSearchTabSchema.optional() }).parse(search);
+    return { tab: parsed.tab ?? "overview" };
+  },
+  head: ({ params }) => ({ meta: [{ title: `${params.name} [${params.namespace}] — Trigger Bindings | KRCI` }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-details/view.tsx
@@ -1,0 +1,41 @@
+import { Link2 } from "lucide-react";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { useTabsContext } from "@/core/providers/Tabs/hooks";
+import { PATH_TRIGGER_BINDINGS_FULL } from "../trigger-binding-list/route";
+import { useTriggerBindingWatch } from "./hooks/data";
+import { useTabs } from "./hooks/useTabs";
+import { routeTriggerBindingDetails } from "./route";
+
+export default function TriggerBindingDetailsView({ searchTabIdx }: { searchTabIdx: number }) {
+  const params = routeTriggerBindingDetails.useParams();
+  const watch = useTriggerBindingWatch();
+  const tabs = useTabs();
+  const { handleChangeTab } = useTabsContext();
+  const showTabs = !watch.query.error && !watch.query.isLoading;
+
+  return (
+    <PageWrapper
+      breadcrumbs={[
+        { label: "Webhook Triggers" },
+        { label: "Trigger Bindings", route: { to: PATH_TRIGGER_BINDINGS_FULL } },
+        { label: params.name },
+      ]}
+    >
+      <PageContentWrapper
+        icon={Link2}
+        title={params.name}
+        enableCopyTitle
+        description="Webhook payload → TriggerTemplate parameter mapping."
+        tabs={showTabs ? tabs : undefined}
+        activeTab={searchTabIdx}
+        onTabChange={handleChangeTab}
+      >
+        {watch.query.error && <ErrorContent error={watch.query.error} />}
+        {watch.query.isLoading && <LoadingWrapper isLoading>{null}</LoadingWrapper>}
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/constants.test.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/constants.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { triggerBindingSchema } from "@my-project/shared";
+import { matchFunctions, TRIGGER_BINDING_LIST_FILTER_NAMES } from "./constants";
+
+const searchMatch = matchFunctions[TRIGGER_BINDING_LIST_FILTER_NAMES.SEARCH]!;
+const namespaceMatch = matchFunctions[TRIGGER_BINDING_LIST_FILTER_NAMES.NAMESPACES]!;
+
+const make = (name: string, namespace = "ns") =>
+  triggerBindingSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "TriggerBinding",
+    metadata: { name, namespace, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z" },
+    spec: {},
+  });
+
+describe("TriggerBinding matchFunctions.search", () => {
+  test("empty search passes everything", () => {
+    expect(searchMatch(make("github"), "")).toBe(true);
+  });
+  test("name substring match", () => {
+    expect(searchMatch(make("github-build"), "build")).toBe(true);
+  });
+  test("name substring match is case-insensitive", () => {
+    expect(searchMatch(make("Github-Build"), "github")).toBe(true);
+  });
+  test("non-matching name dropped", () => {
+    expect(searchMatch(make("github-build"), "gitlab")).toBe(false);
+  });
+});
+
+describe("TriggerBinding matchFunctions.namespaces", () => {
+  test("empty selection passes everything", () => {
+    expect(namespaceMatch(make("x", "a"), [])).toBe(true);
+  });
+  test("matching namespace kept", () => {
+    expect(namespaceMatch(make("x", "a"), ["a"])).toBe(true);
+  });
+  test("non-matching namespace dropped", () => {
+    expect(namespaceMatch(make("x", "a"), ["b"])).toBe(false);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/constants.ts
@@ -1,0 +1,18 @@
+import { MatchFunctions, createSearchMatchFunction, createNamespaceMatchFunction } from "@/core/providers/Filter";
+import { TriggerBinding } from "@my-project/shared";
+import { TriggerBindingListFilterValues } from "./types";
+
+export const TRIGGER_BINDING_LIST_FILTER_NAMES = {
+  SEARCH: "search",
+  NAMESPACES: "namespaces",
+} as const;
+
+export const triggerBindingFilterDefaultValues: TriggerBindingListFilterValues = {
+  [TRIGGER_BINDING_LIST_FILTER_NAMES.SEARCH]: "",
+  [TRIGGER_BINDING_LIST_FILTER_NAMES.NAMESPACES]: [],
+};
+
+export const matchFunctions: MatchFunctions<TriggerBinding, TriggerBindingListFilterValues> = {
+  [TRIGGER_BINDING_LIST_FILTER_NAMES.SEARCH]: createSearchMatchFunction<TriggerBinding>(),
+  [TRIGGER_BINDING_LIST_FILTER_NAMES.NAMESPACES]: createNamespaceMatchFunction<TriggerBinding>(),
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/hooks/useFilter.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/hooks/useFilter.tsx
@@ -1,0 +1,7 @@
+import { useFilterContext } from "@/core/providers/Filter";
+import { TriggerBinding } from "@my-project/shared";
+import { TriggerBindingListFilterValues } from "../types";
+
+export function useTriggerBindingFilter() {
+  return useFilterContext<TriggerBinding, TriggerBindingListFilterValues>();
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/index.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Button } from "@/core/components/ui/button";
+import { Label } from "@/core/components/ui/label";
+import { useClusterStore } from "@/k8s/store";
+import { useShallow } from "zustand/react/shallow";
+import { X } from "lucide-react";
+import { TRIGGER_BINDING_LIST_FILTER_NAMES } from "./constants";
+import { useTriggerBindingFilter } from "./hooks/useFilter";
+
+export function TriggerBindingFilter() {
+  const { form, reset, isDefaultValue } = useTriggerBindingFilter();
+  const allowedNamespaces = useClusterStore(useShallow((s) => s.allowedNamespaces));
+  const showNamespaceFilter = allowedNamespaces.length > 1;
+  const namespaceOptions = React.useMemo(
+    () => allowedNamespaces.map((value) => ({ label: value, value })),
+    [allowedNamespaces]
+  );
+
+  return (
+    <>
+      <div className="col-span-3">
+        <form.AppField name={TRIGGER_BINDING_LIST_FILTER_NAMES.SEARCH}>
+          {(field) => <field.FormTextField label="Search" placeholder="Search trigger bindings" />}
+        </form.AppField>
+      </div>
+      {showNamespaceFilter && (
+        <div className="col-span-4">
+          <form.AppField name={TRIGGER_BINDING_LIST_FILTER_NAMES.NAMESPACES}>
+            {(field) => (
+              <field.FormCombobox
+                options={namespaceOptions}
+                label="Namespaces"
+                placeholder="Select namespaces"
+                multiple
+              />
+            )}
+          </form.AppField>
+        </div>
+      )}
+      {!isDefaultValue && (
+        <div className="col-span-1 flex flex-col gap-2">
+          <Label> </Label>
+          <Button variant="secondary" onClick={reset} size="sm" className="mt-0.5">
+            <X size={16} />
+            Clear
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/types.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingFilter/types.ts
@@ -1,0 +1,6 @@
+import { TRIGGER_BINDING_LIST_FILTER_NAMES } from "./constants";
+
+export type TriggerBindingListFilterValues = {
+  [TRIGGER_BINDING_LIST_FILTER_NAMES.SEARCH]: string;
+  [TRIGGER_BINDING_LIST_FILTER_NAMES.NAMESPACES]: string[];
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingList/hooks/useColumns.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Link2 } from "lucide-react";
+import { TriggerBinding, EventListener, Trigger } from "@my-project/shared";
+import { TableColumn } from "@/core/components/Table/types";
+import { Button } from "@/core/components/ui/button";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { useTableSettings } from "@/core/components/Table/components/TableSettings/hooks/useTableSettings";
+import { getSyncedColumnData } from "@/core/components/Table/components/TableSettings/utils";
+import { TABLE } from "@/k8s/constants/tables";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { useClusterStore } from "@/k8s/store";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { useTriggerWatchList } from "@/k8s/api/groups/Tekton/Trigger";
+import { routeTriggerBindingDetails } from "@/modules/platform/tekton/pages/trigger-binding-details/route";
+
+const paramsCount = (tb: TriggerBinding): number => tb.spec?.params?.length ?? 0;
+
+const usedByCount = (tb: TriggerBinding, els: EventListener[], triggers: Trigger[]): number => {
+  const name = tb.metadata.name;
+  const ns = tb.metadata.namespace;
+  let count = 0;
+  for (const el of els) {
+    if (el.metadata.namespace !== ns) continue;
+    count += (el.spec?.triggers ?? []).filter((entry) =>
+      (entry.bindings ?? []).some((b) => b.ref === name && (b.kind ?? "TriggerBinding") === "TriggerBinding")
+    ).length;
+  }
+  for (const t of triggers) {
+    if (t.metadata.namespace !== ns) continue;
+    if ((t.spec?.bindings ?? []).some((b) => b.ref === name && (b.kind ?? "TriggerBinding") === "TriggerBinding"))
+      count += 1;
+  }
+  return count;
+};
+
+export function useColumns(): TableColumn<TriggerBinding>[] {
+  const { loadSettings } = useTableSettings(TABLE.TRIGGER_BINDING_LIST.id);
+  const tableSettings = loadSettings();
+  const { namespace: defaultNamespace, clusterName } = useClusterStore(
+    useShallow((s) => ({ namespace: s.defaultNamespace, clusterName: s.clusterName }))
+  );
+  const els = useEventListenerWatchList().data.array;
+  const triggers = useTriggerWatchList().data.array;
+
+  return React.useMemo(
+    () => [
+      {
+        id: "name",
+        label: "Name",
+        data: {
+          columnSortableValuePath: "metadata.name",
+          render: ({ data }) => {
+            const { name, namespace } = data.metadata;
+            return (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={routeTriggerBindingDetails.fullPath}
+                  params={{ clusterName, namespace: namespace || defaultNamespace, name }}
+                >
+                  <Link2 className="text-muted-foreground/70 size-4" />
+                  <TextWithTooltip text={name} />
+                </Link>
+              </Button>
+            );
+          },
+        },
+        cell: { isFixed: true, baseWidth: 35, ...getSyncedColumnData(tableSettings, "name") },
+      },
+      {
+        id: "namespace",
+        label: "Namespace",
+        data: { render: ({ data }) => <span>{data.metadata.namespace}</span> },
+        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "namespace") },
+      },
+      {
+        id: "params",
+        label: "Params",
+        data: { render: ({ data }) => <span>{paramsCount(data)}</span> },
+        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "params") },
+      },
+      {
+        id: "usedBy",
+        label: "Used by",
+        data: { render: ({ data }) => <span>{usedByCount(data, els, triggers)}</span> },
+        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "usedBy") },
+      },
+      {
+        id: "createdAt",
+        label: "Age",
+        data: {
+          render: ({ data }) => formatTimestamp(data.metadata.creationTimestamp),
+        },
+        cell: { isFixed: true, baseWidth: 20, ...getSyncedColumnData(tableSettings, "createdAt") },
+      },
+    ],
+    [tableSettings, clusterName, defaultNamespace, els, triggers]
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingList/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/components/TriggerBindingList/index.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { DataTable } from "@/core/components/Table";
+import { EmptyList } from "@/core/components/EmptyList";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { TABLE } from "@/k8s/constants/tables";
+import { useTriggerBindingWatchList, useTriggerBindingPermissions } from "@/k8s/api/groups/Tekton/TriggerBinding";
+import { getForbiddenError } from "@/k8s/api/utils/get-forbidden-error";
+import { useColumns } from "./hooks/useColumns";
+import { TriggerBindingFilter } from "../TriggerBindingFilter";
+import { useTriggerBindingFilter } from "../TriggerBindingFilter/hooks/useFilter";
+
+export const TriggerBindingList = () => {
+  const columns = useColumns();
+  // permissions.isFetched is used as a loading-state synchronizer to align
+  // with the rest of the resource lists (e.g. PipelineList). The data is not
+  // consumed yet — reserved for future row actions / create button gating.
+  const permissions = useTriggerBindingPermissions();
+  const watch = useTriggerBindingWatchList();
+  const { filterFunction } = useTriggerBindingFilter();
+
+  const renderEmptyList = React.useMemo(() => {
+    if (!permissions.isFetched || !watch.query.isFetched) return null;
+    const forbiddenError = watch.query.error && getForbiddenError(watch.query.error);
+    if (forbiddenError) return <ErrorContent error={forbiddenError} outlined />;
+    return (
+      <EmptyList
+        missingItemName="Trigger Bindings"
+        description="No Tekton TriggerBindings found in the current namespace."
+      />
+    );
+  }, [permissions.isFetched, watch.query.isFetched, watch.query.error]);
+
+  const tableSlots = React.useMemo(() => ({ header: { component: <TriggerBindingFilter /> } }), []);
+
+  return (
+    <DataTable
+      id={TABLE.TRIGGER_BINDING_LIST.id}
+      name={TABLE.TRIGGER_BINDING_LIST.name}
+      isLoading={!watch.query.isFetched || !permissions.isFetched}
+      data={watch.data.array}
+      errors={[]}
+      columns={columns}
+      emptyListComponent={renderEmptyList}
+      filterFunction={filterFunction}
+      slots={tableSlots}
+    />
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/page.tsx
@@ -1,0 +1,17 @@
+import { FilterProvider } from "@/core/providers/Filter";
+import { TriggerBinding } from "@my-project/shared";
+import { TriggerBindingListFilterValues } from "./components/TriggerBindingFilter/types";
+import { triggerBindingFilterDefaultValues, matchFunctions } from "./components/TriggerBindingFilter/constants";
+import PageView from "./view";
+
+export default function TriggerBindingListPage() {
+  return (
+    <FilterProvider<TriggerBinding, TriggerBindingListFilterValues>
+      defaultValues={triggerBindingFilterDefaultValues}
+      matchFunctions={matchFunctions}
+      syncWithUrl
+    >
+      <PageView />
+    </FilterProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_TRIGGER_BINDINGS } from "./route";
+import TriggerBindingListPage from "./page";
+
+const TriggerBindingListRoute = createLazyRoute(ROUTE_ID_TRIGGER_BINDINGS)({
+  component: TriggerBindingListPage,
+});
+
+export default TriggerBindingListRoute;

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/route.ts
@@ -1,0 +1,15 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+
+export const PATH_TRIGGER_BINDINGS = "webhook-triggers/trigger-bindings" as const;
+export const PATH_TRIGGER_BINDINGS_FULL = "/c/$clusterName/cicd/webhook-triggers/trigger-bindings" as const;
+export const ROUTE_ID_TRIGGER_BINDINGS = "/_layout/c/$clusterName/cicd/webhook-triggers/trigger-bindings" as const;
+
+export type Search = Record<string, unknown>;
+
+export const routeTriggerBindingList = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_TRIGGER_BINDINGS,
+  validateSearch: (search: Record<string, unknown>): Search => search,
+  head: () => ({ meta: [{ title: "Trigger Bindings | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-binding-list/view.tsx
@@ -1,0 +1,20 @@
+import { Link2 } from "lucide-react";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { TriggerBindingList } from "./components/TriggerBindingList";
+
+export default function TriggerBindingListView() {
+  return (
+    <PageWrapper breadcrumbs={[{ label: "Webhook Triggers" }, { label: "Trigger Bindings" }]}>
+      <PageContentWrapper
+        icon={Link2}
+        title="Trigger Bindings"
+        description="Mappings from webhook payload fields to TriggerTemplate parameter values."
+      >
+        <div className="flex flex-grow flex-col gap-6">
+          <TriggerBindingList />
+        </div>
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/components/Overview/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/components/Overview/index.tsx
@@ -1,0 +1,157 @@
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "@/core/components/ui/card";
+import { Badge } from "@/core/components/ui/badge";
+import { Button } from "@/core/components/ui/button";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { useClusterStore } from "@/k8s/store";
+import { useTriggerWatch } from "../../hooks/data";
+import { routeTriggerBindingDetails } from "@/modules/platform/tekton/pages/trigger-binding-details/route";
+import { routeTriggerTemplateDetails } from "@/modules/platform/tekton/pages/trigger-template-details/route";
+import { routeInterceptorDetails } from "@/modules/platform/tekton/pages/interceptor-details/route";
+import { routeClusterInterceptorDetails } from "@/modules/platform/tekton/pages/cluster-interceptor-details/route";
+
+export function Overview() {
+  const watch = useTriggerWatch();
+  const trigger = watch.query.data;
+  const { clusterName, namespace: defaultNamespace } = useClusterStore(
+    useShallow((s) => ({ clusterName: s.clusterName, namespace: s.defaultNamespace }))
+  );
+
+  return (
+    <Card className="p-6">
+      <LoadingWrapper isLoading={watch.isLoading || !trigger}>
+        {trigger && (
+          <div className="flex flex-col gap-6">
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Metadata</h3>
+              <dl className="grid grid-cols-4 gap-x-6 gap-y-3 text-sm">
+                <div>
+                  <dt className="text-muted-foreground">Created</dt>
+                  <dd>{formatTimestamp(trigger.metadata.creationTimestamp)}</dd>
+                </div>
+                <div className="col-span-3">
+                  <dt className="text-muted-foreground">Labels</dt>
+                  <dd className="flex flex-wrap gap-1">
+                    {(() => {
+                      const labels = Object.entries(trigger.metadata.labels ?? {});
+                      if (labels.length === 0) {
+                        return <span className="text-muted-foreground">No labels</span>;
+                      }
+                      return labels.map(([k, v]) => (
+                        <Badge key={k} variant="secondary">
+                          {k}:{v}
+                        </Badge>
+                      ));
+                    })()}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Bindings</h3>
+              <ul className="flex flex-col gap-2">
+                {(trigger.spec?.bindings ?? []).map((b, i) => {
+                  const kind = b.kind ?? "TriggerBinding";
+                  const isResolvable = kind === "TriggerBinding" && !!b.ref;
+                  return (
+                    <li key={`${b.ref ?? "binding"}-${i}`} className="flex items-center gap-2 text-sm">
+                      <Badge variant="secondary">{kind}</Badge>
+                      {isResolvable ? (
+                        <Button variant="link" asChild className="h-auto p-0">
+                          <Link
+                            to={routeTriggerBindingDetails.fullPath}
+                            params={{
+                              clusterName,
+                              namespace: trigger.metadata.namespace || defaultNamespace,
+                              name: b.ref!,
+                            }}
+                          >
+                            {b.ref}
+                          </Link>
+                        </Button>
+                      ) : (
+                        <span>{b.ref ?? "(unresolved)"}</span>
+                      )}
+                    </li>
+                  );
+                })}
+                {!trigger.spec?.bindings?.length && <li className="text-muted-foreground text-sm">No bindings</li>}
+              </ul>
+            </section>
+
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Template</h3>
+              {(() => {
+                const ref = trigger.spec?.template?.ref;
+                if (!ref) return <span className="text-muted-foreground text-sm">No template</span>;
+                return (
+                  <Button variant="link" asChild className="h-auto p-0">
+                    <Link
+                      to={routeTriggerTemplateDetails.fullPath}
+                      params={{ clusterName, namespace: trigger.metadata.namespace || defaultNamespace, name: ref }}
+                    >
+                      {ref}
+                    </Link>
+                  </Button>
+                );
+              })()}
+            </section>
+
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Interceptors</h3>
+              <ul className="flex flex-col gap-3">
+                {(trigger.spec?.interceptors ?? []).map((i, idx) => (
+                  <li key={`${i.ref?.name ?? "interceptor"}-${idx}`} className="border-border rounded border p-3">
+                    <div className="mb-2 flex items-center gap-2">
+                      <Badge variant="secondary">
+                        {i.ref?.kind === "ClusterInterceptor" ? "Cluster" : "Namespaced"}
+                      </Badge>
+                      {i.ref?.name && i.ref?.kind === "ClusterInterceptor" && (
+                        <Button variant="link" asChild className="h-auto p-0">
+                          <Link to={routeClusterInterceptorDetails.fullPath} params={{ clusterName, name: i.ref.name }}>
+                            {i.ref.name}
+                          </Link>
+                        </Button>
+                      )}
+                      {i.ref?.name && i.ref?.kind !== "ClusterInterceptor" && (
+                        <Button variant="link" asChild className="h-auto p-0">
+                          <Link
+                            to={routeInterceptorDetails.fullPath}
+                            params={{
+                              clusterName,
+                              namespace: trigger.metadata.namespace || defaultNamespace,
+                              name: i.ref.name,
+                            }}
+                          >
+                            {i.ref.name}
+                          </Link>
+                        </Button>
+                      )}
+                    </div>
+                    <table className="w-full text-sm">
+                      <tbody>
+                        {(i.params ?? []).map((p) => (
+                          <tr key={p.name}>
+                            <td className="text-muted-foreground py-1 pr-4 align-top font-mono">{p.name}</td>
+                            <td className="py-1">
+                              <pre className="font-mono text-xs break-words whitespace-pre-wrap">
+                                {typeof p.value === "string" ? p.value : JSON.stringify(p.value, null, 2)}
+                              </pre>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+        )}
+      </LoadingWrapper>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/components/UsedBy/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/components/UsedBy/index.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "@/core/components/ui/card";
+import { Button } from "@/core/components/ui/button";
+import { useClusterStore } from "@/k8s/store";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { useTriggerWatch } from "../../hooks/data";
+import { routeEventListenerDetails } from "@/modules/platform/tekton/pages/event-listener-details/route";
+
+export const UsedBy = () => {
+  const watch = useTriggerWatch();
+  const trigger = watch.query.data;
+  const els = useEventListenerWatchList().data.array;
+  const { clusterName, namespace: defaultNamespace } = useClusterStore(
+    useShallow((s) => ({ clusterName: s.clusterName, namespace: s.defaultNamespace }))
+  );
+
+  const referencingEls = React.useMemo(() => {
+    if (!trigger) return [];
+    return els.filter((el) => {
+      if (el.metadata.namespace !== trigger.metadata.namespace) return false;
+      return (el.spec?.triggers ?? []).some((t) => t.triggerRef === trigger.metadata.name);
+    });
+  }, [els, trigger]);
+
+  return (
+    <Card className="p-6">
+      <h3 className="text-foreground mb-3 text-lg font-semibold">Used by</h3>
+      {referencingEls.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No EventListeners reference this Trigger.</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {referencingEls.map((el) => (
+            <li key={el.metadata.uid} className="text-sm">
+              <Button variant="link" asChild className="h-auto p-0">
+                <Link
+                  to={routeEventListenerDetails.fullPath}
+                  params={{ clusterName, namespace: el.metadata.namespace || defaultNamespace, name: el.metadata.name }}
+                >
+                  {el.metadata.name}
+                </Link>
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/components/ViewYaml/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/components/ViewYaml/index.tsx
@@ -1,0 +1,9 @@
+import CodeEditor from "@/core/components/CodeEditor";
+import { useTriggerWatch } from "../../hooks/data";
+
+export const ViewYaml = () => {
+  const watch = useTriggerWatch();
+  const trigger = watch.query.data;
+  if (!trigger) return null;
+  return <CodeEditor language="yaml" content={trigger} />;
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/constants.ts
@@ -1,0 +1,6 @@
+import { RouteSearchTab, routeSearchTabName } from "./route";
+
+export const tabNameToIndexMap: Record<RouteSearchTab, number> = {
+  [routeSearchTabName.overview]: 0,
+  [routeSearchTabName.yaml]: 1,
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/hooks/data.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/hooks/data.ts
@@ -1,0 +1,7 @@
+import { useTriggerWatchItem } from "@/k8s/api/groups/Tekton/Trigger";
+import { routeTriggerDetails } from "../route";
+
+export const useTriggerWatch = () => {
+  const params = routeTriggerDetails.useParams();
+  return useTriggerWatchItem({ namespace: params.namespace, name: params.name });
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/hooks/useTabs.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/hooks/useTabs.tsx
@@ -1,0 +1,15 @@
+import { useDetailTabs } from "@/modules/platform/tekton/hooks/useDetailTabs";
+import { Tab } from "@/core/providers/Tabs/components/Tabs/types";
+import { Overview } from "../components/Overview";
+import { UsedBy } from "../components/UsedBy";
+import { ViewYaml } from "../components/ViewYaml";
+import { routeTriggerDetails, PATH_TRIGGER_DETAILS_FULL } from "../route";
+
+export const useTabs = (): Tab[] =>
+  useDetailTabs({
+    route: routeTriggerDetails,
+    path: PATH_TRIGGER_DETAILS_FULL,
+    Overview,
+    UsedBy,
+    ViewYaml,
+  });

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/page.tsx
@@ -1,0 +1,14 @@
+import { TabsContextProvider } from "@/core/providers/Tabs/provider";
+import { tabNameToIndexMap } from "./constants";
+import { routeTriggerDetails } from "./route";
+import TriggerDetailsView from "./view";
+
+export default function TriggerDetailsPage() {
+  const search = routeTriggerDetails.useSearch();
+  const initialTabIdx = search.tab ? tabNameToIndexMap[search.tab] : 0;
+  return (
+    <TabsContextProvider id="trigger-details-page" initialTabIdx={initialTabIdx}>
+      <TriggerDetailsView searchTabIdx={initialTabIdx} />
+    </TabsContextProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/route.lazy.ts
@@ -1,0 +1,6 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_TRIGGER_DETAILS } from "./route";
+import TriggerDetailsPage from "./page";
+
+const TriggerDetailsRoute = createLazyRoute(ROUTE_ID_TRIGGER_DETAILS)({ component: TriggerDetailsPage });
+export default TriggerDetailsRoute;

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/route.ts
@@ -1,0 +1,26 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+export const PATH_TRIGGER_DETAILS = "webhook-triggers/triggers/$namespace/$name" as const;
+export const PATH_TRIGGER_DETAILS_FULL = "/c/$clusterName/cicd/webhook-triggers/triggers/$namespace/$name" as const;
+export const ROUTE_ID_TRIGGER_DETAILS =
+  "/_layout/c/$clusterName/cicd/webhook-triggers/triggers/$namespace/$name" as const;
+
+export const routeSearchTabSchema = z.enum(["overview", "yaml"]);
+export const routeSearchTabName = routeSearchTabSchema.enum;
+export type RouteSearchTab = z.infer<typeof routeSearchTabSchema>;
+
+export interface Search {
+  tab?: RouteSearchTab;
+}
+
+export const routeTriggerDetails = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_TRIGGER_DETAILS,
+  validateSearch: (search: Record<string, unknown>): Search => {
+    const parsed = z.object({ tab: routeSearchTabSchema.optional() }).parse(search);
+    return { tab: parsed.tab ?? "overview" };
+  },
+  head: ({ params }) => ({ meta: [{ title: `${params.name} [${params.namespace}] — Triggers | KRCI` }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/trigger-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-details/view.tsx
@@ -1,0 +1,41 @@
+import { Zap } from "lucide-react";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { useTabsContext } from "@/core/providers/Tabs/hooks";
+import { PATH_TRIGGERS_FULL } from "../trigger-list/route";
+import { useTriggerWatch } from "./hooks/data";
+import { useTabs } from "./hooks/useTabs";
+import { routeTriggerDetails } from "./route";
+
+export default function TriggerDetailsView({ searchTabIdx }: { searchTabIdx: number }) {
+  const params = routeTriggerDetails.useParams();
+  const watch = useTriggerWatch();
+  const tabs = useTabs();
+  const { handleChangeTab } = useTabsContext();
+  const showTabs = !watch.query.error && !watch.query.isLoading;
+
+  return (
+    <PageWrapper
+      breadcrumbs={[
+        { label: "Webhook Triggers" },
+        { label: "Triggers", route: { to: PATH_TRIGGERS_FULL } },
+        { label: params.name },
+      ]}
+    >
+      <PageContentWrapper
+        icon={Zap}
+        title={params.name}
+        enableCopyTitle
+        description="Webhook trigger configuration: bindings + interceptors + template."
+        tabs={showTabs ? tabs : undefined}
+        activeTab={searchTabIdx}
+        onTabChange={handleChangeTab}
+      >
+        {watch.query.error && <ErrorContent error={watch.query.error} />}
+        {watch.query.isLoading && <LoadingWrapper isLoading>{null}</LoadingWrapper>}
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/constants.test.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/constants.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { triggerSchema } from "@my-project/shared";
+import { matchFunctions, TRIGGER_LIST_FILTER_NAMES } from "./constants";
+
+const searchMatch = matchFunctions[TRIGGER_LIST_FILTER_NAMES.SEARCH]!;
+const namespaceMatch = matchFunctions[TRIGGER_LIST_FILTER_NAMES.NAMESPACES]!;
+
+const make = (name: string, namespace = "ns") =>
+  triggerSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "Trigger",
+    metadata: { name, namespace, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+    spec: { interceptors: [], bindings: [], template: { ref: "" } },
+  });
+
+describe("Trigger matchFunctions.search", () => {
+  test("empty search passes everything", () => {
+    expect(searchMatch(make("github"), "")).toBe(true);
+  });
+  test("name substring match", () => {
+    expect(searchMatch(make("github-build"), "build")).toBe(true);
+  });
+  test("name substring match is case-insensitive", () => {
+    expect(searchMatch(make("Github-Build"), "github")).toBe(true);
+  });
+  test("non-matching name dropped", () => {
+    expect(searchMatch(make("github-build"), "gitlab")).toBe(false);
+  });
+});
+
+describe("Trigger matchFunctions.namespaces", () => {
+  test("empty selection passes everything", () => {
+    expect(namespaceMatch(make("x", "a"), [])).toBe(true);
+  });
+  test("matching namespace kept", () => {
+    expect(namespaceMatch(make("x", "a"), ["a"])).toBe(true);
+  });
+  test("non-matching namespace dropped", () => {
+    expect(namespaceMatch(make("x", "a"), ["b"])).toBe(false);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/constants.ts
@@ -1,0 +1,18 @@
+import { MatchFunctions, createSearchMatchFunction, createNamespaceMatchFunction } from "@/core/providers/Filter";
+import { Trigger } from "@my-project/shared";
+import { TriggerListFilterValues } from "./types";
+
+export const TRIGGER_LIST_FILTER_NAMES = {
+  SEARCH: "search",
+  NAMESPACES: "namespaces",
+} as const;
+
+export const triggerFilterDefaultValues: TriggerListFilterValues = {
+  [TRIGGER_LIST_FILTER_NAMES.SEARCH]: "",
+  [TRIGGER_LIST_FILTER_NAMES.NAMESPACES]: [],
+};
+
+export const matchFunctions: MatchFunctions<Trigger, TriggerListFilterValues> = {
+  [TRIGGER_LIST_FILTER_NAMES.SEARCH]: createSearchMatchFunction<Trigger>(),
+  [TRIGGER_LIST_FILTER_NAMES.NAMESPACES]: createNamespaceMatchFunction<Trigger>(),
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/hooks/useFilter.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/hooks/useFilter.tsx
@@ -1,0 +1,7 @@
+import { useFilterContext } from "@/core/providers/Filter";
+import { Trigger } from "@my-project/shared";
+import { TriggerListFilterValues } from "../types";
+
+export function useTriggerFilter() {
+  return useFilterContext<Trigger, TriggerListFilterValues>();
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/index.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Button } from "@/core/components/ui/button";
+import { Label } from "@/core/components/ui/label";
+import { useClusterStore } from "@/k8s/store";
+import { useShallow } from "zustand/react/shallow";
+import { X } from "lucide-react";
+import { TRIGGER_LIST_FILTER_NAMES } from "./constants";
+import { useTriggerFilter } from "./hooks/useFilter";
+
+export function TriggerFilter() {
+  const { form, reset, isDefaultValue } = useTriggerFilter();
+  const allowedNamespaces = useClusterStore(useShallow((s) => s.allowedNamespaces));
+  const showNamespaceFilter = allowedNamespaces.length > 1;
+  const namespaceOptions = React.useMemo(
+    () => allowedNamespaces.map((value) => ({ label: value, value })),
+    [allowedNamespaces]
+  );
+
+  return (
+    <>
+      <div className="col-span-3">
+        <form.AppField name={TRIGGER_LIST_FILTER_NAMES.SEARCH}>
+          {(field) => <field.FormTextField label="Search" placeholder="Search triggers" />}
+        </form.AppField>
+      </div>
+      {showNamespaceFilter && (
+        <div className="col-span-4">
+          <form.AppField name={TRIGGER_LIST_FILTER_NAMES.NAMESPACES}>
+            {(field) => (
+              <field.FormCombobox
+                options={namespaceOptions}
+                label="Namespaces"
+                placeholder="Select namespaces"
+                multiple
+              />
+            )}
+          </form.AppField>
+        </div>
+      )}
+      {!isDefaultValue && (
+        <div className="col-span-1 flex flex-col gap-2">
+          <Label> </Label>
+          <Button variant="secondary" onClick={reset} size="sm" className="mt-0.5">
+            <X size={16} />
+            Clear
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/types.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerFilter/types.ts
@@ -1,0 +1,6 @@
+import { TRIGGER_LIST_FILTER_NAMES } from "./constants";
+
+export type TriggerListFilterValues = {
+  [TRIGGER_LIST_FILTER_NAMES.SEARCH]: string;
+  [TRIGGER_LIST_FILTER_NAMES.NAMESPACES]: string[];
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerList/hooks/useColumns.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Zap } from "lucide-react";
+import { Trigger, EventListener } from "@my-project/shared";
+import { TableColumn } from "@/core/components/Table/types";
+import { Button } from "@/core/components/ui/button";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { useTableSettings } from "@/core/components/Table/components/TableSettings/hooks/useTableSettings";
+import { getSyncedColumnData } from "@/core/components/Table/components/TableSettings/utils";
+import { TABLE } from "@/k8s/constants/tables";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { useClusterStore } from "@/k8s/store";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { routeTriggerDetails } from "@/modules/platform/tekton/pages/trigger-details/route";
+
+const bindingsCount = (t: Trigger): number => t.spec?.bindings?.length ?? 0;
+
+const templateRef = (t: Trigger): string => t.spec?.template?.ref ?? "—";
+
+const usedByCount = (t: Trigger, els: EventListener[]): number => {
+  const triggerName = t.metadata.name;
+  const triggerNs = t.metadata.namespace;
+  return els.filter((el) => {
+    if (el.metadata.namespace !== triggerNs) return false;
+    return (el.spec?.triggers ?? []).some((entry) => entry.triggerRef === triggerName);
+  }).length;
+};
+
+export function useColumns(): TableColumn<Trigger>[] {
+  const { loadSettings } = useTableSettings(TABLE.TRIGGER_LIST.id);
+  const tableSettings = loadSettings();
+  const { namespace: defaultNamespace, clusterName } = useClusterStore(
+    useShallow((s) => ({ namespace: s.defaultNamespace, clusterName: s.clusterName }))
+  );
+  const elsWatch = useEventListenerWatchList();
+  const els = elsWatch.data.array;
+
+  return React.useMemo(
+    () => [
+      {
+        id: "name",
+        label: "Name",
+        data: {
+          columnSortableValuePath: "metadata.name",
+          render: ({ data }) => {
+            const { name, namespace } = data.metadata;
+            return (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={routeTriggerDetails.fullPath}
+                  params={{ clusterName, namespace: namespace || defaultNamespace, name }}
+                >
+                  <Zap className="text-muted-foreground/70 size-4" />
+                  <TextWithTooltip text={name} />
+                </Link>
+              </Button>
+            );
+          },
+        },
+        cell: { isFixed: true, baseWidth: 25, ...getSyncedColumnData(tableSettings, "name") },
+      },
+      {
+        id: "namespace",
+        label: "Namespace",
+        data: { render: ({ data }) => <span>{data.metadata.namespace}</span> },
+        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "namespace") },
+      },
+      {
+        id: "bindings",
+        label: "Bindings",
+        data: { render: ({ data }) => <span>{bindingsCount(data)}</span> },
+        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "bindings") },
+      },
+      {
+        id: "template",
+        label: "Template",
+        data: { render: ({ data }) => <TextWithTooltip text={templateRef(data)} /> },
+        cell: { baseWidth: 25, ...getSyncedColumnData(tableSettings, "template") },
+      },
+      {
+        id: "usedBy",
+        label: "Used by",
+        data: { render: ({ data }) => <span>{usedByCount(data, els)}</span> },
+        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "usedBy") },
+      },
+      {
+        id: "createdAt",
+        label: "Age",
+        data: {
+          render: ({ data }) => formatTimestamp(data.metadata.creationTimestamp),
+        },
+        cell: { isFixed: true, baseWidth: 15, ...getSyncedColumnData(tableSettings, "createdAt") },
+      },
+    ],
+    [tableSettings, clusterName, defaultNamespace, els]
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerList/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/components/TriggerList/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { DataTable } from "@/core/components/Table";
+import { EmptyList } from "@/core/components/EmptyList";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { TABLE } from "@/k8s/constants/tables";
+import { useTriggerWatchList, useTriggerPermissions } from "@/k8s/api/groups/Tekton/Trigger";
+import { getForbiddenError } from "@/k8s/api/utils/get-forbidden-error";
+import { useColumns } from "./hooks/useColumns";
+import { TriggerFilter } from "../TriggerFilter";
+import { useTriggerFilter } from "../TriggerFilter/hooks/useFilter";
+
+export const TriggerList = () => {
+  const columns = useColumns();
+  // permissions.isFetched is used as a loading-state synchronizer to align
+  // with the rest of the resource lists (e.g. PipelineList). The data is not
+  // consumed yet — reserved for future row actions / create button gating.
+  const permissions = useTriggerPermissions();
+  const watch = useTriggerWatchList();
+  const { filterFunction } = useTriggerFilter();
+
+  const renderEmptyList = React.useMemo(() => {
+    if (!permissions.isFetched || !watch.query.isFetched) return null;
+    const forbiddenError = watch.query.error && getForbiddenError(watch.query.error);
+    if (forbiddenError) return <ErrorContent error={forbiddenError} outlined />;
+    return <EmptyList missingItemName="Triggers" description="No Tekton Triggers found in the current namespace." />;
+  }, [permissions.isFetched, watch.query.isFetched, watch.query.error]);
+
+  const tableSlots = React.useMemo(() => ({ header: { component: <TriggerFilter /> } }), []);
+
+  return (
+    <DataTable
+      id={TABLE.TRIGGER_LIST.id}
+      name={TABLE.TRIGGER_LIST.name}
+      isLoading={!watch.query.isFetched || !permissions.isFetched}
+      data={watch.data.array}
+      errors={[]}
+      columns={columns}
+      emptyListComponent={renderEmptyList}
+      filterFunction={filterFunction}
+      slots={tableSlots}
+    />
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/page.tsx
@@ -1,0 +1,17 @@
+import { FilterProvider } from "@/core/providers/Filter";
+import { Trigger } from "@my-project/shared";
+import { TriggerListFilterValues } from "./components/TriggerFilter/types";
+import { triggerFilterDefaultValues, matchFunctions } from "./components/TriggerFilter/constants";
+import PageView from "./view";
+
+export default function TriggerListPage() {
+  return (
+    <FilterProvider<Trigger, TriggerListFilterValues>
+      defaultValues={triggerFilterDefaultValues}
+      matchFunctions={matchFunctions}
+      syncWithUrl
+    >
+      <PageView />
+    </FilterProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_TRIGGERS } from "./route";
+import TriggerListPage from "./page";
+
+const TriggerListRoute = createLazyRoute(ROUTE_ID_TRIGGERS)({
+  component: TriggerListPage,
+});
+
+export default TriggerListRoute;

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/route.ts
@@ -1,0 +1,15 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+
+export const PATH_TRIGGERS = "webhook-triggers/triggers" as const;
+export const PATH_TRIGGERS_FULL = "/c/$clusterName/cicd/webhook-triggers/triggers" as const;
+export const ROUTE_ID_TRIGGERS = "/_layout/c/$clusterName/cicd/webhook-triggers/triggers" as const;
+
+export type Search = Record<string, unknown>;
+
+export const routeTriggerList = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_TRIGGERS,
+  validateSearch: (search: Record<string, unknown>): Search => search,
+  head: () => ({ meta: [{ title: "Triggers | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/trigger-list/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-list/view.tsx
@@ -1,0 +1,20 @@
+import { Zap } from "lucide-react";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { TriggerList } from "./components/TriggerList";
+
+export default function TriggerListView() {
+  return (
+    <PageWrapper breadcrumbs={[{ label: "Webhook Triggers" }, { label: "Triggers" }]}>
+      <PageContentWrapper
+        icon={Zap}
+        title="Triggers"
+        description="A reusable bundle of interceptors, bindings, and a template that can be referenced by one or more EventListeners."
+      >
+        <div className="flex flex-grow flex-col gap-6">
+          <TriggerList />
+        </div>
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/components/Overview/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/components/Overview/index.tsx
@@ -1,0 +1,130 @@
+import { Card } from "@/core/components/ui/card";
+import { Badge } from "@/core/components/ui/badge";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { classifyPipelineRef } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { useTriggerTemplateWatch } from "../../hooks/data";
+
+export const Overview = () => {
+  const watch = useTriggerTemplateWatch();
+  const tt = watch.query.data;
+
+  return (
+    <Card className="p-6">
+      <LoadingWrapper isLoading={watch.isLoading || !tt}>
+        {tt && (
+          <div className="flex flex-col gap-6">
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Metadata</h3>
+              <dl className="grid grid-cols-4 gap-x-6 gap-y-3 text-sm">
+                <div>
+                  <dt className="text-muted-foreground">Created</dt>
+                  <dd>{formatTimestamp(tt.metadata.creationTimestamp)}</dd>
+                </div>
+                <div className="col-span-3">
+                  <dt className="text-muted-foreground">Labels</dt>
+                  <dd className="flex flex-wrap gap-1">
+                    {(() => {
+                      const labels = Object.entries(tt.metadata.labels ?? {});
+                      if (labels.length === 0) {
+                        return <span className="text-muted-foreground">No labels</span>;
+                      }
+                      return labels.map(([k, v]) => (
+                        <Badge key={k} variant="secondary">
+                          {k}:{v}
+                        </Badge>
+                      ));
+                    })()}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Params</h3>
+              {(() => {
+                const params = tt.spec?.params ?? [];
+                if (params.length === 0) {
+                  return <p className="text-muted-foreground text-sm">No params declared.</p>;
+                }
+                return (
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-muted-foreground border-b text-left">
+                        <th className="py-2 pr-4 font-medium">Name</th>
+                        <th className="py-2 pr-4 font-medium">Description</th>
+                        <th className="py-2 font-medium">Default</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {params.map((p) => (
+                        <tr key={p.name} className="border-b last:border-b-0">
+                          <td className="py-2 pr-4 font-mono">{p.name}</td>
+                          <td className="text-muted-foreground py-2 pr-4">{p.description ?? "—"}</td>
+                          <td className="py-2 font-mono text-xs">
+                            {p.default !== undefined ? (
+                              <code>{p.default}</code>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                );
+              })()}
+            </section>
+
+            <section>
+              <h3 className="text-foreground mb-2 text-lg font-semibold">Resource templates</h3>
+              {(() => {
+                const rts = tt.spec?.resourcetemplates ?? [];
+                if (rts.length === 0) {
+                  return <p className="text-muted-foreground text-sm">No resource templates defined.</p>;
+                }
+                return (
+                  <ul className="flex flex-col gap-3">
+                    {rts.map((rt, idx) => {
+                      const cls = classifyPipelineRef(rt.spec?.pipelineRef?.name);
+                      const rtKey = rt.metadata?.name ?? rt.metadata?.generateName ?? `rt-${idx}`;
+                      return (
+                        <li key={`${rtKey}-${idx}`} className="border-border rounded border p-3">
+                          <div className="mb-2 flex flex-wrap items-center gap-2 text-sm">
+                            <span className="text-muted-foreground">apiVersion:</span>
+                            <code className="font-mono text-xs">{rt.apiVersion ?? "—"}</code>
+                            <span className="text-muted-foreground">kind:</span>
+                            <code className="font-mono text-xs">{rt.kind ?? "—"}</code>
+                            <span className="text-muted-foreground">name:</span>
+                            <code className="font-mono text-xs">
+                              {rt.metadata?.generateName ?? rt.metadata?.name ?? "—"}
+                            </code>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 text-sm">
+                            <span className="text-muted-foreground">pipelineRef:</span>
+                            {cls.kind === "literal" && (
+                              <Badge className="bg-primary/10 text-primary">{cls.pipelineName}</Badge>
+                            )}
+                            {cls.kind === "templated" && (
+                              <>
+                                <Badge variant="secondary">
+                                  <code className="font-mono text-xs">{cls.raw}</code>
+                                </Badge>
+                                {cls.sourceParam && <Badge variant="outline">← param: {cls.sourceParam}</Badge>}
+                              </>
+                            )}
+                            {cls.kind === "unknown" && <Badge variant="warning">unknown</Badge>}
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                );
+              })()}
+            </section>
+          </div>
+        )}
+      </LoadingWrapper>
+    </Card>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/components/UsedBy/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/components/UsedBy/index.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "@/core/components/ui/card";
+import { Button } from "@/core/components/ui/button";
+import { Badge } from "@/core/components/ui/badge";
+import { useClusterStore } from "@/k8s/store";
+import { useTriggerWatchList } from "@/k8s/api/groups/Tekton/Trigger";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { useTriggerTemplateWatch } from "../../hooks/data";
+import { routeTriggerDetails } from "@/modules/platform/tekton/pages/trigger-details/route";
+import { routeEventListenerDetails } from "@/modules/platform/tekton/pages/event-listener-details/route";
+
+export const UsedBy = () => {
+  const watch = useTriggerTemplateWatch();
+  const tt = watch.query.data;
+  const triggers = useTriggerWatchList().data.array;
+  const els = useEventListenerWatchList().data.array;
+  const { clusterName, namespace: defaultNamespace } = useClusterStore(
+    useShallow((s) => ({ clusterName: s.clusterName, namespace: s.defaultNamespace }))
+  );
+
+  const referencingTriggers = React.useMemo(() => {
+    if (!tt) return [];
+    return triggers.filter((t) => {
+      if (t.metadata.namespace !== tt.metadata.namespace) return false;
+      return t.spec?.template?.ref === tt.metadata.name;
+    });
+  }, [triggers, tt]);
+
+  const referencingEls = React.useMemo(() => {
+    if (!tt) return [];
+    return els.filter((el) => {
+      if (el.metadata.namespace !== tt.metadata.namespace) return false;
+      return (el.spec?.triggers ?? []).some((entry) => entry.template?.ref === tt.metadata.name);
+    });
+  }, [els, tt]);
+
+  return (
+    <Card className="p-6">
+      <h3 className="text-foreground mb-3 text-lg font-semibold">Used by</h3>
+      {referencingTriggers.length === 0 && referencingEls.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No Triggers or EventListeners reference this TriggerTemplate.</p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {referencingTriggers.length > 0 && (
+            <div>
+              <h4 className="text-muted-foreground mb-2 text-xs uppercase">Triggers</h4>
+              <ul className="flex flex-col gap-2">
+                {referencingTriggers.map((t) => (
+                  <li key={t.metadata.uid} className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">Trigger</Badge>
+                    <Button variant="link" asChild className="h-auto p-0">
+                      <Link
+                        to={routeTriggerDetails.fullPath}
+                        params={{
+                          clusterName,
+                          namespace: t.metadata.namespace || defaultNamespace,
+                          name: t.metadata.name,
+                        }}
+                      >
+                        {t.metadata.name}
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {referencingEls.length > 0 && (
+            <div>
+              <h4 className="text-muted-foreground mb-2 text-xs uppercase">EventListeners (inline)</h4>
+              <ul className="flex flex-col gap-2">
+                {referencingEls.map((el) => (
+                  <li key={el.metadata.uid} className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">EventListener</Badge>
+                    <Button variant="link" asChild className="h-auto p-0">
+                      <Link
+                        to={routeEventListenerDetails.fullPath}
+                        params={{
+                          clusterName,
+                          namespace: el.metadata.namespace || defaultNamespace,
+                          name: el.metadata.name,
+                        }}
+                      >
+                        {el.metadata.name}
+                      </Link>
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/components/ViewYaml/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/components/ViewYaml/index.tsx
@@ -1,0 +1,9 @@
+import CodeEditor from "@/core/components/CodeEditor";
+import { useTriggerTemplateWatch } from "../../hooks/data";
+
+export const ViewYaml = () => {
+  const watch = useTriggerTemplateWatch();
+  const tt = watch.query.data;
+  if (!tt) return null;
+  return <CodeEditor language="yaml" content={tt} />;
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/constants.ts
@@ -1,0 +1,6 @@
+import { RouteSearchTab, routeSearchTabName } from "./route";
+
+export const tabNameToIndexMap: Record<RouteSearchTab, number> = {
+  [routeSearchTabName.overview]: 0,
+  [routeSearchTabName.yaml]: 1,
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/hooks/data.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/hooks/data.ts
@@ -1,0 +1,7 @@
+import { useTriggerTemplateWatchItem } from "@/k8s/api/groups/Tekton/TriggerTemplate";
+import { routeTriggerTemplateDetails } from "../route";
+
+export const useTriggerTemplateWatch = () => {
+  const params = routeTriggerTemplateDetails.useParams();
+  return useTriggerTemplateWatchItem({ namespace: params.namespace, name: params.name });
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/hooks/useTabs.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/hooks/useTabs.tsx
@@ -1,0 +1,15 @@
+import { useDetailTabs } from "@/modules/platform/tekton/hooks/useDetailTabs";
+import { Tab } from "@/core/providers/Tabs/components/Tabs/types";
+import { Overview } from "../components/Overview";
+import { UsedBy } from "../components/UsedBy";
+import { ViewYaml } from "../components/ViewYaml";
+import { routeTriggerTemplateDetails, PATH_TRIGGER_TEMPLATE_DETAILS_FULL } from "../route";
+
+export const useTabs = (): Tab[] =>
+  useDetailTabs({
+    route: routeTriggerTemplateDetails,
+    path: PATH_TRIGGER_TEMPLATE_DETAILS_FULL,
+    Overview,
+    UsedBy,
+    ViewYaml,
+  });

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/page.tsx
@@ -1,0 +1,14 @@
+import { TabsContextProvider } from "@/core/providers/Tabs/provider";
+import { tabNameToIndexMap } from "./constants";
+import { routeTriggerTemplateDetails } from "./route";
+import TriggerTemplateDetailsView from "./view";
+
+export default function TriggerTemplateDetailsPage() {
+  const search = routeTriggerTemplateDetails.useSearch();
+  const initialTabIdx = search.tab ? tabNameToIndexMap[search.tab] : 0;
+  return (
+    <TabsContextProvider id="trigger-template-details-page" initialTabIdx={initialTabIdx}>
+      <TriggerTemplateDetailsView searchTabIdx={initialTabIdx} />
+    </TabsContextProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/route.lazy.ts
@@ -1,0 +1,8 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_TRIGGER_TEMPLATE_DETAILS } from "./route";
+import TriggerTemplateDetailsPage from "./page";
+
+const TriggerTemplateDetailsRoute = createLazyRoute(ROUTE_ID_TRIGGER_TEMPLATE_DETAILS)({
+  component: TriggerTemplateDetailsPage,
+});
+export default TriggerTemplateDetailsRoute;

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/route.ts
@@ -1,0 +1,27 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+export const PATH_TRIGGER_TEMPLATE_DETAILS = "webhook-triggers/trigger-templates/$namespace/$name" as const;
+export const PATH_TRIGGER_TEMPLATE_DETAILS_FULL =
+  "/c/$clusterName/cicd/webhook-triggers/trigger-templates/$namespace/$name" as const;
+export const ROUTE_ID_TRIGGER_TEMPLATE_DETAILS =
+  "/_layout/c/$clusterName/cicd/webhook-triggers/trigger-templates/$namespace/$name" as const;
+
+export const routeSearchTabSchema = z.enum(["overview", "yaml"]);
+export const routeSearchTabName = routeSearchTabSchema.enum;
+export type RouteSearchTab = z.infer<typeof routeSearchTabSchema>;
+
+export interface Search {
+  tab?: RouteSearchTab;
+}
+
+export const routeTriggerTemplateDetails = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_TRIGGER_TEMPLATE_DETAILS,
+  validateSearch: (search: Record<string, unknown>): Search => {
+    const parsed = z.object({ tab: routeSearchTabSchema.optional() }).parse(search);
+    return { tab: parsed.tab ?? "overview" };
+  },
+  head: ({ params }) => ({ meta: [{ title: `${params.name} [${params.namespace}] — Trigger Templates | KRCI` }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-details/view.tsx
@@ -1,0 +1,41 @@
+import { FileCode } from "lucide-react";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { LoadingWrapper } from "@/core/components/misc/LoadingWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { useTabsContext } from "@/core/providers/Tabs/hooks";
+import { PATH_TRIGGER_TEMPLATES_FULL } from "../trigger-template-list/route";
+import { useTriggerTemplateWatch } from "./hooks/data";
+import { useTabs } from "./hooks/useTabs";
+import { routeTriggerTemplateDetails } from "./route";
+
+export default function TriggerTemplateDetailsView({ searchTabIdx }: { searchTabIdx: number }) {
+  const params = routeTriggerTemplateDetails.useParams();
+  const watch = useTriggerTemplateWatch();
+  const tabs = useTabs();
+  const { handleChangeTab } = useTabsContext();
+  const showTabs = !watch.query.error && !watch.query.isLoading;
+
+  return (
+    <PageWrapper
+      breadcrumbs={[
+        { label: "Webhook Triggers" },
+        { label: "Trigger Templates", route: { to: PATH_TRIGGER_TEMPLATES_FULL } },
+        { label: params.name },
+      ]}
+    >
+      <PageContentWrapper
+        icon={FileCode}
+        title={params.name}
+        enableCopyTitle
+        description="PipelineRun blueprint."
+        tabs={showTabs ? tabs : undefined}
+        activeTab={searchTabIdx}
+        onTabChange={handleChangeTab}
+      >
+        {watch.query.error && <ErrorContent error={watch.query.error} />}
+        {watch.query.isLoading && <LoadingWrapper isLoading>{null}</LoadingWrapper>}
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/constants.test.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/constants.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { triggerTemplateSchema } from "@my-project/shared";
+import { matchFunctions, TRIGGER_TEMPLATE_LIST_FILTER_NAMES } from "./constants";
+
+const searchMatch = matchFunctions[TRIGGER_TEMPLATE_LIST_FILTER_NAMES.SEARCH]!;
+const namespaceMatch = matchFunctions[TRIGGER_TEMPLATE_LIST_FILTER_NAMES.NAMESPACES]!;
+
+const make = (name: string, namespace = "ns") =>
+  triggerTemplateSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "TriggerTemplate",
+    metadata: { name, namespace, uid: `u-${name}`, creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+    spec: {},
+  });
+
+describe("TriggerTemplate matchFunctions.search", () => {
+  test("empty search passes everything", () => {
+    expect(searchMatch(make("github"), "")).toBe(true);
+  });
+  test("name substring match", () => {
+    expect(searchMatch(make("github-build"), "build")).toBe(true);
+  });
+  test("name substring match is case-insensitive", () => {
+    expect(searchMatch(make("Github-Build"), "github")).toBe(true);
+  });
+  test("non-matching name dropped", () => {
+    expect(searchMatch(make("github-build"), "gitlab")).toBe(false);
+  });
+});
+
+describe("TriggerTemplate matchFunctions.namespaces", () => {
+  test("empty selection passes everything", () => {
+    expect(namespaceMatch(make("x", "a"), [])).toBe(true);
+  });
+  test("matching namespace kept", () => {
+    expect(namespaceMatch(make("x", "a"), ["a"])).toBe(true);
+  });
+  test("non-matching namespace dropped", () => {
+    expect(namespaceMatch(make("x", "a"), ["b"])).toBe(false);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/constants.ts
@@ -1,0 +1,18 @@
+import { MatchFunctions, createSearchMatchFunction, createNamespaceMatchFunction } from "@/core/providers/Filter";
+import { TriggerTemplate } from "@my-project/shared";
+import { TriggerTemplateListFilterValues } from "./types";
+
+export const TRIGGER_TEMPLATE_LIST_FILTER_NAMES = {
+  SEARCH: "search",
+  NAMESPACES: "namespaces",
+} as const;
+
+export const triggerTemplateFilterDefaultValues: TriggerTemplateListFilterValues = {
+  [TRIGGER_TEMPLATE_LIST_FILTER_NAMES.SEARCH]: "",
+  [TRIGGER_TEMPLATE_LIST_FILTER_NAMES.NAMESPACES]: [],
+};
+
+export const matchFunctions: MatchFunctions<TriggerTemplate, TriggerTemplateListFilterValues> = {
+  [TRIGGER_TEMPLATE_LIST_FILTER_NAMES.SEARCH]: createSearchMatchFunction<TriggerTemplate>(),
+  [TRIGGER_TEMPLATE_LIST_FILTER_NAMES.NAMESPACES]: createNamespaceMatchFunction<TriggerTemplate>(),
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/hooks/useFilter.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/hooks/useFilter.tsx
@@ -1,0 +1,7 @@
+import { useFilterContext } from "@/core/providers/Filter";
+import { TriggerTemplate } from "@my-project/shared";
+import { TriggerTemplateListFilterValues } from "../types";
+
+export function useTriggerTemplateFilter() {
+  return useFilterContext<TriggerTemplate, TriggerTemplateListFilterValues>();
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/index.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Button } from "@/core/components/ui/button";
+import { Label } from "@/core/components/ui/label";
+import { useClusterStore } from "@/k8s/store";
+import { useShallow } from "zustand/react/shallow";
+import { X } from "lucide-react";
+import { TRIGGER_TEMPLATE_LIST_FILTER_NAMES } from "./constants";
+import { useTriggerTemplateFilter } from "./hooks/useFilter";
+
+export function TriggerTemplateFilter() {
+  const { form, reset, isDefaultValue } = useTriggerTemplateFilter();
+  const allowedNamespaces = useClusterStore(useShallow((s) => s.allowedNamespaces));
+  const showNamespaceFilter = allowedNamespaces.length > 1;
+  const namespaceOptions = React.useMemo(
+    () => allowedNamespaces.map((value) => ({ label: value, value })),
+    [allowedNamespaces]
+  );
+
+  return (
+    <>
+      <div className="col-span-3">
+        <form.AppField name={TRIGGER_TEMPLATE_LIST_FILTER_NAMES.SEARCH}>
+          {(field) => <field.FormTextField label="Search" placeholder="Search trigger templates" />}
+        </form.AppField>
+      </div>
+      {showNamespaceFilter && (
+        <div className="col-span-4">
+          <form.AppField name={TRIGGER_TEMPLATE_LIST_FILTER_NAMES.NAMESPACES}>
+            {(field) => (
+              <field.FormCombobox
+                options={namespaceOptions}
+                label="Namespaces"
+                placeholder="Select namespaces"
+                multiple
+              />
+            )}
+          </form.AppField>
+        </div>
+      )}
+      {!isDefaultValue && (
+        <div className="col-span-1 flex flex-col gap-2">
+          <Label> </Label>
+          <Button variant="secondary" onClick={reset} size="sm" className="mt-0.5">
+            <X size={16} />
+            Clear
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/types.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateFilter/types.ts
@@ -1,0 +1,6 @@
+import { TRIGGER_TEMPLATE_LIST_FILTER_NAMES } from "./constants";
+
+export type TriggerTemplateListFilterValues = {
+  [TRIGGER_TEMPLATE_LIST_FILTER_NAMES.SEARCH]: string;
+  [TRIGGER_TEMPLATE_LIST_FILTER_NAMES.NAMESPACES]: string[];
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateList/hooks/useColumns.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { FileCode } from "lucide-react";
+import { TriggerTemplate, EventListener, Trigger } from "@my-project/shared";
+import { TableColumn } from "@/core/components/Table/types";
+import { Button } from "@/core/components/ui/button";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { useTableSettings } from "@/core/components/Table/components/TableSettings/hooks/useTableSettings";
+import { getSyncedColumnData } from "@/core/components/Table/components/TableSettings/utils";
+import { TABLE } from "@/k8s/constants/tables";
+import { formatTimestamp } from "@/core/utils/date-humanize";
+import { useClusterStore } from "@/k8s/store";
+import { useEventListenerWatchList } from "@/k8s/api/groups/Tekton/EventListener";
+import { useTriggerWatchList } from "@/k8s/api/groups/Tekton/Trigger";
+import { routeTriggerTemplateDetails } from "@/modules/platform/tekton/pages/trigger-template-details/route";
+
+const paramsCount = (tt: TriggerTemplate): number => tt.spec?.params?.length ?? 0;
+
+const parsePipelineRefName = (tt: TriggerTemplate): string => {
+  const refName = tt.spec?.resourcetemplates?.[0]?.spec?.pipelineRef?.name;
+  if (!refName) return "(unknown)";
+  if (/\$\(.*?\)/.test(refName)) return "(dynamic)";
+  return refName;
+};
+
+const usedByCount = (tt: TriggerTemplate, els: EventListener[], triggers: Trigger[]): number => {
+  const name = tt.metadata.name;
+  const ns = tt.metadata.namespace;
+  let count = 0;
+  for (const el of els) {
+    if (el.metadata.namespace !== ns) continue;
+    count += (el.spec?.triggers ?? []).filter((entry) => entry.template?.ref === name).length;
+  }
+  for (const t of triggers) {
+    if (t.metadata.namespace !== ns) continue;
+    if (t.spec?.template?.ref === name) count += 1;
+  }
+  return count;
+};
+
+export function useColumns(): TableColumn<TriggerTemplate>[] {
+  const { loadSettings } = useTableSettings(TABLE.TRIGGER_TEMPLATE_LIST.id);
+  const tableSettings = loadSettings();
+  const { namespace: defaultNamespace, clusterName } = useClusterStore(
+    useShallow((s) => ({ namespace: s.defaultNamespace, clusterName: s.clusterName }))
+  );
+  const els = useEventListenerWatchList().data.array;
+  const triggers = useTriggerWatchList().data.array;
+
+  return React.useMemo(
+    () => [
+      {
+        id: "name",
+        label: "Name",
+        data: {
+          columnSortableValuePath: "metadata.name",
+          render: ({ data }) => {
+            const { name, namespace } = data.metadata;
+            return (
+              <Button variant="link" asChild className="p-0">
+                <Link
+                  to={routeTriggerTemplateDetails.fullPath}
+                  params={{ clusterName, namespace: namespace || defaultNamespace, name }}
+                >
+                  <FileCode className="text-muted-foreground/70 size-4" />
+                  <TextWithTooltip text={name} />
+                </Link>
+              </Button>
+            );
+          },
+        },
+        cell: { isFixed: true, baseWidth: 25, ...getSyncedColumnData(tableSettings, "name") },
+      },
+      {
+        id: "namespace",
+        label: "Namespace",
+        data: { render: ({ data }) => <span>{data.metadata.namespace}</span> },
+        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "namespace") },
+      },
+      {
+        id: "params",
+        label: "Params",
+        data: { render: ({ data }) => <span>{paramsCount(data)}</span> },
+        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "params") },
+      },
+      {
+        id: "pipeline",
+        label: "Pipeline",
+        data: { render: ({ data }) => <TextWithTooltip text={parsePipelineRefName(data)} /> },
+        cell: { baseWidth: 25, ...getSyncedColumnData(tableSettings, "pipeline") },
+      },
+      {
+        id: "usedBy",
+        label: "Used by",
+        data: { render: ({ data }) => <span>{usedByCount(data, els, triggers)}</span> },
+        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "usedBy") },
+      },
+      {
+        id: "createdAt",
+        label: "Age",
+        data: {
+          render: ({ data }) => formatTimestamp(data.metadata.creationTimestamp),
+        },
+        cell: { isFixed: true, baseWidth: 15, ...getSyncedColumnData(tableSettings, "createdAt") },
+      },
+    ],
+    [tableSettings, clusterName, defaultNamespace, els, triggers]
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateList/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/components/TriggerTemplateList/index.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { DataTable } from "@/core/components/Table";
+import { EmptyList } from "@/core/components/EmptyList";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { TABLE } from "@/k8s/constants/tables";
+import { useTriggerTemplateWatchList, useTriggerTemplatePermissions } from "@/k8s/api/groups/Tekton/TriggerTemplate";
+import { getForbiddenError } from "@/k8s/api/utils/get-forbidden-error";
+import { useColumns } from "./hooks/useColumns";
+import { TriggerTemplateFilter } from "../TriggerTemplateFilter";
+import { useTriggerTemplateFilter } from "../TriggerTemplateFilter/hooks/useFilter";
+
+export const TriggerTemplateList = () => {
+  const columns = useColumns();
+  // permissions.isFetched is used as a loading-state synchronizer to align
+  // with the rest of the resource lists (e.g. PipelineList). The data is not
+  // consumed yet — reserved for future row actions / create button gating.
+  const permissions = useTriggerTemplatePermissions();
+  const watch = useTriggerTemplateWatchList();
+  const { filterFunction } = useTriggerTemplateFilter();
+
+  const renderEmptyList = React.useMemo(() => {
+    if (!permissions.isFetched || !watch.query.isFetched) return null;
+    const forbiddenError = watch.query.error && getForbiddenError(watch.query.error);
+    if (forbiddenError) return <ErrorContent error={forbiddenError} outlined />;
+    return (
+      <EmptyList
+        missingItemName="Trigger Templates"
+        description="No Tekton TriggerTemplates found in the current namespace."
+      />
+    );
+  }, [permissions.isFetched, watch.query.isFetched, watch.query.error]);
+
+  const tableSlots = React.useMemo(() => ({ header: { component: <TriggerTemplateFilter /> } }), []);
+
+  return (
+    <DataTable
+      id={TABLE.TRIGGER_TEMPLATE_LIST.id}
+      name={TABLE.TRIGGER_TEMPLATE_LIST.name}
+      isLoading={!watch.query.isFetched || !permissions.isFetched}
+      data={watch.data.array}
+      errors={[]}
+      columns={columns}
+      emptyListComponent={renderEmptyList}
+      filterFunction={filterFunction}
+      slots={tableSlots}
+    />
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/page.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/page.tsx
@@ -1,0 +1,17 @@
+import { FilterProvider } from "@/core/providers/Filter";
+import { TriggerTemplate } from "@my-project/shared";
+import { TriggerTemplateListFilterValues } from "./components/TriggerTemplateFilter/types";
+import { triggerTemplateFilterDefaultValues, matchFunctions } from "./components/TriggerTemplateFilter/constants";
+import PageView from "./view";
+
+export default function TriggerTemplateListPage() {
+  return (
+    <FilterProvider<TriggerTemplate, TriggerTemplateListFilterValues>
+      defaultValues={triggerTemplateFilterDefaultValues}
+      matchFunctions={matchFunctions}
+      syncWithUrl
+    >
+      <PageView />
+    </FilterProvider>
+  );
+}

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/route.lazy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_TRIGGER_TEMPLATES } from "./route";
+import TriggerTemplateListPage from "./page";
+
+const TriggerTemplateListRoute = createLazyRoute(ROUTE_ID_TRIGGER_TEMPLATES)({
+  component: TriggerTemplateListPage,
+});
+
+export default TriggerTemplateListRoute;

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/route.ts
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/route.ts
@@ -1,0 +1,15 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+
+export const PATH_TRIGGER_TEMPLATES = "webhook-triggers/trigger-templates" as const;
+export const PATH_TRIGGER_TEMPLATES_FULL = "/c/$clusterName/cicd/webhook-triggers/trigger-templates" as const;
+export const ROUTE_ID_TRIGGER_TEMPLATES = "/_layout/c/$clusterName/cicd/webhook-triggers/trigger-templates" as const;
+
+export type Search = Record<string, unknown>;
+
+export const routeTriggerTemplateList = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_TRIGGER_TEMPLATES,
+  validateSearch: (search: Record<string, unknown>): Search => search,
+  head: () => ({ meta: [{ title: "Trigger Templates | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/tekton/pages/trigger-template-list/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/trigger-template-list/view.tsx
@@ -1,0 +1,20 @@
+import { FileCode } from "lucide-react";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { TriggerTemplateList } from "./components/TriggerTemplateList";
+
+export default function TriggerTemplateListView() {
+  return (
+    <PageWrapper breadcrumbs={[{ label: "Webhook Triggers" }, { label: "Trigger Templates" }]}>
+      <PageContentWrapper
+        icon={FileCode}
+        title="Trigger Templates"
+        description="PipelineRun blueprints. Templates produce a Tekton PipelineRun whenever an EventListener fires; bindings supply the parameter values."
+      >
+        <div className="flex flex-grow flex-col gap-6">
+          <TriggerTemplateList />
+        </div>
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/constants.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/constants.ts
@@ -1,0 +1,11 @@
+import { K8sResourceConfig } from "../../../common/index.js";
+
+export const k8sClusterInterceptorConfig = {
+  apiVersion: "triggers.tekton.dev/v1alpha1",
+  version: "v1alpha1",
+  kind: "ClusterInterceptor",
+  group: "triggers.tekton.dev",
+  singularName: "clusterinterceptor",
+  pluralName: "clusterinterceptors",
+  clusterScoped: true,
+} as const satisfies K8sResourceConfig;

--- a/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/index.ts
@@ -1,0 +1,4 @@
+export * from "./schema.js";
+export * from "./types.js";
+export * from "./constants.js";
+export * from "./labels.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/labels.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/labels.ts
@@ -1,0 +1,1 @@
+export const clusterInterceptorLabels = {} as const;

--- a/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/schema.ts
@@ -1,0 +1,17 @@
+import z from "zod";
+import { kubeObjectBaseSchema } from "../../../common/index.js";
+import { clientConfigSchema } from "../common/schema.js";
+
+const clusterInterceptorSpecSchema = z
+  .object({
+    clientConfig: clientConfigSchema.optional(),
+    description: z.string().optional(),
+    params: z.array(z.object({ name: z.string(), value: z.unknown() }).catchall(z.any())).optional(),
+  })
+  .catchall(z.any());
+
+export const clusterInterceptorSchema = kubeObjectBaseSchema
+  .extend({
+    spec: clusterInterceptorSpecSchema.optional(),
+  })
+  .catchall(z.any());

--- a/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/types.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/ClusterInterceptor/types.ts
@@ -1,0 +1,4 @@
+import z from "zod";
+import { clusterInterceptorSchema } from "./schema.js";
+
+export type ClusterInterceptor = z.infer<typeof clusterInterceptorSchema>;

--- a/packages/shared/src/models/k8s/groups/Tekton/EventListener/constants.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/EventListener/constants.ts
@@ -1,0 +1,10 @@
+import { K8sResourceConfig } from "../../../common/index.js";
+
+export const k8sEventListenerConfig = {
+  apiVersion: "triggers.tekton.dev/v1beta1",
+  version: "v1beta1",
+  kind: "EventListener",
+  group: "triggers.tekton.dev",
+  singularName: "eventlistener",
+  pluralName: "eventlisteners",
+} as const satisfies K8sResourceConfig;

--- a/packages/shared/src/models/k8s/groups/Tekton/EventListener/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/EventListener/index.ts
@@ -1,0 +1,4 @@
+export * from "./schema.js";
+export * from "./types.js";
+export * from "./constants.js";
+export * from "./labels.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/EventListener/labels.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/EventListener/labels.ts
@@ -1,0 +1,3 @@
+export const eventListenerLabels = {
+  gitServer: "app.edp.epam.com/gitServer",
+} as const;

--- a/packages/shared/src/models/k8s/groups/Tekton/EventListener/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/EventListener/schema.ts
@@ -1,0 +1,43 @@
+import z from "zod";
+import { kubeObjectBaseSchema, kubeObjectMetadataSchema } from "../../../common/index.js";
+import { triggerSpecSchema } from "../Trigger/schema.js";
+import { eventListenerLabels } from "./labels.js";
+
+const eventListenerLabelsSchema = z.object({
+  [eventListenerLabels.gitServer]: z.string().optional(),
+});
+
+const eventListenerSpecSchema = z
+  .object({
+    triggers: z.array(triggerSpecSchema).optional(),
+  })
+  .catchall(z.any());
+
+const eventListenerStatusConditionSchema = z
+  .object({
+    type: z.string(),
+    status: z.string(),
+  })
+  .catchall(z.any());
+
+const eventListenerStatusSchema = z
+  .object({
+    address: z
+      .object({
+        url: z.string().optional(),
+      })
+      .catchall(z.any())
+      .optional(),
+    conditions: z.array(eventListenerStatusConditionSchema).optional(),
+  })
+  .catchall(z.any());
+
+export const eventListenerSchema = kubeObjectBaseSchema
+  .extend({
+    metadata: kubeObjectMetadataSchema.extend({
+      labels: eventListenerLabelsSchema.optional(),
+    }),
+    spec: eventListenerSpecSchema.optional(),
+    status: eventListenerStatusSchema.optional(),
+  })
+  .catchall(z.any());

--- a/packages/shared/src/models/k8s/groups/Tekton/EventListener/types.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/EventListener/types.ts
@@ -1,0 +1,4 @@
+import z from "zod";
+import { eventListenerSchema } from "./schema.js";
+
+export type EventListener = z.infer<typeof eventListenerSchema>;

--- a/packages/shared/src/models/k8s/groups/Tekton/Interceptor/constants.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Interceptor/constants.ts
@@ -1,0 +1,10 @@
+import { K8sResourceConfig } from "../../../common/index.js";
+
+export const k8sInterceptorConfig = {
+  apiVersion: "triggers.tekton.dev/v1alpha1",
+  version: "v1alpha1",
+  kind: "Interceptor",
+  group: "triggers.tekton.dev",
+  singularName: "interceptor",
+  pluralName: "interceptors",
+} as const satisfies K8sResourceConfig;

--- a/packages/shared/src/models/k8s/groups/Tekton/Interceptor/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Interceptor/index.ts
@@ -1,0 +1,4 @@
+export * from "./schema.js";
+export * from "./types.js";
+export * from "./constants.js";
+export * from "./labels.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/Interceptor/labels.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Interceptor/labels.ts
@@ -1,0 +1,1 @@
+export const interceptorLabels = {} as const;

--- a/packages/shared/src/models/k8s/groups/Tekton/Interceptor/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Interceptor/schema.ts
@@ -1,0 +1,17 @@
+import z from "zod";
+import { kubeObjectBaseSchema } from "../../../common/index.js";
+import { clientConfigSchema } from "../common/schema.js";
+
+const interceptorSpecSchema = z
+  .object({
+    clientConfig: clientConfigSchema.optional(),
+    description: z.string().optional(),
+    params: z.array(z.object({ name: z.string(), value: z.unknown() }).catchall(z.any())).optional(),
+  })
+  .catchall(z.any());
+
+export const interceptorSchema = kubeObjectBaseSchema
+  .extend({
+    spec: interceptorSpecSchema.optional(),
+  })
+  .catchall(z.any());

--- a/packages/shared/src/models/k8s/groups/Tekton/Interceptor/types.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Interceptor/types.ts
@@ -1,0 +1,4 @@
+import z from "zod";
+import { interceptorSchema } from "./schema.js";
+
+export type Interceptor = z.infer<typeof interceptorSchema>;

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/schema.ts
@@ -252,7 +252,7 @@ const taskRunSpecSchema = z.object({
   taskServiceAccountName: z.string().optional(),
 });
 
-const workspaceSchema = z
+export const workspaceSchema = z
   .object({
     name: z.string(),
     configMap: z
@@ -285,7 +285,8 @@ const workspaceSchema = z
         readOnly: z.boolean().optional(),
         volumeAttributes: z.record(z.string()).optional(),
       })
-      .required({ driver: true }),
+      .required({ driver: true })
+      .optional(),
     emptyDir: z
       .object({
         medium: z.string().optional(),
@@ -297,7 +298,8 @@ const workspaceSchema = z
         claimName: z.string(),
         readOnly: z.boolean().optional(),
       })
-      .required({ claimName: true }),
+      .required({ claimName: true })
+      .optional(),
     projected: z
       .object({
         defaultMode: z.number().int().optional(),

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.ts
@@ -5,6 +5,16 @@ import { TriggerTemplate } from "../../../TriggerTemplate/index.js";
 import { pipelineLabels } from "../../../Pipeline/labels.js";
 import { pipelineRunLabels } from "../../labels.js";
 
+interface PipelineRunWorkspaceWithVCT {
+  name: string;
+  volumeClaimTemplate: {
+    spec: {
+      accessModes: string[];
+      resources: { requests: { storage: string } };
+    };
+  };
+}
+
 // Matches Tekton Triggers placeholder syntax: $(tt.params.<name>)
 const TT_PARAM_RE = /^\$\(tt\.params\.([^)]+)\)$/;
 
@@ -85,19 +95,24 @@ function resolveTtParams(
   });
 }
 
-const getPipelineRunFromTriggerTemplate = (triggerTemplate: TriggerTemplate, pipeline: Pipeline) => {
+const getPipelineRunFromTriggerTemplate = (
+  triggerTemplate: TriggerTemplate,
+  pipeline: Pipeline
+): PipelineRunDraft | null => {
   if (!triggerTemplate) {
     return null;
   }
 
-  const template = triggerTemplate.spec.resourcetemplates?.[0];
+  const template = triggerTemplate.spec?.resourcetemplates?.[0];
   if (!template) {
     return null;
   }
 
   // Deep-clone so mutations below never write back into the original
-  // TriggerTemplate object (e.g. a K8s watch cache entry).
-  let pipelineRun = structuredClone(template);
+  // TriggerTemplate object (e.g. a K8s watch cache entry). The schema only
+  // models the fields read here (spec.pipelineRef.name); the runtime payload
+  // is a full PipelineRun, which the cast reflects.
+  let pipelineRun = structuredClone(template) as unknown as PipelineRunDraft;
 
   // Always pin pipelineRef to the user-requested pipeline.
   if (pipelineRun.spec?.pipelineRef) {
@@ -121,7 +136,10 @@ const getPipelineRunFromTriggerTemplate = (triggerTemplate: TriggerTemplate, pip
     // Pass 2: re-apply type-aware resolution to spec.params so that array
     // params get [] instead of the "" assigned by the string pass above.
     if (Array.isArray(pipelineRun.spec?.params)) {
-      pipelineRun.spec.params = resolveTtParams(pipelineRun.spec.params, pipeline.spec.params);
+      pipelineRun.spec.params = resolveTtParams(
+        pipelineRun.spec.params as { name: string; value: unknown }[],
+        pipeline.spec.params
+      );
     }
   }
 
@@ -133,7 +151,8 @@ export const createPipelineRunDraftFromPipeline = (
   pipeline: Pipeline
 ): PipelineRunDraft => {
   if (triggerTemplate) {
-    return getPipelineRunFromTriggerTemplate(triggerTemplate, pipeline);
+    const fromTemplate = getPipelineRunFromTriggerTemplate(triggerTemplate, pipeline);
+    if (fromTemplate) return fromTemplate;
   }
 
   const pipelineName = pipeline.metadata.name;
@@ -165,16 +184,17 @@ export const createPipelineRunDraftFromPipeline = (
       })),
       ...(pipeline.spec.workspaces?.length
         ? {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            workspaces: pipeline.spec.workspaces.map((ws: { name: string }) => ({
-              name: ws.name,
-              volumeClaimTemplate: {
-                spec: {
-                  accessModes: ["ReadWriteOnce"],
-                  resources: { requests: { storage: "1Gi" } },
+            workspaces: pipeline.spec.workspaces.map(
+              (ws: { name: string }): PipelineRunWorkspaceWithVCT => ({
+                name: ws.name,
+                volumeClaimTemplate: {
+                  spec: {
+                    accessModes: ["ReadWriteOnce"],
+                    resources: { requests: { storage: "1Gi" } },
+                  },
                 },
-              },
-            })) as any[],
+              })
+            ),
           }
         : {}),
     },

--- a/packages/shared/src/models/k8s/groups/Tekton/Trigger/constants.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Trigger/constants.ts
@@ -1,0 +1,10 @@
+import { K8sResourceConfig } from "../../../common/index.js";
+
+export const k8sTriggerConfig = {
+  apiVersion: "triggers.tekton.dev/v1beta1",
+  version: "v1beta1",
+  kind: "Trigger",
+  group: "triggers.tekton.dev",
+  singularName: "trigger",
+  pluralName: "triggers",
+} as const satisfies K8sResourceConfig;

--- a/packages/shared/src/models/k8s/groups/Tekton/Trigger/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Trigger/index.ts
@@ -1,0 +1,4 @@
+export * from "./schema.js";
+export * from "./types.js";
+export * from "./constants.js";
+export * from "./labels.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/Trigger/labels.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Trigger/labels.ts
@@ -1,0 +1,1 @@
+export const triggerLabels = {} as const;

--- a/packages/shared/src/models/k8s/groups/Tekton/Trigger/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Trigger/schema.ts
@@ -1,0 +1,52 @@
+import z from "zod";
+import { kubeObjectBaseSchema } from "../../../common/index.js";
+
+const triggerInterceptorSchema = z
+  .object({
+    ref: z
+      .object({
+        name: z.string().optional(),
+        kind: z.string().optional(),
+      })
+      .catchall(z.any())
+      .optional(),
+    params: z
+      .array(
+        z
+          .object({
+            name: z.string(),
+            value: z.unknown(),
+          })
+          .catchall(z.any())
+      )
+      .optional(),
+  })
+  .catchall(z.any());
+
+const triggerBindingRefSchema = z
+  .object({
+    ref: z.string().optional(),
+    kind: z.string().optional(),
+  })
+  .catchall(z.any());
+
+export const triggerSpecSchema = z
+  .object({
+    name: z.string().optional(),
+    interceptors: z.array(triggerInterceptorSchema).optional(),
+    bindings: z.array(triggerBindingRefSchema).optional(),
+    template: z
+      .object({
+        ref: z.string().optional(),
+      })
+      .catchall(z.any())
+      .optional(),
+    triggerRef: z.string().optional(),
+  })
+  .catchall(z.any());
+
+export const triggerSchema = kubeObjectBaseSchema
+  .extend({
+    spec: triggerSpecSchema.optional(),
+  })
+  .catchall(z.any());

--- a/packages/shared/src/models/k8s/groups/Tekton/Trigger/types.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Trigger/types.ts
@@ -1,0 +1,4 @@
+import z from "zod";
+import { triggerSchema } from "./schema.js";
+
+export type Trigger = z.infer<typeof triggerSchema>;

--- a/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/constants.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/constants.ts
@@ -1,0 +1,10 @@
+import { K8sResourceConfig } from "../../../common/index.js";
+
+export const k8sTriggerBindingConfig = {
+  apiVersion: "triggers.tekton.dev/v1beta1",
+  version: "v1beta1",
+  kind: "TriggerBinding",
+  group: "triggers.tekton.dev",
+  singularName: "triggerbinding",
+  pluralName: "triggerbindings",
+} as const satisfies K8sResourceConfig;

--- a/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/index.ts
@@ -1,0 +1,4 @@
+export * from "./schema.js";
+export * from "./types.js";
+export * from "./constants.js";
+export * from "./labels.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/labels.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/labels.ts
@@ -1,0 +1,1 @@
+export const triggerBindingLabels = {} as const;

--- a/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/schema.ts
@@ -1,0 +1,21 @@
+import z from "zod";
+import { kubeObjectBaseSchema } from "../../../common/index.js";
+
+export const triggerBindingParamSchema = z
+  .object({
+    name: z.string(),
+    value: z.unknown(),
+  })
+  .catchall(z.any());
+
+export const triggerBindingSpecSchema = z
+  .object({
+    params: z.array(triggerBindingParamSchema).optional(),
+  })
+  .catchall(z.any());
+
+export const triggerBindingSchema = kubeObjectBaseSchema
+  .extend({
+    spec: triggerBindingSpecSchema.optional(),
+  })
+  .catchall(z.any());

--- a/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/types.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/TriggerBinding/types.ts
@@ -1,0 +1,4 @@
+import z from "zod";
+import { triggerBindingSchema } from "./schema.js";
+
+export type TriggerBinding = z.infer<typeof triggerBindingSchema>;

--- a/packages/shared/src/models/k8s/groups/Tekton/TriggerTemplate/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/TriggerTemplate/schema.ts
@@ -12,11 +12,42 @@ const triggerTemplateLabelsSchema = z.object({
   [triggerTemplateLabels.pipelineType]: pipelineTypeEnum.optional(),
 });
 
+const resourceTemplateSchema = z
+  .object({
+    spec: z
+      .object({
+        pipelineRef: z
+          .object({
+            name: z.string().optional(),
+          })
+          .catchall(z.any())
+          .optional(),
+      })
+      .catchall(z.any())
+      .optional(),
+  })
+  .catchall(z.any());
+
+const triggerTemplateSpecSchema = z
+  .object({
+    resourcetemplates: z.array(resourceTemplateSchema).optional(),
+    params: z
+      .array(
+        z
+          .object({ name: z.string(), description: z.string().optional(), default: z.string().optional() })
+          .catchall(z.any())
+      )
+      .optional(),
+  })
+  .catchall(z.any());
+
 export const triggerTemplateSchema = kubeObjectBaseSchema
   .extend({
     metadata: kubeObjectMetadataSchema.extend({
-      labels: triggerTemplateLabelsSchema,
+      // Optional because TriggerTemplates created outside the portal may not carry the pipelinetype label.
+      labels: triggerTemplateLabelsSchema.optional(),
     }),
+    spec: triggerTemplateSpecSchema.optional(),
   })
   .catchall(z.any());
 

--- a/packages/shared/src/models/k8s/groups/Tekton/common/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/common/schema.ts
@@ -34,3 +34,20 @@ export const taskRefSchema = z.object({
   params: z.array(paramValueSchema).optional(),
   resolver: z.string().optional(),
 });
+
+// Shared client config schema used by Interceptor and ClusterInterceptor
+export const clientConfigSchema = z
+  .object({
+    url: z.string().optional(),
+    service: z
+      .object({
+        name: z.string().optional(),
+        namespace: z.string().optional(),
+        port: z.number().optional(),
+        path: z.string().optional(),
+        caBundle: z.string().optional(),
+      })
+      .catchall(z.any())
+      .optional(),
+  })
+  .catchall(z.any());

--- a/packages/shared/src/models/k8s/groups/Tekton/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/index.ts
@@ -4,3 +4,8 @@ export * from "./PipelineRun/index.js";
 export * from "./Task/index.js";
 export * from "./TaskRun/index.js";
 export * from "./TriggerTemplate/index.js";
+export * from "./EventListener/index.js";
+export * from "./Trigger/index.js";
+export * from "./TriggerBinding/index.js";
+export * from "./Interceptor/index.js";
+export * from "./ClusterInterceptor/index.js";

--- a/packages/trpc/src/routers/pipelineRun/procedures/start/index.test.ts
+++ b/packages/trpc/src/routers/pipelineRun/procedures/start/index.test.ts
@@ -233,8 +233,11 @@ describe("pipelineRun.start", () => {
     await expect(caller.pipelineRun.start({ ...baseInput, pipeline: "Foo_Build" })).rejects.toThrow();
   });
 
-  it("null draft from createPipelineRunDraftFromPipeline → INTERNAL_SERVER_ERROR", async () => {
-    // TriggerTemplate with no resourcetemplates → helper returns null.
+  it("TT with empty resourcetemplates falls back to a minimal PipelineRun draft", async () => {
+    // A TriggerTemplate that exists but carries no resourcetemplates is a
+    // misconfiguration the user can still recover from — we build a minimal
+    // PipelineRun pinned to the requested pipeline rather than failing the
+    // start request. Dead `if (!baseDraft)` removed accordingly.
     const pipelineWithTT = {
       ...minimalPipeline,
       metadata: {
@@ -250,14 +253,15 @@ describe("pipelineRun.start", () => {
     };
 
     mockK8sClientInstance.getResource.mockResolvedValueOnce(pipelineWithTT).mockResolvedValueOnce(emptyTriggerTemplate);
+    mockK8sClientInstance.createResource.mockResolvedValueOnce(minimalCreatedPipelineRun);
 
     const caller = createCaller(mockContext);
-    await expect(caller.pipelineRun.start(baseInput)).rejects.toMatchObject({
-      code: "INTERNAL_SERVER_ERROR",
-      message: expect.stringContaining("failed to build PipelineRun draft"),
-    });
+    const result = await caller.pipelineRun.start(baseInput);
 
-    expect(mockK8sClientInstance.createResource).not.toHaveBeenCalled();
+    expect(result.kind).toBe("created");
+    expect(mockK8sClientInstance.createResource).toHaveBeenCalledOnce();
+    const [, , draft] = mockK8sClientInstance.createResource.mock.calls[0];
+    expect((draft as { spec: { pipelineRef: { name: string } } }).spec.pipelineRef.name).toBe("foo-build");
   });
 
   it("TT path: $(tt.params.*) placeholders resolved to Pipeline defaults before create", async () => {

--- a/packages/trpc/src/routers/pipelineRun/procedures/start/index.ts
+++ b/packages/trpc/src/routers/pipelineRun/procedures/start/index.ts
@@ -82,14 +82,10 @@ export const pipelineRunStartProcedure = protectedProcedure
       );
     }
 
+    // createPipelineRunDraftFromPipeline always returns a draft: the TT path
+    // gracefully falls through to a minimal builder when the TriggerTemplate
+    // is missing resourcetemplates.
     const baseDraft = createPipelineRunDraftFromPipeline(triggerTemplate, pipeline);
-    if (!baseDraft) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: `failed to build PipelineRun draft for '${input.pipeline}'`,
-      });
-    }
-
     const draft = prepareStartDraft(baseDraft, input.pipeline, input.namespace, input.params, input.labels);
 
     // Return the resource as an object so transport layers (tRPC + Fastify)


### PR DESCRIPTION
Adds a "Webhook Triggers" section to the KubeRocketCI portal that lists Tekton Triggers resources (EventListener, Trigger, TriggerTemplate, TriggerBinding, Interceptor, ClusterInterceptor) and renders an interactive DAG topology on the EventListener detail page.

Architecture: three layers — shared K8s models with Zod schemas, client watch-hook factories (one wrapper per resource), and presentation (list/detail pages, topology resolution hook, EventFlowDiagram). All cross-resource composition happens client-side via React.useMemo; no new tRPC procedures.

Highlights:
- 5 new shared K8s resource models (read-only) under Tekton group + Tekton barrel update exposing them via @my-project/shared.
- Client watch-hook factories per resource (reuses existing createUseWatchListHook / createUseWatchItemHook / createUsePermissionsHook).
- 6 list pages (event-listener, trigger, trigger-template, trigger-binding, interceptor, cluster-interceptor) with route + filter + columns. Cluster-scoped ClusterInterceptor list omits the Namespace column and namespace filter.
- 5 secondary detail pages (Trigger / TriggerTemplate / TriggerBinding / Interceptor / ClusterInterceptor) with Overview + UsedBy + ViewYAML tabs reusing the existing CodeEditor.
- EventListener detail page composing a topology DAG hero with two metric cards (Triggers configured, Triggered runs · 24h).
- Pure buildTopology helper resolving every cross-reference (EL → Trigger → bindings/interceptors/template → pipelineRef + GitServer link + latest PipelineRun) with comprehensive unit tests.
- useEventListenerTopology hook composing 8 watches and feeding buildTopology.
- EventFlowDiagram (xyflow + dagre): 7 typed node renderers, missing-ref fallback, configurable layout/density/edge style, side-drawer with details + YAML, MiniMap with dark-mode-aware colors.
- Refactor: extract MetricCard from modules/platform/security/shared to core/components/MetricCard for cross-module reuse.
- 12 new routes registered under routeCICD; sidebar subgroup "Webhook Triggers" added under "CI/CD Pipelines".
