### PR TITLE
EPMDEDP-17031: fix: Align inputDockerStreams with applications positionally in create wizard

### DIFF
--- a/apps/client/src/modules/platform/cdpipelines/pages/create/components/CreateCDPipelineWizard/components/Applications/index.test.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/create/components/CreateCDPipelineWizard/components/Applications/index.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import React from "react";
+
+// ---- Module mocks must be hoisted before importing the component under test ----
+
+const mockUseCodebaseWatchList = vi.fn();
+const mockUseCodebaseBranchWatchList = vi.fn();
+
+vi.mock("@/k8s/api/groups/KRCI/Codebase", () => ({
+  useCodebaseWatchList: (opts: unknown) => mockUseCodebaseWatchList(opts),
+}));
+
+vi.mock("@/k8s/api/groups/KRCI/CodebaseBranch/hooks", () => ({
+  useCodebaseBranchWatchList: (opts: unknown) => mockUseCodebaseBranchWatchList(opts),
+}));
+
+// Replace the heavy combobox with a stub that exposes the renderSelectedContent
+// callback so application cards still mount under the form provider.
+vi.mock("@/core/components/form/components/FormCombobox", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  FormCombobox: (props: any) => {
+    const { renderSelectedContent, data, options } = props;
+    if (!renderSelectedContent || !data?.form) return null;
+    const selectedValues = (data.form.getFieldValue("applications") as string[]) ?? [];
+    return (
+      <div data-testid="form-combobox-stub">
+        {renderSelectedContent({
+          selectedValues,
+          data,
+          options: options ?? [],
+          onRemove: () => {},
+        })}
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/core/components/misc/LoadingWrapper", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  LoadingWrapper: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock("@/core/components/sprites/K8sRelatedIconsSVGSprite", () => ({
+  UseSpriteSymbol: () => null,
+}));
+
+// ---- imports under test (after mocks) ----
+import { Applications } from "./index";
+import { CreateCDPipelineFormProvider } from "../../providers/form/provider";
+import { CreateCDPipelineFormContext, type CreateCDPipelineFormInstance } from "../../providers/form/context";
+import type { CreateCDPipelineFormValues } from "../../types";
+
+const codebaseLabelKey = "app.edp.epam.com/codebaseName";
+
+type FormRef = { current: CreateCDPipelineFormInstance | null };
+
+const FormCapture: React.FC<{ formRef: FormRef }> = ({ formRef }) => {
+  const form = React.useContext(CreateCDPipelineFormContext);
+  formRef.current = form;
+  return null;
+};
+
+const buildCodebase = (name: string, defaultBranch = "main") => ({
+  metadata: { name, namespace: "ns", creationTimestamp: "2024-01-01T00:00:00Z" },
+  spec: { defaultBranch, description: "", lang: "", framework: "", buildTool: "", type: "application" },
+});
+
+const buildBranch = (codebaseName: string, branchName: string) => ({
+  metadata: {
+    name: `${codebaseName}-${branchName}`,
+    namespace: "ns",
+    creationTimestamp: "2024-01-01T00:00:00Z",
+  },
+  spec: { branchName, codebaseName },
+});
+
+const renderApplications = (defaultValues: Partial<CreateCDPipelineFormValues>) => {
+  const formRef: FormRef = { current: null };
+  const utils = render(
+    <CreateCDPipelineFormProvider defaultValues={defaultValues} onSubmit={async () => {}} onSubmitError={() => {}}>
+      <FormCapture formRef={formRef} />
+      <Applications />
+    </CreateCDPipelineFormProvider>
+  );
+  return { formRef, ...utils };
+};
+
+describe("CreateCDPipelineWizard Applications", () => {
+  beforeEach(() => {
+    mockUseCodebaseWatchList.mockReset();
+    mockUseCodebaseBranchWatchList.mockReset();
+    mockUseCodebaseWatchList.mockReturnValue({
+      data: { array: [buildCodebase("app-a"), buildCodebase("app-b")] },
+      query: { isLoading: false },
+    });
+    mockUseCodebaseBranchWatchList.mockReturnValue({
+      data: { array: [] },
+      query: { isLoading: true },
+    });
+  });
+
+  describe("Bug 1: handleApplicationsChange — value-based filter on app removal", () => {
+    it("keeps inputDockerStreams in 1:1 alignment when removing an app whose appBranch was cleared (stale stream entry)", () => {
+      // Realistic precondition: both apps auto-init their branches (fieldArray and
+      // inputDockerStreams both length 2), then the user clears app-b's branch via
+      // the FormCombobox. The per-card listener early-returns on empty values, so
+      // inputDockerStreams retains the stale "app-b-main" entry while fieldArray[1].appBranch
+      // is "". The bug is what happens next, when the user removes app-b entirely.
+      const { formRef } = renderApplications({
+        name: "",
+        applications: ["app-a", "app-b"],
+        inputDockerStreams: ["app-a-main", "app-b-main"],
+        ui_applicationsFieldArray: [
+          { appName: "app-a", appBranch: "app-a-main" },
+          { appName: "app-b", appBranch: "" },
+        ],
+        ui_applicationsToPromoteAll: false,
+        description: "",
+        deploymentType: "container",
+        applicationsToPromote: [],
+      });
+
+      const form = formRef.current!;
+      act(() => {
+        form.setFieldValue("applications", ["app-a"]);
+      });
+
+      const fieldArray = form.getFieldValue("ui_applicationsFieldArray");
+      const inputDockerStreams = form.getFieldValue("inputDockerStreams") as string[];
+
+      expect(fieldArray).toHaveLength(1);
+      expect(inputDockerStreams).toHaveLength(1);
+      expect(inputDockerStreams[0]).toBe("app-a-main");
+    });
+
+    it("preserves the remaining app's branch when two apps shared the same appBranch value", () => {
+      const { formRef } = renderApplications({
+        name: "",
+        applications: ["app-a", "app-b"],
+        inputDockerStreams: ["shared-main", "shared-main"],
+        ui_applicationsFieldArray: [
+          { appName: "app-a", appBranch: "shared-main" },
+          { appName: "app-b", appBranch: "shared-main" },
+        ],
+        ui_applicationsToPromoteAll: false,
+        description: "",
+        deploymentType: "container",
+        applicationsToPromote: [],
+      });
+
+      const form = formRef.current!;
+      act(() => {
+        form.setFieldValue("applications", ["app-a"]);
+      });
+
+      const fieldArray = form.getFieldValue("ui_applicationsFieldArray");
+      const inputDockerStreams = form.getFieldValue("inputDockerStreams") as string[];
+
+      expect(fieldArray).toHaveLength(1);
+      expect(inputDockerStreams).toEqual(["shared-main"]);
+    });
+  });
+
+  describe("Bug 2: ApplicationCard auto-init effect writes positionally", () => {
+    it("writes the auto-selected branch to inputDockerStreams[index] (not append) when only the second app's branches have resolved", async () => {
+      mockUseCodebaseBranchWatchList.mockImplementation((opts: { labels: Record<string, string> }) => {
+        const codebase = opts.labels[codebaseLabelKey];
+        if (codebase === "app-b") {
+          return {
+            data: { array: [buildBranch("app-b", "main")] },
+            query: { isLoading: false },
+          };
+        }
+        return {
+          data: { array: [] },
+          query: { isLoading: true },
+        };
+      });
+
+      const { formRef } = renderApplications({
+        name: "",
+        applications: ["app-a", "app-b"],
+        inputDockerStreams: [],
+        ui_applicationsFieldArray: [
+          { appName: "app-a", appBranch: "" },
+          { appName: "app-b", appBranch: "" },
+        ],
+        ui_applicationsToPromoteAll: false,
+        description: "",
+        deploymentType: "container",
+        applicationsToPromote: [],
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const form = formRef.current!;
+      const inputDockerStreams = form.getFieldValue("inputDockerStreams") as string[];
+
+      expect(inputDockerStreams[1]).toBe("app-b-main");
+      expect(inputDockerStreams[0] ?? "").toBe("");
+    });
+  });
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/create/components/CreateCDPipelineWizard/components/Applications/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/create/components/CreateCDPipelineWizard/components/Applications/index.tsx
@@ -96,15 +96,11 @@ const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, index, o
         };
         form.setFieldValue(CREATE_CDPIPELINE_FORM_NAMES.ui_applicationsFieldArray.name, updatedFieldArray);
 
-        // Also update inputDockerStreams
-        const currentInputDockerStreams =
-          form.getFieldValue(CREATE_CDPIPELINE_FORM_NAMES.inputDockerStreams.name) || [];
-        if (!currentInputDockerStreams.includes(branchToSelect.metadata.name)) {
-          form.setFieldValue(CREATE_CDPIPELINE_FORM_NAMES.inputDockerStreams.name, [
-            ...currentInputDockerStreams,
-            branchToSelect.metadata.name,
-          ]);
-        }
+        // Write the auto-selected branch positionally so streams[i] tracks applications[i]
+        const streams = structuredClone(form.getFieldValue(CREATE_CDPIPELINE_FORM_NAMES.inputDockerStreams.name) ?? []);
+        while (streams.length <= index) streams.push("");
+        streams[index] = branchToSelect.metadata.name;
+        form.setFieldValue(CREATE_CDPIPELINE_FORM_NAMES.inputDockerStreams.name, streams);
 
         hasInitializedRef.current = true;
       }
@@ -234,16 +230,6 @@ export const Applications: React.FC = () => {
     (selectedApps: string[]) => {
       const currentFieldArray = fieldArrayValue || [];
 
-      // Remove branches from inputDockerStreams for apps that were deselected
-      const removedApps = currentFieldArray.filter((app) => !selectedApps.includes(app.appName));
-      if (removedApps.length > 0) {
-        const currentStreams =
-          (form.getFieldValue(CREATE_CDPIPELINE_FORM_NAMES.inputDockerStreams.name) as string[]) || [];
-        const branchesToRemove = removedApps.map((app) => app.appBranch).filter(Boolean);
-        const newStreams = currentStreams.filter((stream) => !branchesToRemove.includes(stream));
-        form.setFieldValue(CREATE_CDPIPELINE_FORM_NAMES.inputDockerStreams.name, newStreams);
-      }
-
       const newFieldArray = selectedApps.map((appName) => {
         const existing = currentFieldArray.find((app) => app.appName === appName);
         if (existing) {
@@ -253,6 +239,12 @@ export const Applications: React.FC = () => {
       });
 
       form.setFieldValue(CREATE_CDPIPELINE_FORM_NAMES.ui_applicationsFieldArray.name, newFieldArray);
+
+      // Rebuild inputDockerStreams from field array to guarantee index alignment
+      form.setFieldValue(
+        CREATE_CDPIPELINE_FORM_NAMES.inputDockerStreams.name,
+        newFieldArray.map((item) => item.appBranch)
+      );
 
       const applicationsToPromoteAllFieldValue =
         form.getFieldValue(CREATE_CDPIPELINE_FORM_NAMES.ui_applicationsToPromoteAll.name) || false;


### PR DESCRIPTION
Fixed two issues in the CDPipeline create wizard's Applications component that caused spec.inputDockerStreams and spec.applications arrays to drift out of alignment:

1. Rebuild from field array on selection change: the handler now atomically derives inputDockerStreams from the field array instead of using a fragile value-based filter. This mirrors the pattern already in the edit form and guarantees 1:1 positional alignment.

2. Write auto-selected branches positionally: the auto-init effect now writes to streams[index] (the card's position) instead of appending to the end and deduping by value. This ensures the order of Kubernetes API responses doesn't affect the final spec layout. Uses the same idiom as the per-card onChange listener.

Impact:
- Fixes a race condition where concurrent branch-watch API calls resolving out of order could produce a spec with matching lengths but wrong positional alignment.
- Eliminates latent value-based filtering logic that could drift lengths in edge cases (empty branches, duplicate branch values).
- Brings create wizard into alignment with the edit form's rebuild-from-field- array pattern.
