### PR TITLE
EPMDEDP-16849: refactor: Remove ConfigMap-based GitFusion feature gate

### DIFF
--- a/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/BranchName/index.tsx
+++ b/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/BranchName/index.tsx
@@ -8,7 +8,6 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
 import { useTRPCClient } from "@/core/providers/trpc";
-import { useWatchKRCIConfig } from "@/k8s/api/groups/Core/ConfigMap/hooks/useWatchKRCIConfig";
 import { RotateCw } from "lucide-react";
 import { useStore } from "@tanstack/react-form";
 
@@ -23,18 +22,12 @@ export const BranchName = ({ codebase, defaultBranchVersion }: BranchNameProps) 
     }))
   );
 
-  const krciConfigMapWatch = useWatchKRCIConfig();
-  const krciConfigMap = krciConfigMapWatch.data;
-  const apiBaseUrl = krciConfigMap?.data?.api_gateway_url;
-
   const codebaseGitUrlPath = codebase.spec.gitUrlPath;
   const codebaseGitServer = codebase.spec.gitServer;
   const codebaseRepoName = codebaseGitUrlPath.split("/").at(-1) || "";
   const codebaseOwner = codebaseGitUrlPath.split("/").filter(Boolean).slice(0, -1).join("/");
 
-  const canLoadBranches = React.useMemo(() => {
-    return !!apiBaseUrl && !!codebaseGitServer && !!codebaseOwner && !!codebaseRepoName;
-  }, [apiBaseUrl, codebaseGitServer, codebaseOwner, codebaseRepoName]);
+  const canLoadBranches = !!codebaseGitServer && !!codebaseOwner && !!codebaseRepoName;
 
   const query = useQuery({
     queryKey: ["branchList", codebaseGitServer, codebaseOwner, codebaseRepoName],
@@ -107,17 +100,7 @@ export const BranchName = ({ codebase, defaultBranchVersion }: BranchNameProps) 
     });
   }, [invalidateBranchListCacheMutation, query]);
 
-  const helperText = React.useMemo(() => {
-    if (!apiBaseUrl) {
-      return "Branches auto-discovery cannot be performed.";
-    }
-
-    if (query.isError) {
-      return "Branches auto-discovery could not be performed.";
-    }
-
-    return " ";
-  }, [apiBaseUrl, query.isError]);
+  const helperText = query.isError ? "Branches auto-discovery could not be performed." : " ";
 
   return (
     <div>
@@ -135,7 +118,7 @@ export const BranchName = ({ codebase, defaultBranchVersion }: BranchNameProps) 
             options={branchesOptions}
             disabled={releaseFieldValue}
             freeSolo={true}
-            loading={!!apiBaseUrl && query.isLoading}
+            loading={query.isLoading}
             helperText={helperText}
             suffix={
               canLoadBranches ? (

--- a/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/FromCommit/index.tsx
+++ b/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/FromCommit/index.tsx
@@ -1,5 +1,4 @@
 import { useTRPCClient } from "@/core/providers/trpc";
-import { useWatchKRCIConfig } from "@/k8s/api/groups/Core/ConfigMap/hooks/useWatchKRCIConfig";
 import { useClusterStore } from "@/k8s/store";
 import { useQuery } from "@tanstack/react-query";
 import React from "react";
@@ -39,10 +38,6 @@ export const FromCommit = ({ codebase, defaultBranch }: FromCommitProps) => {
     }))
   );
 
-  const krciConfigMapWatch = useWatchKRCIConfig();
-  const krciConfigMap = krciConfigMapWatch.data;
-  const apiBaseUrl = krciConfigMap?.data?.api_gateway_url;
-
   const codebaseGitUrlPath = codebase.spec.gitUrlPath;
   const codebaseGitServer = codebase.spec.gitServer;
   const codebaseRepoName = codebaseGitUrlPath.split("/").at(-1) || "";
@@ -58,7 +53,7 @@ export const FromCommit = ({ codebase, defaultBranch }: FromCommitProps) => {
         namespace: defaultNamespace,
         clusterName,
       }),
-    enabled: !!apiBaseUrl && !!codebaseGitServer && !!codebaseOwner && !!codebaseRepoName,
+    enabled: !!codebaseGitServer && !!codebaseOwner && !!codebaseRepoName,
     staleTime: 0,
     refetchOnMount: true,
   });
@@ -89,17 +84,7 @@ export const FromCommit = ({ codebase, defaultBranch }: FromCommitProps) => {
     );
   }, [releaseValue, defaultBranch, query.isLoading, query.isError, query.data, defaultBranchOption]);
 
-  const helperText = React.useMemo(() => {
-    if (!apiBaseUrl) {
-      return "Branches auto-discovery cannot be performed.";
-    }
-
-    if (query.isError) {
-      return "Branches auto-discovery could not be performed.";
-    }
-
-    return " ";
-  }, [apiBaseUrl, query.isError]);
+  const helperText = query.isError ? "Branches auto-discovery could not be performed." : " ";
 
   const fromTypeOptions = React.useMemo(() => {
     return FROM_TYPE_OPTIONS.map((option) => ({
@@ -141,7 +126,7 @@ export const FromCommit = ({ codebase, defaultBranch }: FromCommitProps) => {
                 options={branchesOptions}
                 disabled={query.isLoading}
                 helperText={helperText}
-                loading={!!apiBaseUrl && query.isLoading}
+                loading={query.isLoading}
                 freeSolo={true}
               />
             )}

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/__mocks__/index.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/__mocks__/index.ts
@@ -115,9 +115,6 @@ export const mockGitOrganizations = [
   { name: "company-name" },
 ];
 
-/**
- * Mock KRCI Config for API gateway URL
- */
 export const mockKRCIConfig = {
   apiVersion: "v1",
   kind: "ConfigMap",
@@ -126,7 +123,6 @@ export const mockKRCIConfig = {
     namespace: "default",
   },
   data: {
-    api_gateway_url: "http://localhost:3000/api",
     cluster_name: "test-cluster",
   },
 };

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/Owner/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/Owner/index.tsx
@@ -5,7 +5,6 @@ import { gitProvider } from "@my-project/shared";
 import { useTRPCClient } from "@/core/providers/trpc";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
-import { useWatchKRCIConfig } from "@/k8s/api/groups/Core/ConfigMap/hooks/useWatchKRCIConfig";
 import { useGitServerWatchItem } from "@/k8s/api/groups/KRCI/GitServer";
 import { useCreateCodebaseForm } from "../../../providers/form/hooks";
 import { NAMES } from "../../../names";
@@ -19,9 +18,6 @@ export const Owner: React.FC = () => {
   const gitServerProvider = gitServerWatch.data?.spec?.gitProvider;
   const isGerrit = gitServerProvider?.includes(gitProvider.gerrit);
 
-  const krciConfigMapWatch = useWatchKRCIConfig();
-  const apiBaseUrl = krciConfigMapWatch.data?.data?.api_gateway_url;
-
   const { clusterName, defaultNamespace } = useClusterStore(
     useShallow((s) => ({ clusterName: s.clusterName, defaultNamespace: s.defaultNamespace }))
   );
@@ -34,7 +30,7 @@ export const Owner: React.FC = () => {
         namespace: defaultNamespace,
         clusterName,
       }),
-    enabled: !!apiBaseUrl && !!gitServerFieldValue,
+    enabled: !!gitServerFieldValue,
   });
 
   const options = React.useMemo(() => {
@@ -42,11 +38,7 @@ export const Owner: React.FC = () => {
     return ownerQuery.data.data?.map(({ name }: { name: string }) => ({ label: name, value: name })) ?? [];
   }, [ownerQuery.data, ownerQuery.isError, ownerQuery.isLoading]);
 
-  const helperText = React.useMemo(() => {
-    if (!apiBaseUrl) return "Owners auto-discovery cannot be performed.";
-    if (ownerQuery.isError) return "Owners auto-discovery could not be performed.";
-    return "";
-  }, [apiBaseUrl, ownerQuery.isError]);
+  const helperText = ownerQuery.isError ? "Owners auto-discovery could not be performed." : "";
 
   return (
     <form.AppField
@@ -68,7 +60,7 @@ export const Owner: React.FC = () => {
           placeholder="owner"
           options={options}
           freeSolo
-          loading={!!apiBaseUrl && ownerQuery.isLoading}
+          loading={ownerQuery.isLoading}
           helperText={helperText}
         />
       )}

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/RepositoryName/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/RepositoryName/index.tsx
@@ -5,7 +5,6 @@ import { codebaseCreationStrategy, gitProvider } from "@my-project/shared";
 import { useTRPCClient } from "@/core/providers/trpc";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
-import { useWatchKRCIConfig } from "@/k8s/api/groups/Core/ConfigMap/hooks/useWatchKRCIConfig";
 import { useGitServerWatchItem } from "@/k8s/api/groups/KRCI/GitServer";
 import { validationRules } from "@/core/constants/validation";
 import { validateField } from "@/core/utils/forms/validation";
@@ -23,9 +22,6 @@ export const RepositoryName: React.FC = () => {
   const gitServerProvider = gitServerWatch.data?.spec?.gitProvider;
   const isGerrit = gitServerProvider?.includes(gitProvider.gerrit);
 
-  const krciConfigMapWatch = useWatchKRCIConfig();
-  const apiBaseUrl = krciConfigMapWatch.data?.data?.api_gateway_url;
-
   const { clusterName, defaultNamespace } = useClusterStore(
     useShallow((s) => ({ clusterName: s.clusterName, defaultNamespace: s.defaultNamespace }))
   );
@@ -39,7 +35,7 @@ export const RepositoryName: React.FC = () => {
         namespace: defaultNamespace,
         clusterName,
       }),
-    enabled: !!apiBaseUrl && !!gitServerFieldValue && !!ownerFieldValue,
+    enabled: !!gitServerFieldValue && !!ownerFieldValue,
   });
 
   const repositoryOptions = React.useMemo(() => {
@@ -52,11 +48,7 @@ export const RepositoryName: React.FC = () => {
     );
   }, [repoListQuery.data, repoListQuery.isError, repoListQuery.isLoading]);
 
-  const helperText = React.useMemo(() => {
-    if (!apiBaseUrl) return "Repositories auto-discovery cannot be performed.";
-    if (repoListQuery.isError) return "Repositories auto-discovery could not be performed.";
-    return "";
-  }, [apiBaseUrl, repoListQuery.isError]);
+  const helperText = repoListQuery.isError ? "Repositories auto-discovery could not be performed." : "";
 
   const isImportStrategy = strategyFieldValue === codebaseCreationStrategy.import;
 
@@ -102,7 +94,7 @@ export const RepositoryName: React.FC = () => {
             placeholder="repository_name"
             options={repositoryOptions}
             freeSolo
-            loading={!!apiBaseUrl && repoListQuery.isLoading}
+            loading={repoListQuery.isLoading}
             helperText={helperText}
             disabled={!ownerFieldValue}
           />

--- a/apps/client/src/modules/platform/configuration/modules/gitops/components/CreateGitOpsForm/components/fields/Owner/index.tsx
+++ b/apps/client/src/modules/platform/configuration/modules/gitops/components/CreateGitOpsForm/components/fields/Owner/index.tsx
@@ -4,7 +4,6 @@ import { gitProvider } from "@my-project/shared";
 import { useTRPCClient } from "@/core/providers/trpc";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
-import { useWatchKRCIConfig } from "@/k8s/api/groups/Core/ConfigMap/hooks/useWatchKRCIConfig";
 import { useStore } from "@tanstack/react-form";
 import { CODEBASE_FORM_NAMES } from "../../../constants";
 import { useCreateGitOpsForm } from "../../../providers/form/hooks";
@@ -13,9 +12,6 @@ export const Owner = () => {
   const trpc = useTRPCClient();
   const gitServerFieldValue = useStore(form.store, (s) => s.values[CODEBASE_FORM_NAMES.GIT_SERVER]);
   const repositoryNameFieldValue = useStore(form.store, (s) => s.values[CODEBASE_FORM_NAMES.UI_REPOSITORY_NAME]);
-
-  const krciConfigMapWatch = useWatchKRCIConfig();
-  const apiBaseUrl = krciConfigMapWatch.data?.data?.api_gateway_url;
 
   const { clusterName, defaultNamespace } = useClusterStore(
     useShallow((s) => ({ clusterName: s.clusterName, defaultNamespace: s.defaultNamespace }))
@@ -29,7 +25,7 @@ export const Owner = () => {
         namespace: defaultNamespace,
         clusterName,
       }),
-    enabled: !!apiBaseUrl && !!gitServerFieldValue,
+    enabled: !!gitServerFieldValue,
   });
 
   const options = React.useMemo(() => {
@@ -37,11 +33,7 @@ export const Owner = () => {
     return ownerQuery.data.data?.map(({ name }: { name: string }) => ({ label: name, value: name })) ?? [];
   }, [ownerQuery.data, ownerQuery.isError, ownerQuery.isLoading]);
 
-  const helperText = React.useMemo(() => {
-    if (!apiBaseUrl) return "Owners auto-discovery cannot be performed.";
-    if (ownerQuery.isError) return "Owners auto-discovery could not be performed.";
-    return "";
-  }, [apiBaseUrl, ownerQuery.isError]);
+  const helperText = ownerQuery.isError ? "Owners auto-discovery could not be performed." : "";
 
   return (
     <form.AppField
@@ -68,7 +60,7 @@ export const Owner = () => {
           placeholder="owner"
           options={options}
           freeSolo
-          loading={!!apiBaseUrl && ownerQuery.isLoading}
+          loading={ownerQuery.isLoading}
           helperText={helperText}
         />
       )}

--- a/apps/client/src/modules/platform/configuration/modules/gitops/components/CreateGitOpsForm/components/fields/RepositoryName/index.tsx
+++ b/apps/client/src/modules/platform/configuration/modules/gitops/components/CreateGitOpsForm/components/fields/RepositoryName/index.tsx
@@ -4,7 +4,6 @@ import { codebaseCreationStrategy, gitProvider } from "@my-project/shared";
 import { useTRPCClient } from "@/core/providers/trpc";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
-import { useWatchKRCIConfig } from "@/k8s/api/groups/Core/ConfigMap/hooks/useWatchKRCIConfig";
 import { validationRules } from "@/core/constants/validation";
 import { validateField } from "@/core/utils/forms/validation";
 import { useStore } from "@tanstack/react-form";
@@ -16,9 +15,6 @@ export const RepositoryName = () => {
   const gitServerFieldValue = useStore(form.store, (s) => s.values[CODEBASE_FORM_NAMES.GIT_SERVER]);
   const ownerFieldValue = useStore(form.store, (s) => s.values[CODEBASE_FORM_NAMES.UI_REPOSITORY_OWNER]);
   const strategyFieldValue = useStore(form.store, (s) => s.values[CODEBASE_FORM_NAMES.STRATEGY]);
-
-  const krciConfigMapWatch = useWatchKRCIConfig();
-  const apiBaseUrl = krciConfigMapWatch.data?.data?.api_gateway_url;
 
   const { clusterName, defaultNamespace } = useClusterStore(
     useShallow((s) => ({ clusterName: s.clusterName, defaultNamespace: s.defaultNamespace }))
@@ -33,7 +29,7 @@ export const RepositoryName = () => {
         namespace: defaultNamespace,
         clusterName,
       }),
-    enabled: !!apiBaseUrl && !!gitServerFieldValue && !!ownerFieldValue,
+    enabled: !!gitServerFieldValue && !!ownerFieldValue,
   });
 
   const repositoryOptions = React.useMemo(() => {
@@ -46,11 +42,7 @@ export const RepositoryName = () => {
     );
   }, [repoListQuery.data, repoListQuery.isError, repoListQuery.isLoading]);
 
-  const helperText = React.useMemo(() => {
-    if (!apiBaseUrl) return "Repositories auto-discovery cannot be performed.";
-    if (repoListQuery.isError) return "Repositories auto-discovery could not be performed.";
-    return undefined;
-  }, [apiBaseUrl, repoListQuery.isError]);
+  const helperText = repoListQuery.isError ? "Repositories auto-discovery could not be performed." : undefined;
 
   const isImportStrategy = strategyFieldValue === codebaseCreationStrategy.import;
 
@@ -96,7 +88,7 @@ export const RepositoryName = () => {
             placeholder="repository_name"
             options={repositoryOptions}
             freeSolo
-            loading={!!apiBaseUrl && repoListQuery.isLoading}
+            loading={repoListQuery.isLoading}
             helperText={helperText}
             disabled={!ownerFieldValue}
           />

--- a/packages/trpc/src/clients/gitfusion/index.ts
+++ b/packages/trpc/src/clients/gitfusion/index.ts
@@ -65,7 +65,7 @@ const config = loadConfig();
 export function createGitFusionClient(): GitFusionClient {
   if (!config.apiBaseURL) {
     throw new TRPCError({
-      code: "INTERNAL_SERVER_ERROR",
+      code: "PRECONDITION_FAILED",
       message: "GITFUSION_URL environment variable is not configured",
     });
   }


### PR DESCRIPTION
Rely on server-side GITFUSION_URL validation instead of client-side api_gateway_url ConfigMap key. Simplifies 6 form-field components by removing the useWatchKRCIConfig dependency and conditional "cannot be performed" messages. When GitFusion is unreachable, queries now fail and display "could not be performed" via existing error handling. Changed GitFusion client to return PRECONDITION_FAILED instead of INTERNAL_SERVER_ERROR when GITFUSION_URL is unset, reducing log noise for misconfigured environments. Also simplified redundant useMemo hooks into direct const expressions for better code clarity.
