### PR TITLE
EPMDEDP-17077: feat: Add scroll-to-top/bottom controls to LogViewer

### DIFF
--- a/apps/client/src/core/components/LogViewer/index.test.tsx
+++ b/apps/client/src/core/components/LogViewer/index.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { LogViewer } from "./index";
+
+// Capture the props LazyLog is rendered with, and expose a fake virtua
+// list handle via `listRef` so the scroll controls have something to call.
+const scrollTo = vi.fn();
+const lazyLogProps: Record<string, unknown>[] = [];
+
+vi.mock("@melloware/react-logviewer", () => ({
+  LazyLog: React.forwardRef<unknown, Record<string, unknown>>(function MockLazyLog(props, ref) {
+    lazyLogProps.push(props);
+    React.useImperativeHandle(ref, () => ({
+      listRef: { current: { scrollTo, scrollSize: 5000 } },
+      appendLines: vi.fn(),
+      clear: vi.fn(),
+    }));
+    return <div data-testid="lazylog" />;
+  }),
+}));
+
+vi.mock("@/core/hooks/useTheme", () => ({ useTheme: () => "light" }));
+
+beforeEach(() => {
+  scrollTo.mockClear();
+  lazyLogProps.length = 0;
+});
+
+describe("LogViewer scroll controls", () => {
+  it("renders To top / To bottom controls when static content is present", () => {
+    render(<LogViewer content={"line 1\nline 2"} />);
+    expect(screen.getByLabelText("Scroll to top")).toBeInTheDocument();
+    expect(screen.getByLabelText("Scroll to bottom")).toBeInTheDocument();
+  });
+
+  it("does not render scroll controls when there is no content", () => {
+    render(<LogViewer content="" emptyMessage="No logs" />);
+    expect(screen.queryByLabelText("Scroll to top")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Scroll to bottom")).not.toBeInTheDocument();
+  });
+
+  it("scrolls to the very top when To top is clicked", async () => {
+    const user = userEvent.setup();
+    render(<LogViewer content={"a\nb\nc"} />);
+    await user.click(screen.getByLabelText("Scroll to top"));
+    expect(scrollTo).toHaveBeenCalledWith(0);
+  });
+
+  it("scrolls to the very bottom (scrollSize) when To bottom is clicked", async () => {
+    const user = userEvent.setup();
+    render(<LogViewer content={"a\nb\nc"} />);
+    await user.click(screen.getByLabelText("Scroll to bottom"));
+    expect(scrollTo).toHaveBeenCalledWith(5000);
+  });
+
+  it("keeps scroll controls visible across a stream clear in streaming mode (no flicker on reload)", async () => {
+    const ref = React.createRef<{ appendLines: (l: string[]) => void; clear: () => void }>();
+    // renderControls keeps the toolbar row mounted (as live callers always do).
+    render(<LogViewer streaming ref={ref} renderControls={() => <span>controls</span>} />);
+
+    ref.current?.appendLines(["live line"]);
+    expect(await screen.findByLabelText("Scroll to bottom")).toBeInTheDocument();
+
+    // Switching container clears the stream — controls must NOT disappear.
+    ref.current?.clear();
+    expect(screen.getByLabelText("Scroll to top")).toBeInTheDocument();
+    expect(screen.getByLabelText("Scroll to bottom")).toBeInTheDocument();
+  });
+
+  it("resumes auto-follow after clear() even if follow was paused (no frozen viewport on reload)", async () => {
+    const user = userEvent.setup();
+    const ref = React.createRef<{ appendLines: (l: string[]) => void; clear: () => void }>();
+    render(<LogViewer streaming ref={ref} renderControls={() => <span>controls</span>} />);
+
+    ref.current?.appendLines(["live line"]);
+    await user.click(await screen.findByLabelText("Scroll to top"));
+    expect(lazyLogProps.at(-1)?.follow).toBe(false);
+
+    // Switching container clears the stream; follow must resume for the new one.
+    ref.current?.clear();
+    await waitFor(() => expect(lazyLogProps.at(-1)?.follow).toBe(true));
+  });
+
+  it("orders the toolbar: left controls → built-in controls → right-aligned controls", () => {
+    render(
+      <LogViewer
+        content={"a\nb"}
+        renderLeftControls={() => <span>LEFT</span>}
+        renderControls={() => <span>RIGHT</span>}
+      />
+    );
+    const left = screen.getByText("LEFT");
+    const top = screen.getByLabelText("Scroll to top");
+    const right = screen.getByText("RIGHT");
+    expect(left.compareDocumentPosition(top) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(top.compareDocumentPosition(right) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("pauses follow on To top and resumes it on To bottom in streaming mode", async () => {
+    const user = userEvent.setup();
+    const ref = React.createRef<{ appendLines: (l: string[]) => void; clear: () => void }>();
+    render(<LogViewer streaming ref={ref} />);
+
+    // Surface streamed content so the controls render.
+    ref.current?.appendLines(["live line"]);
+
+    await user.click(await screen.findByLabelText("Scroll to top"));
+    // Latest render of the streaming LazyLog should have follow disabled.
+    expect(lazyLogProps.at(-1)?.follow).toBe(false);
+
+    await user.click(screen.getByLabelText("Scroll to bottom"));
+    expect(lazyLogProps.at(-1)?.follow).toBe(true);
+    expect(scrollTo).toHaveBeenCalledWith(5000);
+  });
+});

--- a/apps/client/src/core/components/LogViewer/index.tsx
+++ b/apps/client/src/core/components/LogViewer/index.tsx
@@ -1,8 +1,11 @@
-import React, { useRef, useImperativeHandle, forwardRef, useState } from "react";
+import React, { useRef, useImperativeHandle, forwardRef, useState, useCallback, useEffect } from "react";
 import { LazyLog } from "@melloware/react-logviewer";
+import { ArrowDownToLine, ArrowUpToLine } from "lucide-react";
+import { Button } from "@/core/components/ui/button";
 import { Card } from "@/core/components/ui/card";
 import { LoadingSpinner } from "@/core/components/ui/LoadingSpinner";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/core/components/ui/select";
+import { Tooltip } from "@/core/components/ui/tooltip";
 import { useTheme } from "@/core/hooks/useTheme";
 
 export interface LogViewerProps {
@@ -15,17 +18,16 @@ export interface LogViewerProps {
   /** Error message to display */
   error?: string;
   /**
-   * Custom controls to render above the log viewer.
-   * In inline mode (default) the node shares a row with the font-size selector
-   * in a `flex-1 min-w-0` slot. Set `fontSizeInline={false}` to give the caller
-   * controls their own full-width row.
+   * Custom controls rendered at the LEFT of the toolbar row, before the
+   * built-in controls (font size + scroll-to-top/bottom). Use for inputs that
+   * select what is shown, e.g. a container/pod selector or a timestamps toggle.
+   */
+  renderLeftControls?: () => React.ReactNode;
+  /**
+   * Custom controls rendered RIGHT-aligned in the toolbar row, after a flexible
+   * spacer. Use for actions like copy / download.
    */
   renderControls?: () => React.ReactNode;
-  /**
-   * When true (default) the font-size selector shares a row with `renderControls`.
-   * Set false for callers whose controls need the full row width.
-   */
-  fontSizeInline?: boolean;
   /** Loading message */
   loadingMessage?: string;
   /** Error message prefix */
@@ -163,6 +165,17 @@ const lazyLogProps = {
   highlightLineClassName: "log-viewer-highlight",
 };
 
+/** Compact secondary icon button used for the scroll-to-top/bottom controls. */
+function ScrollButton({ label, icon, onClick }: { label: string; icon: React.ReactNode; onClick: () => void }) {
+  return (
+    <Tooltip title={label}>
+      <Button variant="secondary" size="icon" onClick={onClick} aria-label={label} className="h-8 w-8">
+        {icon}
+      </Button>
+    </Tooltip>
+  );
+}
+
 /**
  * LogViewer - Generic log viewer component
  *
@@ -178,8 +191,8 @@ export const LogViewer = forwardRef<LogViewerRef, LogViewerProps>(
       streaming = false,
       isLoading = false,
       error,
+      renderLeftControls,
       renderControls,
-      fontSizeInline = true,
       loadingMessage = "Loading logs...",
       errorMessagePrefix = "Failed to load logs",
       emptyMessage = "No logs available",
@@ -192,6 +205,48 @@ export const LogViewer = forwardRef<LogViewerRef, LogViewerProps>(
     const [hasStreamContent, setHasStreamContent] = useState(false);
     const hasStreamContentRef = useRef(false);
     const [fontSize, setFontSize] = useState(11);
+    // In streaming mode LazyLog's `follow` keeps the view pinned to the latest
+    // line. Jumping to the top pauses it (so it doesn't get yanked back on the
+    // next append); jumping to the bottom resumes it.
+    const [isFollowing, setIsFollowing] = useState(true);
+
+    /** virtua list handle exposed by LazyLog: scrollTo(offset)/scrollSize.
+     * `listRef` is a LazyLog implementation detail, so guard defensively against
+     * a future library version changing or removing it. */
+    const getScrollHandle = useCallback(() => {
+      const handle = lazyLogRef.current?.listRef?.current as
+        | { scrollTo: (o: number) => void; scrollSize: number }
+        | undefined;
+      return typeof handle?.scrollTo === "function" && typeof handle.scrollSize === "number" ? handle : undefined;
+    }, []);
+
+    // The streaming LazyLog `key` includes the theme, so a theme switch remounts
+    // it as a fresh, bottom-following instance. Mirror that by resuming follow —
+    // otherwise a prior "scroll to top" (which paused follow) would leave the
+    // remounted stream frozen at the top.
+    useEffect(() => {
+      setIsFollowing(true);
+    }, [theme]);
+
+    const scrollToTop = useCallback(() => {
+      // Only pause follow once there is content to pause on. The scroll
+      // controls stay visible in streaming mode even during the initial
+      // loading overlay (to avoid flicker on clear/repopulate); pausing here
+      // before the first line arrives would leave the stream frozen at the top
+      // once it starts, with follow silently disabled for the whole session.
+      if (streaming && hasStreamContent) {
+        setIsFollowing(false);
+      }
+      getScrollHandle()?.scrollTo(0);
+    }, [streaming, hasStreamContent, getScrollHandle]);
+
+    const scrollToBottom = useCallback(() => {
+      if (streaming) {
+        setIsFollowing(true);
+      }
+      const handle = getScrollHandle();
+      handle?.scrollTo(handle.scrollSize);
+    }, [streaming, getScrollHandle]);
 
     useImperativeHandle(
       ref,
@@ -208,6 +263,10 @@ export const LogViewer = forwardRef<LogViewerRef, LogViewerProps>(
         clear: () => {
           hasStreamContentRef.current = false;
           setHasStreamContent(false);
+          // Resume auto-follow for the fresh stream — otherwise a prior
+          // "scroll to top" (which paused follow) would leave the new stream
+          // (e.g. after switching container) frozen at the top.
+          setIsFollowing(true);
           lazyLogRef.current?.clear();
         },
       }),
@@ -216,6 +275,10 @@ export const LogViewer = forwardRef<LogViewerRef, LogViewerProps>(
 
     const hasContent = streaming ? hasStreamContent : !!content;
     const showOverlay = isLoading || !!error || !hasContent;
+    // In streaming mode the LazyLog instance stays mounted across reloads
+    // (e.g. switching container), so keep the scroll controls visible to avoid
+    // them flickering each time the stream is cleared and re-populated.
+    const showScrollControls = streaming || hasContent;
 
     const fontSizeSelector = (
       <div className="flex flex-shrink-0 items-center gap-2">
@@ -235,27 +298,40 @@ export const LogViewer = forwardRef<LogViewerRef, LogViewerProps>(
       </div>
     );
 
+    // Built-in controls: font size + scroll-to-top/bottom, grouped together
+    // (kept clear of LazyLog's own search-match navigation).
+    const builtInControls = (
+      <div className="flex flex-shrink-0 items-center gap-3">
+        {fontSizeSelector}
+        {showScrollControls && (
+          <div className="flex items-center gap-1">
+            <ScrollButton label="Scroll to top" icon={<ArrowUpToLine className="h-4 w-4" />} onClick={scrollToTop} />
+            <ScrollButton
+              label="Scroll to bottom"
+              icon={<ArrowDownToLine className="h-4 w-4" />}
+              onClick={scrollToBottom}
+            />
+          </div>
+        )}
+      </div>
+    );
+
     return (
       <>
         <style>{logViewerStyles}</style>
 
         <div className="flex h-full min-h-0 flex-col gap-4 pt-1">
-          {(hasContent || renderControls) &&
-            (fontSizeInline ? (
-              <div className="flex items-end gap-3">
-                {fontSizeSelector}
-                {renderControls && <div className="min-w-0 flex-1">{renderControls()}</div>}
-              </div>
-            ) : (
-              <>
-                {renderControls && <div>{renderControls()}</div>}
-                <div className="flex justify-end">{fontSizeSelector}</div>
-              </>
-            ))}
+          {(hasContent || streaming || renderControls || renderLeftControls) && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+              {renderLeftControls && renderLeftControls()}
+              {builtInControls}
+              {renderControls && <div className="ml-auto flex-shrink-0">{renderControls()}</div>}
+            </div>
+          )}
 
           {/* Log Viewer Card */}
           <Card
-            className="relative flex min-h-0 min-h-[45svh] flex-1 flex-col overflow-hidden"
+            className="relative flex min-h-[45svh] flex-1 flex-col overflow-hidden"
             style={{ "--log-font-size": `${fontSize}px` } as React.CSSProperties}
           >
             {/* Overlay for loading/error/empty states */}
@@ -284,9 +360,16 @@ export const LogViewer = forwardRef<LogViewerRef, LogViewerProps>(
             {/* LazyLog — streaming or static mode */}
             <div className="log-viewer-container min-h-0 flex-1">
               {streaming ? (
-                <LazyLog key={`stream-${theme}`} ref={lazyLogRef} external follow extraLines={1} {...lazyLogProps} />
+                <LazyLog
+                  key={`stream-${theme}`}
+                  ref={lazyLogRef}
+                  external
+                  follow={isFollowing}
+                  extraLines={1}
+                  {...lazyLogProps}
+                />
               ) : (
-                hasContent && <LazyLog key={theme} text={content || ""} {...lazyLogProps} />
+                hasContent && <LazyLog key={theme} ref={lazyLogRef} text={content || ""} {...lazyLogProps} />
               )}
             </div>
           </Card>

--- a/apps/client/src/core/components/PodLogsTerminal/format.test.ts
+++ b/apps/client/src/core/components/PodLogsTerminal/format.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { formatLogText } from "./format";
+
+describe("formatLogText", () => {
+  describe("showTimestamps = false", () => {
+    it("strips the [[timestamp]] prefix, leaving the message", () => {
+      expect(formatLogText("[[2026-05-29T12:00:00Z]] hello world", false)).toBe("hello world");
+    });
+
+    it("strips every timestamp marker on a line", () => {
+      expect(formatLogText("[[2026-05-29T12:00:00Z]] a [[2026-05-29T12:00:01Z]] b", false)).toBe("a b");
+    });
+
+    it("strips fractional-second timestamps", () => {
+      expect(formatLogText("[[2026-05-29T12:00:00.123Z]] payload", false)).toBe("payload");
+    });
+
+    it("leaves lines without a timestamp marker unchanged", () => {
+      expect(formatLogText("plain log line", false)).toBe("plain log line");
+    });
+
+    it("strips markers across every line of a multi-line blob", () => {
+      const input = "[[2026-05-29T12:00:00Z]] first\n[[2026-05-29T12:00:01Z]] second";
+      expect(formatLogText(input, false)).toBe("first\nsecond");
+    });
+  });
+
+  describe("showTimestamps = true", () => {
+    it("replaces the raw [[...]] marker with a bracketed locale time", () => {
+      const out = formatLogText("[[2026-05-29T12:00:00Z]] hello", true);
+      // Locale/timezone of the runner is unknown, so assert structure, not an exact time.
+      expect(out).not.toContain("[[");
+      expect(out).toMatch(/^\[ .+ \] hello$/);
+    });
+
+    it("preserves the original message text alongside the formatted time", () => {
+      expect(formatLogText("[[2026-05-29T12:00:00Z]] deploy finished", true)).toContain("deploy finished");
+    });
+
+    it("leaves lines without a timestamp marker unchanged", () => {
+      expect(formatLogText("plain log line", true)).toBe("plain log line");
+    });
+
+    it("formats markers on every line of a multi-line blob", () => {
+      const input = "[[2026-05-29T12:00:00Z]] first\n[[2026-05-29T12:00:01Z]] second";
+      const lines = formatLogText(input, true).split("\n");
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toMatch(/^\[ .+ \] first$/);
+      expect(lines[1]).toMatch(/^\[ .+ \] second$/);
+    });
+
+    it("falls back to the original text for a semantically invalid timestamp", () => {
+      // Matches the digit pattern but is not a real date — must not render "Invalid Date".
+      const input = "[[9999-99-99T99:99:99Z]] message";
+      const out = formatLogText(input, true);
+      expect(out).not.toContain("Invalid Date");
+      expect(out).toBe(input);
+    });
+  });
+});

--- a/apps/client/src/core/components/PodLogsTerminal/format.ts
+++ b/apps/client/src/core/components/PodLogsTerminal/format.ts
@@ -1,0 +1,41 @@
+/** Matches the `[[<ISO-8601 UTC timestamp>]] ` prefix the log backend emits. */
+const TIMESTAMP_REGEX = /\[\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.?\d*Z)\]\]\s+/g;
+
+/**
+ * Normalizes the timestamp markers in raw log text.
+ *
+ * Accepts either a single line or a multi-line blob — every `[[...]]` marker is
+ * processed (the regex is global), so this is safe for both the streaming
+ * per-line path and the static whole-log path.
+ *
+ * - `showTimestamps=false`: strips the `[[...]]` prefix entirely.
+ * - `showTimestamps=true`: replaces it with a locale-formatted `[ ... ]` marker.
+ *   An unparseable timestamp falls back to the original matched text.
+ *
+ * Text without a timestamp marker is returned unchanged.
+ */
+export function formatLogText(text: string, showTimestamps: boolean): string {
+  if (!showTimestamps) {
+    return text.replace(TIMESTAMP_REGEX, "");
+  }
+
+  return text.replace(TIMESTAMP_REGEX, (_match, timestamp) => {
+    const date = new Date(timestamp);
+    // `new Date(badString)` never throws — it yields an Invalid Date whose
+    // toLocaleString() returns "Invalid Date". Guard explicitly so a malformed
+    // timestamp falls back to the original text instead of rendering garbage.
+    if (isNaN(date.getTime())) {
+      return _match;
+    }
+    const localeTime = date.toLocaleString(undefined, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+    return `[ ${localeTime} ] `;
+  });
+}

--- a/apps/client/src/core/components/PodLogsTerminal/index.tsx
+++ b/apps/client/src/core/components/PodLogsTerminal/index.tsx
@@ -9,6 +9,7 @@ import { LogViewer, type LogViewerRef } from "@/core/components/LogViewer";
 import { downloadTextFile, generateTimestampedLogFilename, sanitizeLogFilenamePart } from "@/core/utils/download";
 import { Pod } from "@my-project/shared";
 import { usePodLogs } from "./hooks/usePodLogs";
+import { formatLogText } from "./format";
 
 export interface PodLogsProps {
   clusterName: string;
@@ -25,32 +26,6 @@ export interface PodLogsProps {
 
 // Legacy alias for backward compatibility
 export type PodLogsTerminalProps = PodLogsProps;
-
-const TIMESTAMP_REGEX = /\[\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.?\d*Z?)\]\]\s+/g;
-
-function formatLogLine(line: string, showTimestamps: boolean): string {
-  if (!showTimestamps) {
-    return line.replace(TIMESTAMP_REGEX, "");
-  }
-
-  return line.replace(TIMESTAMP_REGEX, (_match, timestamp) => {
-    try {
-      const date = new Date(timestamp);
-      const localeTime = date.toLocaleString(undefined, {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        hour12: false,
-      });
-      return `[ ${localeTime} ] `;
-    } catch {
-      return _match;
-    }
-  });
-}
 
 export const PodLogsTerminal: React.FC<PodLogsProps> = ({
   clusterName,
@@ -108,7 +83,7 @@ export const PodLogsTerminal: React.FC<PodLogsProps> = ({
         hasStreamContentRef.current = true;
         setHasStreamContent(true);
       }
-      const formatted = lines.map((line) => formatLogLine(line, logsTimestamps));
+      const formatted = lines.map((line) => formatLogText(line, logsTimestamps));
       logViewerRef.current?.appendLines(formatted);
     },
     [logsTimestamps]
@@ -127,7 +102,7 @@ export const PodLogsTerminal: React.FC<PodLogsProps> = ({
       // If only timestamps changed and we have raw lines, re-append with new formatting
       if (prev.podName === podName && prev.container === activeContainer && prev.timestamps !== logsTimestamps) {
         if (savedLines.length > 0) {
-          const reformatted = savedLines.map((line) => formatLogLine(line, logsTimestamps));
+          const reformatted = savedLines.map((line) => formatLogText(line, logsTimestamps));
           logViewerRef.current?.appendLines(reformatted);
           rawLinesRef.current = savedLines;
         }
@@ -194,7 +169,7 @@ export const PodLogsTerminal: React.FC<PodLogsProps> = ({
   // Format logs for static mode only
   const formattedLogs = useMemo(() => {
     if (!logs) return "";
-    return formatLogLine(logs, logsTimestamps);
+    return formatLogText(logs, logsTimestamps);
   }, [logs, logsTimestamps]);
 
   // Generate download filename
@@ -206,7 +181,7 @@ export const PodLogsTerminal: React.FC<PodLogsProps> = ({
   // Copy/download use raw lines ref in streaming mode, formatted string in static mode
   const getExportContent = useCallback(() => {
     if (follow && rawLinesRef.current.length > 0) {
-      return rawLinesRef.current.map((line) => formatLogLine(line, logsTimestamps)).join("\n");
+      return rawLinesRef.current.map((line) => formatLogText(line, logsTimestamps)).join("\n");
     }
     return formattedLogs;
   }, [follow, formattedLogs, logsTimestamps]);
@@ -275,69 +250,77 @@ export const PodLogsTerminal: React.FC<PodLogsProps> = ({
 
   const hasExportContent = follow ? hasStreamContent : !!formattedLogs;
 
-  const renderControls = () => (
-    <div className="flex w-full items-end justify-between gap-4">
-      <div className="flex flex-wrap items-end gap-4">
-        {pods.length > 1 && (
-          <div className="flex min-w-[180px] flex-col gap-1.5">
-            <Label htmlFor="pod-select">Pod</Label>
-            <Select value={activePod?.metadata?.name || ""} onValueChange={handlePodChange}>
-              <SelectTrigger id="pod-select" className="h-9">
-                <SelectValue placeholder="Select pod" />
-              </SelectTrigger>
-              <SelectContent>
-                {pods.map((pod: Pod) => (
-                  <SelectItem key={pod.metadata?.name} value={pod.metadata?.name || ""}>
-                    {pod.metadata?.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
-
-        <div className="flex min-w-[200px] flex-col gap-1.5">
-          <Label htmlFor="container-select">Container</Label>
-          <Select value={activeContainer} onValueChange={handleContainerChange}>
-            <SelectTrigger id="container-select" className="h-9">
-              <SelectValue placeholder="Select container" />
+  // Left toolbar group: what to show (pod / container / timestamps).
+  // Inline labels + h-8 controls so every item matches the built-in font-size
+  // selector and scroll buttons in height and baseline.
+  const renderLeftControls = () => (
+    <div className="flex flex-shrink-0 flex-wrap items-center gap-3">
+      {pods.length > 1 && (
+        <div className="flex items-center gap-2">
+          <Label htmlFor="pod-select" className="text-muted-foreground text-xs">
+            Pod
+          </Label>
+          <Select value={activePod?.metadata?.name || ""} onValueChange={handlePodChange}>
+            <SelectTrigger id="pod-select" className="h-8 min-w-[180px] text-xs">
+              <SelectValue placeholder="Select pod" />
             </SelectTrigger>
             <SelectContent>
-              {availableContainers.map((container) => (
-                <SelectItem key={container.name} value={container.name}>
-                  {container.name} {container.type !== "container" && <em>({container.type})</em>}
+              {pods.map((pod: Pod) => (
+                <SelectItem key={pod.metadata?.name} value={pod.metadata?.name || ""} className="text-xs">
+                  {pod.metadata?.name}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
+      )}
 
-        <div className="flex items-center gap-2 pb-1">
-          <Switch checked={logsTimestamps} onCheckedChange={setLogsTimestamps} id="timestamps-switch" />
-          <Label htmlFor="timestamps-switch" className="cursor-pointer text-sm">
-            Timestamps
-          </Label>
-        </div>
+      <div className="flex items-center gap-2">
+        <Label htmlFor="container-select" className="text-muted-foreground text-xs">
+          Container
+        </Label>
+        <Select value={activeContainer} onValueChange={handleContainerChange}>
+          <SelectTrigger id="container-select" className="h-8 min-w-[200px] text-xs">
+            <SelectValue placeholder="Select container" />
+          </SelectTrigger>
+          <SelectContent>
+            {availableContainers.map((container) => (
+              <SelectItem key={container.name} value={container.name} className="text-xs">
+                {container.name} {container.type !== "container" && <em>({container.type})</em>}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
-      <div className="flex gap-1 pb-1">
-        <Tooltip title="Copy to clipboard">
-          <Button variant="secondary" size="icon" onClick={handleCopy} disabled={!hasExportContent} className="h-8 w-8">
-            <Copy className="h-4 w-4" />
-          </Button>
-        </Tooltip>
-        <Tooltip title="Download logs">
-          <Button
-            variant="secondary"
-            size="icon"
-            onClick={handleDownload}
-            disabled={!hasExportContent}
-            className="h-8 w-8"
-          >
-            <Download className="h-4 w-4" />
-          </Button>
-        </Tooltip>
+      <div className="flex items-center gap-2">
+        <Switch checked={logsTimestamps} onCheckedChange={setLogsTimestamps} id="timestamps-switch" />
+        <Label htmlFor="timestamps-switch" className="text-muted-foreground cursor-pointer text-xs">
+          Timestamps
+        </Label>
       </div>
+    </div>
+  );
+
+  // Right toolbar group: actions (copy / download).
+  const renderControls = () => (
+    <div className="flex flex-shrink-0 gap-1">
+      <Tooltip title="Copy to clipboard">
+        <Button variant="secondary" size="icon" onClick={handleCopy} disabled={!hasExportContent} className="h-8 w-8">
+          <Copy className="h-4 w-4" />
+        </Button>
+      </Tooltip>
+      <Tooltip title="Download logs">
+        <Button
+          variant="secondary"
+          size="icon"
+          onClick={handleDownload}
+          disabled={!hasExportContent}
+          className="h-8 w-8"
+        >
+          <Download className="h-4 w-4" />
+        </Button>
+      </Tooltip>
     </div>
   );
 
@@ -348,8 +331,8 @@ export const PodLogsTerminal: React.FC<PodLogsProps> = ({
       content={follow ? undefined : formattedLogs}
       isLoading={isLoading || !podReadyForLogs}
       error={getErrorMessage()}
+      renderLeftControls={renderLeftControls}
       renderControls={renderControls}
-      fontSizeInline={false}
       loadingMessage={getLoadingMessage()}
       errorMessagePrefix="Error loading logs"
       emptyMessage="No logs available"

--- a/apps/client/src/modules/platform/tekton/components/UnifiedTaskRunLogs/components/HistoryStepLogs/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/UnifiedTaskRunLogs/components/HistoryStepLogs/index.tsx
@@ -56,19 +56,17 @@ export function HistoryStepLogs({ taskRunName, stepName, resultUid, namespace }:
   };
 
   const renderControls = () => (
-    <div className="flex w-full justify-end">
-      <div className="flex gap-1">
-        <Tooltip title="Copy to clipboard">
-          <Button variant="secondary" size="icon" onClick={handleCopy} disabled={!logs} className="h-8 w-8">
-            <Copy className="h-4 w-4" />
-          </Button>
-        </Tooltip>
-        <Tooltip title="Download logs">
-          <Button variant="secondary" size="icon" onClick={handleDownload} disabled={!logs} className="h-8 w-8">
-            <Download className="h-4 w-4" />
-          </Button>
-        </Tooltip>
-      </div>
+    <div className="flex flex-shrink-0 gap-1">
+      <Tooltip title="Copy to clipboard">
+        <Button variant="secondary" size="icon" onClick={handleCopy} disabled={!logs} className="h-8 w-8">
+          <Copy className="h-4 w-4" />
+        </Button>
+      </Tooltip>
+      <Tooltip title="Download logs">
+        <Button variant="secondary" size="icon" onClick={handleDownload} disabled={!logs} className="h-8 w-8">
+          <Download className="h-4 w-4" />
+        </Button>
+      </Tooltip>
     </div>
   );
 


### PR DESCRIPTION
Split toolbar controls into left-aligned inputs (pod/container/timestamps) and right-aligned actions (copy/download), replacing the fontSizeInline toggle.

Add scroll buttons that pause auto-follow on scroll-to-top and resume it on scroll-to-bottom, clear, and theme change to avoid frozen viewports.
