### PR TITLE
EPMDEDP-17077: fix: Align stage quality gate step name validation

### DIFF
--- a/apps/client/src/modules/platform/cdpipelines/components/EditStageForm/components/QualityGatesFieldInline/QualityGateFormFields.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/components/EditStageForm/components/QualityGatesFieldInline/QualityGateFormFields.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useStore } from "@tanstack/react-form";
-import { z } from "zod";
 import { Button } from "@/core/components/ui/button";
 import { Card } from "@/core/components/ui/card";
 import { Shield, X, Check, CheckCircle, TestTube2 } from "lucide-react";
@@ -8,6 +7,7 @@ import { stageQualityGateType, codebaseBranchLabels, codebaseLabels, codebaseTyp
 import { useCodebaseWatchList } from "@/k8s/api/groups/KRCI/Codebase";
 import { useCodebaseBranchWatchList } from "@/k8s/api/groups/KRCI/CodebaseBranch";
 import { useAppForm } from "@/core/components/form";
+import { stepNameSchema } from "../../schema";
 
 export type QualityGateFormValues = {
   qualityGateType: "manual" | "autotests";
@@ -68,6 +68,22 @@ export const QualityGateInlineForm: React.FC<QualityGateInlineFormProps> = ({
       return undefined;
     },
     [existingQualityGates, isEditing, editingGateId]
+  );
+
+  // Validate against the shared stepNameSchema so the inline form can't accept a
+  // value the main edit form would silently reject on submit.
+  const validateStepName = React.useCallback(
+    (value: string) => {
+      if (!value || value.trim().length === 0) {
+        return "Step name is required";
+      }
+      const result = stepNameSchema.safeParse(value);
+      if (!result.success) {
+        return result.error.errors[0]?.message;
+      }
+      return validateStepNameUnique(value);
+    },
+    [validateStepNameUnique]
   );
 
   // Fetch autotests
@@ -233,26 +249,9 @@ export const QualityGateInlineForm: React.FC<QualityGateInlineFormProps> = ({
             <form.AppField
               name="stepName"
               validators={{
-                onChange: ({ value }: { value: string }) => {
-                  // Check for required
-                  if (!value || value.trim().length === 0) {
-                    return "Step name is required";
-                  }
-                  // Check for duplicates
-                  return validateStepNameUnique(value);
-                },
-                onSubmit: ({ value }: { value: string }) => {
-                  if (qualityGateType !== stageQualityGateType.autotests) {
-                    return undefined;
-                  }
-
-                  const result = z.string().min(1, "Step name is required").safeParse(value);
-                  if (!result.success) {
-                    return "Step name is required";
-                  }
-
-                  return validateStepNameUnique(value);
-                },
+                onChange: ({ value }: { value: string }) => validateStepName(value),
+                onSubmit: ({ value }: { value: string }) =>
+                  qualityGateType === stageQualityGateType.autotests ? validateStepName(value) : undefined,
               }}
             >
               {(field) => (
@@ -271,26 +270,9 @@ export const QualityGateInlineForm: React.FC<QualityGateInlineFormProps> = ({
           <form.AppField
             name="stepName"
             validators={{
-              onChange: ({ value }: { value: string }) => {
-                // Check for required
-                if (!value || value.trim().length === 0) {
-                  return "Step name is required";
-                }
-                // Check for duplicates
-                return validateStepNameUnique(value);
-              },
-              onSubmit: ({ value }: { value: string }) => {
-                if (qualityGateType !== stageQualityGateType.manual) {
-                  return undefined;
-                }
-
-                const result = z.string().min(1, "Step name is required").safeParse(value);
-                if (!result.success) {
-                  return "Step name is required";
-                }
-
-                return validateStepNameUnique(value);
-              },
+              onChange: ({ value }: { value: string }) => validateStepName(value),
+              onSubmit: ({ value }: { value: string }) =>
+                qualityGateType === stageQualityGateType.manual ? validateStepName(value) : undefined,
             }}
           >
             {(field) => <field.FormTextField label="Step Name" placeholder="e.g., approve" />}

--- a/apps/client/src/modules/platform/cdpipelines/components/EditStageForm/schema.ts
+++ b/apps/client/src/modules/platform/cdpipelines/components/EditStageForm/schema.ts
@@ -2,11 +2,15 @@ import z from "zod";
 import { EDIT_STAGE_FORM_NAMES } from "./constants";
 import { stageQualityGateType } from "@my-project/shared";
 
+// Single source of truth for the step name rule. Reused by the inline quality
+// gate form so it can't accept a value this schema would reject on submit.
+export const stepNameSchema = z.string().min(2, "Step name must be at least 2 characters");
+
 const qualityGateSchema = z
   .object({
     id: z.string(),
     qualityGateType: z.nativeEnum(stageQualityGateType),
-    stepName: z.string().min(2, "Step name must be at least 2 characters"),
+    stepName: stepNameSchema,
     autotestName: z.string().nullable(),
     branchName: z.string().nullable(),
   })

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/components/QualityGates/QualityGateFormFields.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/components/QualityGates/QualityGateFormFields.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useStore } from "@tanstack/react-form";
-import { z } from "zod";
 import { Button } from "@/core/components/ui/button";
 import { Card } from "@/core/components/ui/card";
 import { Shield, X, Check, CheckCircle, TestTube2 } from "lucide-react";
@@ -8,6 +7,7 @@ import { stageQualityGateType, codebaseBranchLabels, codebaseLabels, codebaseTyp
 import { useCodebaseWatchList } from "@/k8s/api/groups/KRCI/Codebase";
 import { useCodebaseBranchWatchList } from "@/k8s/api/groups/KRCI/CodebaseBranch";
 import { useAppForm } from "@/core/components/form";
+import { stepNameSchema } from "../../names";
 
 export type QualityGateFormValues = {
   qualityGateType: "manual" | "autotests";
@@ -70,6 +70,22 @@ export const QualityGateInlineForm: React.FC<QualityGateInlineFormProps> = ({
       return undefined;
     },
     [existingQualityGates, isEditing, editingGateId]
+  );
+
+  // Validate against the shared stepNameSchema so the inline form can't accept a
+  // value the main create form would silently reject on submit.
+  const validateStepName = React.useCallback(
+    (value: string) => {
+      if (!value || value.trim().length === 0) {
+        return "Step name is required";
+      }
+      const result = stepNameSchema.safeParse(value);
+      if (!result.success) {
+        return result.error.errors[0]?.message;
+      }
+      return validateStepNameUnique(value);
+    },
+    [validateStepNameUnique]
   );
 
   // Fetch autotests
@@ -236,28 +252,9 @@ export const QualityGateInlineForm: React.FC<QualityGateInlineFormProps> = ({
             <form.AppField
               name="stepName"
               validators={{
-                onChange: ({ value }: { value: string }) => {
-                  // Check for required
-                  if (!value || value.trim().length === 0) {
-                    return "Step name is required";
-                  }
-                  // Check for duplicates
-                  return validateStepNameUnique(value);
-                },
-                onSubmit: ({ value }: { value: string }) => {
-                  // Only validate if current type is autotests
-                  if (qualityGateType !== stageQualityGateType.autotests) {
-                    return undefined;
-                  }
-
-                  const result = z.string().min(1, "Step name is required").safeParse(value);
-                  if (!result.success) {
-                    return "Step name is required";
-                  }
-
-                  // Also check for duplicates on submit
-                  return validateStepNameUnique(value);
-                },
+                onChange: ({ value }: { value: string }) => validateStepName(value),
+                onSubmit: ({ value }: { value: string }) =>
+                  qualityGateType === stageQualityGateType.autotests ? validateStepName(value) : undefined,
               }}
             >
               {(field) => (
@@ -276,28 +273,9 @@ export const QualityGateInlineForm: React.FC<QualityGateInlineFormProps> = ({
           <form.AppField
             name="stepName"
             validators={{
-              onChange: ({ value }: { value: string }) => {
-                // Check for required
-                if (!value || value.trim().length === 0) {
-                  return "Step name is required";
-                }
-                // Check for duplicates
-                return validateStepNameUnique(value);
-              },
-              onSubmit: ({ value }: { value: string }) => {
-                // Only validate if current type is manual
-                if (qualityGateType !== stageQualityGateType.manual) {
-                  return undefined;
-                }
-
-                const result = z.string().min(1, "Step name is required").safeParse(value);
-                if (!result.success) {
-                  return "Step name is required";
-                }
-
-                // Also check for duplicates on submit
-                return validateStepNameUnique(value);
-              },
+              onChange: ({ value }: { value: string }) => validateStepName(value),
+              onSubmit: ({ value }: { value: string }) =>
+                qualityGateType === stageQualityGateType.manual ? validateStepName(value) : undefined,
             }}
           >
             {(field) => <field.FormTextField label="Step Name" placeholder="e.g., approve" />}

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/names.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/names.ts
@@ -25,11 +25,15 @@ const deployNamespaceSchema = z
       "Namespace must contain only lowercase letters, numbers, and dashes. It cannot start or end with a dash, and cannot have whitespaces",
   });
 
+// Single source of truth for the step name rule. Reused by the inline quality
+// gate form so it can't accept a value this schema would reject on submit.
+export const stepNameSchema = z.string().min(2, "Step name must be at least 2 characters");
+
 const qualityGateSchema = z
   .object({
     id: z.string(),
     qualityGateType: z.nativeEnum(stageQualityGateType),
-    stepName: z.string(),
+    stepName: stepNameSchema,
     autotestName: z.string().nullable(),
     branchName: z.string().nullable(),
   })
@@ -55,15 +59,6 @@ const qualityGateSchema = z
     {
       message: "Branch is required for autotest quality gates",
       path: ["branchName"],
-    }
-  )
-  .refine(
-    (data) => {
-      return !!(data.stepName && data.stepName.trim().length > 0);
-    },
-    {
-      message: "Step name is required",
-      path: ["stepName"],
     }
   );
 


### PR DESCRIPTION
The inline quality gate form required only min(1) while the main edit schema enforces min(2), so a 1-char step name was added then rejected silently on Apply. Aligned all validator paths to min(2) so the error shows inline and invalid gates never enter the array.
