### PR TITLE
EPMDEDP-17077: fix: Fix silent save failure in resource edit forms

### DIFF
--- a/apps/client/src/modules/platform/cdpipelines/components/EditCDPipelineForm/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/components/EditCDPipelineForm/index.tsx
@@ -26,9 +26,13 @@ export const EditCDPipelineForm: React.FC<EditCDPipelineFormProps> = ({ cdPipeli
   const { triggerEditCDPipeline, mutations } = useCDPipelineCRUD();
   const { cdPipelineEditMutation } = mutations;
 
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+
   const handleSubmit = React.useCallback(
     async (values: EditCDPipelineFormValues) => {
       if (!cdPipeline) return;
+
+      setSubmitError(null);
 
       const updatedCDPipeline = editCDPipelineObject(cdPipeline, {
         description: values.description,
@@ -45,8 +49,10 @@ export const EditCDPipelineForm: React.FC<EditCDPipelineFormProps> = ({ cdPipeli
     [cdPipeline, triggerEditCDPipeline, onClose]
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onSubmitError = React.useCallback((_error: unknown) => {}, []);
+  const onSubmitError = React.useCallback((error: unknown) => {
+    console.error("Failed to prepare deployment flow update:", error);
+    setSubmitError("Failed to prepare the deployment flow update. Please review the form values and try again.");
+  }, []);
 
   const requestError = cdPipelineEditMutation.error as RequestError | null;
   const isSubmitting = cdPipelineEditMutation.isPending;
@@ -66,6 +72,7 @@ export const EditCDPipelineForm: React.FC<EditCDPipelineFormProps> = ({ cdPipeli
           cdPipeline={cdPipeline}
           onClose={onClose}
           requestError={requestError}
+          submitError={submitError}
           isSubmitting={isSubmitting}
         />
       </EditCDPipelineFormProvider>
@@ -77,10 +84,17 @@ interface WizardContentProps {
   cdPipeline: CDPipeline;
   onClose: () => void;
   requestError: RequestError | null;
+  submitError: string | null;
   isSubmitting: boolean;
 }
 
-const WizardContent: React.FC<WizardContentProps> = ({ cdPipeline, onClose, requestError, isSubmitting }) => {
+const WizardContent: React.FC<WizardContentProps> = ({
+  cdPipeline,
+  onClose,
+  requestError,
+  submitError,
+  isSubmitting,
+}) => {
   const { currentStepIdx, goToNextStep, goToPreviousStep } = useEditWizardStore(
     useShallow((state) => ({
       currentStepIdx: state.currentStepIdx,
@@ -107,9 +121,9 @@ const WizardContent: React.FC<WizardContentProps> = ({ cdPipeline, onClose, requ
         <div className="flex min-h-0 flex-1 gap-4">
           <div className="min-h-0 flex-1 overflow-y-auto p-0.5">
             <div className="flex flex-col gap-4">
-              {requestError && (
+              {(submitError || requestError) && (
                 <Alert variant="destructive" title="Failed to update deployment flow">
-                  {getK8sErrorMessage(requestError)}
+                  {submitError ?? (requestError ? getK8sErrorMessage(requestError) : "")}
                 </Alert>
               )}
               {isEditStep && <FormContent />}

--- a/apps/client/src/modules/platform/cdpipelines/components/EditStageForm/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/components/EditStageForm/index.tsx
@@ -22,9 +22,13 @@ export const EditStageForm: React.FC<EditStageFormProps> = ({ stage, onClose }) 
   const { triggerEditStage, mutations } = useStageCRUD();
   const { stageEditMutation } = mutations;
 
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+
   const handleSubmit = React.useCallback(
     async (values: EditStageFormValues) => {
       if (!stage) return;
+
+      setSubmitError(null);
 
       // Remove the 'id' field from qualityGates as it's only used for form state
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -45,8 +49,10 @@ export const EditStageForm: React.FC<EditStageFormProps> = ({ stage, onClose }) 
     [stage, triggerEditStage, onClose]
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onSubmitError = React.useCallback((_error: unknown) => {}, []);
+  const onSubmitError = React.useCallback((error: unknown) => {
+    console.error("Failed to prepare environment update:", error);
+    setSubmitError("Failed to prepare the environment update. Please review the form values and try again.");
+  }, []);
 
   const requestError = stageEditMutation.error as RequestError | null;
 
@@ -65,9 +71,9 @@ export const EditStageForm: React.FC<EditStageFormProps> = ({ stage, onClose }) 
           <div className="flex min-h-0 flex-1 gap-4">
             <div className="min-h-0 flex-1 overflow-y-auto p-0.5">
               <div className="flex flex-col gap-4">
-                {requestError && (
+                {(submitError || requestError) && (
                   <Alert variant="destructive" title="Failed to update environment">
-                    {getK8sErrorMessage(requestError)}
+                    {submitError ?? (requestError ? getK8sErrorMessage(requestError) : "")}
                   </Alert>
                 )}
                 <FormContent />

--- a/apps/client/src/modules/platform/cdpipelines/components/EditStageForm/schema.ts
+++ b/apps/client/src/modules/platform/cdpipelines/components/EditStageForm/schema.ts
@@ -6,7 +6,7 @@ const qualityGateSchema = z
   .object({
     id: z.string(),
     qualityGateType: z.nativeEnum(stageQualityGateType),
-    stepName: z.string().min(1, "Step name is required"),
+    stepName: z.string().min(2, "Step name must be at least 2 characters"),
     autotestName: z.string().nullable(),
     branchName: z.string().nullable(),
   })

--- a/apps/client/src/modules/platform/codebases/components/EditCodebaseBranchForm/index.tsx
+++ b/apps/client/src/modules/platform/codebases/components/EditCodebaseBranchForm/index.tsx
@@ -26,6 +26,8 @@ export const EditCodebaseBranchForm: React.FC<EditCodebaseBranchFormProps> = ({
   const { triggerEditCodebaseBranch, mutations } = useCodebaseBranchCRUD();
   const { codebaseBranchEditMutation } = mutations;
 
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+
   const defaultValues = React.useMemo(
     () => ({
       buildPipeline: codebaseBranch?.spec?.pipelines?.build || "",
@@ -46,6 +48,8 @@ export const EditCodebaseBranchForm: React.FC<EditCodebaseBranchFormProps> = ({
 
   const handleSubmit = React.useCallback(
     async (values: EditCodebaseBranchFormValues) => {
+      setSubmitError(null);
+
       const newCodebaseBranch = editCodebaseBranchObject(codebaseBranch, {
         pipelines: {
           build: values.buildPipeline,
@@ -62,8 +66,10 @@ export const EditCodebaseBranchForm: React.FC<EditCodebaseBranchFormProps> = ({
     [codebaseBranch, onClose, triggerEditCodebaseBranch]
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleSubmitError = React.useCallback((_error: unknown) => {}, []);
+  const handleSubmitError = React.useCallback((error: unknown) => {
+    console.error("Failed to prepare codebase branch update:", error);
+    setSubmitError("Failed to prepare the codebase branch update. Please review the form values and try again.");
+  }, []);
 
   const requestError = codebaseBranchEditMutation.error as RequestError | null;
 
@@ -85,9 +91,9 @@ export const EditCodebaseBranchForm: React.FC<EditCodebaseBranchFormProps> = ({
         <div className="flex min-h-0 flex-1 gap-4">
           <div className="min-h-0 flex-1 overflow-y-auto p-0.5">
             <div className="flex flex-col gap-4">
-              {requestError && (
+              {(submitError || requestError) && (
                 <Alert variant="destructive" title="Failed to update codebase branch">
-                  {getK8sErrorMessage(requestError)}
+                  {submitError ?? (requestError ? getK8sErrorMessage(requestError) : "")}
                 </Alert>
               )}
               <Form pipelines={pipelines} />

--- a/apps/client/src/modules/platform/codebases/components/EditCodebaseForm/index.tsx
+++ b/apps/client/src/modules/platform/codebases/components/EditCodebaseForm/index.tsx
@@ -24,9 +24,13 @@ export const EditCodebaseForm: React.FC<EditCodebaseFormProps> = ({ codebase, on
   const { triggerPatchCodebase, mutations } = useCodebaseCRUD();
   const { codebaseEditMutation } = mutations;
 
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+
   const handleSubmit = React.useCallback(
     async (values: EditCodebaseFormValues) => {
       if (!codebase) return;
+
+      setSubmitError(null);
 
       const hasJiraServerIntegration = values[EDIT_CODEBASE_FORM_NAMES.hasJiraServerIntegration];
       const commitMessagePattern = values[EDIT_CODEBASE_FORM_NAMES.commitMessagePattern];
@@ -51,8 +55,10 @@ export const EditCodebaseForm: React.FC<EditCodebaseFormProps> = ({ codebase, on
     [codebase, triggerPatchCodebase, onClose]
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onSubmitError = React.useCallback((_error: unknown) => {}, []);
+  const onSubmitError = React.useCallback((error: unknown) => {
+    console.error("Failed to prepare codebase update:", error);
+    setSubmitError("Failed to prepare the codebase update. Please review the form values and try again.");
+  }, []);
 
   const requestError = codebaseEditMutation.error as RequestError | null;
 
@@ -70,9 +76,9 @@ export const EditCodebaseForm: React.FC<EditCodebaseFormProps> = ({ codebase, on
         <div className="flex min-h-0 flex-1 gap-4">
           <div className="min-h-0 flex-1 overflow-y-auto p-0.5">
             <div className="flex flex-col gap-4">
-              {requestError && (
+              {(submitError || requestError) && (
                 <Alert variant="destructive" title="Failed to update codebase">
-                  {getK8sErrorMessage(requestError)}
+                  {submitError ?? (requestError ? getK8sErrorMessage(requestError) : "")}
                 </Alert>
               )}
               <FormContent />

--- a/packages/shared/src/models/k8s/groups/KRCI/CDPipeline/utils/editCDPipeline/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/CDPipeline/utils/editCDPipeline/index.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 import { CDPipeline, EditCDPipelineInput } from "../../types.js";
-import { editCDPipelineInputSchema, cdPipelineSchema } from "../../schema.js";
+import { editCDPipelineInputSchema } from "../../schema.js";
 
 /**
  * Updates a CDPipeline resource with editable fields
@@ -13,24 +13,18 @@ export const editCDPipelineObject = (originalCDPipeline: CDPipeline, input: Edit
     throw new ZodError(parsedInput.error.errors);
   }
 
-  // Create updated CDPipeline with only editable fields changed
-  const updatedCDPipeline: CDPipeline = {
+  // Preserve the original object (including server-managed fields) and only
+  // overwrite editable spec fields. The full object is intentionally NOT
+  // re-validated against cdPipelineSchema: a live resource can diverge from the
+  // strict schema and would otherwise fail validation here.
+  return {
     ...originalCDPipeline,
     spec: {
       ...originalCDPipeline.spec,
-      description: input.description,
-      applications: input.applications,
-      inputDockerStreams: input.inputDockerStreams,
-      applicationsToPromote: input.applicationsToPromote,
+      description: parsedInput.data.description,
+      applications: parsedInput.data.applications,
+      inputDockerStreams: parsedInput.data.inputDockerStreams,
+      applicationsToPromote: parsedInput.data.applicationsToPromote,
     },
   };
-
-  // Validate the updated CDPipeline
-  const parsedCDPipeline = cdPipelineSchema.safeParse(updatedCDPipeline);
-
-  if (!parsedCDPipeline.success) {
-    throw new ZodError(parsedCDPipeline.error.errors);
-  }
-
-  return parsedCDPipeline.data;
 };

--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/schema.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/schema.ts
@@ -44,7 +44,8 @@ const codebaseSpecSchema = z.object({
     .object({
       url: z.string(),
     })
-    .nullable(),
+    .nullable()
+    .optional(),
   strategy: codebaseCreationStrategyEnum,
   testReportFramework: z.string().nullable().optional(),
   ticketNamePattern: z.string().nullable().optional(),
@@ -66,7 +67,9 @@ const codebaseStatusSchema = z.object({
   gitWebUrl: z.string().optional(),
   lastTimeUpdated: z.string().datetime(),
   result: codebaseResultEnum,
-  status: codebaseStatusEnum,
+  // The operator types status.status as a free-form string (codebaseStatusEnum
+  // lists only the values the UI maps); keep this lenient to match the CRD.
+  status: z.string(),
   username: z.string(),
   value: z.string(),
   webHookID: z.number().int().optional(),

--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/createCodebaseDraft/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/createCodebaseDraft/index.ts
@@ -32,7 +32,7 @@ export const createCodebaseDraftInputSchema = z.object({
   jiraServer: codebaseDraftSchema.shape.spec.shape.jiraServer,
   lang: codebaseDraftSchema.shape.spec.shape.lang,
   private: codebaseDraftSchema.shape.spec.shape.private,
-  repositoryUrl: codebaseDraftSchema.shape.spec.shape.repository.unwrap().shape.url.nullable(),
+  repositoryUrl: codebaseDraftSchema.shape.spec.shape.repository.unwrap().unwrap().shape.url.nullable(),
   strategy: codebaseDraftSchema.shape.spec.shape.strategy,
   testReportFramework: codebaseDraftSchema.shape.spec.shape.testReportFramework,
   ticketNamePattern: codebaseDraftSchema.shape.spec.shape.ticketNamePattern,

--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/editCodebase/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/editCodebase/index.test.ts
@@ -98,4 +98,41 @@ describe("editCodebaseObject", () => {
       })
     ).toThrow(ZodError);
   });
+
+  it("should not throw for a live codebase whose spec/status diverge from the strict schema", () => {
+    // Mirrors a real imported codebase: the operator omits `spec.repository`
+    // entirely (the schema marks it nullable-but-required) and attaches a full
+    // status subresource. Editing must still succeed and all server-managed
+    // fields must be preserved untouched.
+    const { repository: _omitted, ...specWithoutRepository } = mockCodebase.spec;
+    const liveCodebase = {
+      ...mockCodebase,
+      spec: specWithoutRepository,
+      status: {
+        action: "setup_deployment_templates",
+        available: true,
+        failureCount: 0,
+        git: "templates_pushed",
+        lastTimeUpdated: "2024-05-28T10:00:00Z",
+        result: "success",
+        status: "created",
+        username: "system",
+        value: "active",
+        webHookRef: "12345",
+      },
+    };
+
+    const input = {
+      jiraServer: null,
+      commitMessagePattern: "^(EPMCDME-\\d+:.*)$",
+      ticketNamePattern: null,
+      jiraIssueMetadataPayload: null,
+    };
+
+    const result = editCodebaseObject(liveCodebase as any, input);
+
+    expect(result.spec.commitMessagePattern).toBe("^(EPMCDME-\\d+:.*)$");
+    expect("repository" in result.spec).toBe(false);
+    expect((result as any).status).toEqual(liveCodebase.status);
+  });
 });

--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/editCodebase/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/editCodebase/index.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 import { Codebase, EditCodebaseInput } from "../../types.js";
-import { editCodebaseInputSchema, codebaseSchema } from "../../schema.js";
+import { editCodebaseInputSchema } from "../../schema.js";
 
 /**
  * Updates a Codebase resource with editable fields
@@ -13,24 +13,18 @@ export const editCodebaseObject = (originalCodebase: Codebase, input: EditCodeba
     throw new ZodError(parsedInput.error.errors);
   }
 
-  // Create updated codebase with only editable fields changed
-  const updatedCodebase: Codebase = {
+  // Preserve the original object (including server-managed fields like status)
+  // and only overwrite the editable spec fields. The full object is intentionally
+  // NOT re-validated against codebaseSchema: a live codebase's status may be
+  // partially populated and would otherwise fail strict validation.
+  return {
     ...originalCodebase,
     spec: {
       ...originalCodebase.spec,
-      jiraServer: input.jiraServer,
-      commitMessagePattern: input.commitMessagePattern,
-      ticketNamePattern: input.ticketNamePattern,
-      jiraIssueMetadataPayload: input.jiraIssueMetadataPayload,
+      jiraServer: parsedInput.data.jiraServer,
+      commitMessagePattern: parsedInput.data.commitMessagePattern,
+      ticketNamePattern: parsedInput.data.ticketNamePattern,
+      jiraIssueMetadataPayload: parsedInput.data.jiraIssueMetadataPayload,
     },
   };
-
-  // Validate the updated codebase
-  const parsedCodebase = codebaseSchema.safeParse(updatedCodebase);
-
-  if (!parsedCodebase.success) {
-    throw new ZodError(parsedCodebase.error.errors);
-  }
-
-  return parsedCodebase.data;
 };

--- a/packages/shared/src/models/k8s/groups/KRCI/CodebaseBranch/schema.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/CodebaseBranch/schema.ts
@@ -30,7 +30,9 @@ const codebaseBranchStatusSchema = z.object({
   lastSuccessfulBuild: z.string().nullable().optional(),
   lastTimeUpdated: z.string().datetime(),
   result: codebaseBranchResultEnum,
-  status: codebaseBranchStatusEnum,
+  // The operator types status.status as a free-form string (codebaseBranchStatusEnum
+  // lists only the values the UI maps); keep this lenient to match the CRD.
+  status: z.string(),
   username: z.string(),
   value: z.string(),
   versionHistory: z.array(z.string()).nullable().optional(),

--- a/packages/shared/src/models/k8s/groups/KRCI/CodebaseBranch/utils/editCodebaseBranch/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/CodebaseBranch/utils/editCodebaseBranch/index.ts
@@ -1,5 +1,4 @@
 import { ZodError } from "zod";
-import { codebaseBranchSchema } from "../../schema.js";
 import { CodebaseBranch } from "../../types.js";
 import { editCodebaseBranchInputSchema } from "./schema.js";
 import { EditCodebaseBranchInput } from "./types.js";
@@ -14,14 +13,11 @@ export const editCodebaseBranchObject = (
     throw new ZodError(parsedInput.error.errors);
   }
 
+  // Clone and mutate only the editable field. The full object is intentionally
+  // NOT re-validated against codebaseBranchSchema: a live resource can diverge
+  // from the strict schema and would otherwise fail validation here.
   const draft = structuredClone(codebaseBranch);
-  draft.spec.pipelines = input.pipelines;
+  draft.spec.pipelines = parsedInput.data.pipelines;
 
-  const parsedDraft = codebaseBranchSchema.safeParse(draft);
-
-  if (!parsedDraft.success) {
-    throw new ZodError(parsedDraft.error.errors);
-  }
-
-  return parsedDraft.data;
+  return draft;
 };

--- a/packages/shared/src/models/k8s/groups/KRCI/CodebaseBranch/utils/editDefaultCodebaseBranch/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/CodebaseBranch/utils/editDefaultCodebaseBranch/index.ts
@@ -2,7 +2,6 @@ import { ZodError } from "zod";
 import { CodebaseBranch } from "../../types.js";
 import { editDefaultCodebaseBranchInputSchema } from "./schema.js";
 import { EditDefaultCodebaseBranchInput } from "./types.js";
-import { codebaseBranchSchema } from "../../schema.js";
 
 export const editDefaultCodebaseBranchObject = (
   defaultBranch: CodebaseBranch,
@@ -14,14 +13,11 @@ export const editDefaultCodebaseBranchObject = (
     throw new ZodError(parsedInput.error.errors);
   }
 
+  // Clone and mutate only the editable field. The full object is intentionally
+  // NOT re-validated against codebaseBranchSchema: a live resource can diverge
+  // from the strict schema and would otherwise fail validation here.
   const draft = structuredClone(defaultBranch);
-  draft.spec.version = input.version;
+  draft.spec.version = parsedInput.data.version;
 
-  const parsedDraft = codebaseBranchSchema.safeParse(draft);
-
-  if (!parsedDraft.success) {
-    throw new ZodError(parsedDraft.error.errors);
-  }
-
-  return parsedDraft.data;
+  return draft;
 };

--- a/packages/shared/src/models/k8s/groups/KRCI/QuickLink/utils/editQuickLink/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/QuickLink/utils/editQuickLink/index.ts
@@ -1,5 +1,4 @@
 import z, { ZodError } from "zod";
-import { quickLinkSchema } from "../../schema.js";
 import { QuickLink } from "../../types.js";
 
 const editQuickLinkInputSchema = z.object({
@@ -15,23 +14,19 @@ export const editQuickLink = (quickLink: QuickLink, input: z.infer<typeof editQu
     throw new ZodError(parsedInput.error.errors);
   }
 
-  const updatedQuickLink: QuickLink = {
+  // Preserve the original object (including server-managed fields) and only
+  // overwrite editable spec fields. The full object is intentionally NOT
+  // re-validated against quickLinkSchema: a live resource can diverge from the
+  // strict schema and would otherwise fail validation here.
+  return {
     ...quickLink,
     spec: {
       ...quickLink.spec,
-      url: input.url,
-      visible: input.visible,
-      icon: input.icon,
+      url: parsedInput.data.url,
+      visible: parsedInput.data.visible,
+      icon: parsedInput.data.icon,
     },
   };
-
-  const parsedUpdatedQuickLink = quickLinkSchema.safeParse(updatedQuickLink);
-
-  if (!parsedUpdatedQuickLink.success) {
-    throw new ZodError(parsedUpdatedQuickLink.error.errors);
-  }
-
-  return parsedUpdatedQuickLink.data;
 };
 
 const editQuickLinkURLInputSchema = z.object({
@@ -48,19 +43,14 @@ export const editQuickLinkURL = (
     throw new ZodError(parsedInput.error.errors);
   }
 
-  const updatedQuickLink: QuickLink = {
+  // Preserve the original object and only overwrite the editable url. The full
+  // object is intentionally NOT re-validated against quickLinkSchema: a live
+  // resource can diverge from the strict schema and would otherwise fail here.
+  return {
     ...quickLink,
     spec: {
       ...quickLink.spec,
-      url: input.url,
+      url: parsedInput.data.url,
     },
   };
-
-  const parsedUpdatedQuickLink = quickLinkSchema.safeParse(updatedQuickLink);
-
-  if (!parsedUpdatedQuickLink.success) {
-    throw new ZodError(parsedUpdatedQuickLink.error.errors);
-  }
-
-  return parsedUpdatedQuickLink.data;
 };

--- a/packages/shared/src/models/k8s/groups/KRCI/Stage/schema.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Stage/schema.ts
@@ -58,7 +58,9 @@ const stageStatusSchema = z.object({
   last_time_updated: z.string().datetime(),
   result: stageResultEnum,
   shouldBeHandled: z.boolean().default(false).optional(),
-  status: stageStatusEnum,
+  // The operator types status.status as a free-form string (stageStatusEnum
+  // lists only the values the UI maps); keep this lenient to match the CRD.
+  status: z.string(),
   username: z.string(),
   value: z.string(),
 });

--- a/packages/shared/src/models/k8s/groups/KRCI/Stage/utils/editStage/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Stage/utils/editStage/index.ts
@@ -1,6 +1,6 @@
 import { ZodError } from "zod";
 import { Stage, EditStageInput } from "../../types.js";
-import { editStageInputSchema, stageSchema } from "../../schema.js";
+import { editStageInputSchema } from "../../schema.js";
 
 /**
  * Updates a Stage resource with editable fields
@@ -13,24 +13,18 @@ export const editStageObject = (originalStage: Stage, input: EditStageInput): St
     throw new ZodError(parsedInput.error.errors);
   }
 
-  // Create updated Stage with only editable fields changed
-  const updatedStage: Stage = {
+  // Preserve the original object (including server-managed fields) and only
+  // overwrite editable spec fields. The full object is intentionally NOT
+  // re-validated against stageSchema: a live resource can diverge from the
+  // strict schema and would otherwise fail validation here.
+  return {
     ...originalStage,
     spec: {
       ...originalStage.spec,
-      triggerType: input.triggerType,
-      triggerTemplate: input.triggerTemplate,
-      cleanTemplate: input.cleanTemplate,
-      qualityGates: input.qualityGates,
+      triggerType: parsedInput.data.triggerType,
+      triggerTemplate: parsedInput.data.triggerTemplate,
+      cleanTemplate: parsedInput.data.cleanTemplate,
+      qualityGates: parsedInput.data.qualityGates,
     },
   };
-
-  // Validate the updated Stage
-  const parsedStage = stageSchema.safeParse(updatedStage);
-
-  if (!parsedStage.success) {
-    throw new ZodError(parsedStage.error.errors);
-  }
-
-  return parsedStage.data;
 };


### PR DESCRIPTION
- Remove full-object schema re-validation from edit utilities (Codebase, CodebaseBranch, CDPipeline, Stage, QuickLink). Now validate only the user input and preserve the server object, preventing ZodErrors on live object schema drift.
- Update Codebase schema: spec.repository is now .nullable().optional() to match the CRD (optional in Go, not in required list). Aligns with operator behavior for import/create strategies, which omit the key when unused.
- Widen status.status fields (Codebase, CodebaseBranch, Stage) from enums to z.string() to match CRDs, which type status as free-form strings.
- Add error surfacing to EditCodebaseForm: replace the no-op onSubmitError with console.error and a visible Alert showing the failure reason.
- Add regression test verifying editCodebaseObject succeeds for live codebases with missing spec.repository (reproduces the reported failure scenario).

