### PR TITLE
Refactor k8s mode with crd

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.2",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/apps/client/src/core/components/Confirm/Confirm.test.tsx
+++ b/apps/client/src/core/components/Confirm/Confirm.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfirmDialog } from "./index";
+
+// onSubmit re-throws after `finally` when actionCallback rejects (the dialog
+// itself does not swallow the error). Vitest tracks unhandled rejections via
+// Node's process — jsdom's window event does not suppress it — so silence at
+// the process level. Assertions are on dialog state.
+const swallow = () => {};
+
+describe("ConfirmDialog onSubmit", () => {
+  beforeEach(() => {
+    process.on("unhandledRejection", swallow);
+  });
+  afterEach(() => {
+    process.off("unhandledRejection", swallow);
+  });
+
+  it("keeps the dialog open and re-enables Confirm when actionCallback rejects", async () => {
+    const closeDialog = vi.fn();
+    const actionCallback = vi.fn().mockRejectedValue(new Error("boom"));
+    const user = userEvent.setup();
+
+    render(
+      <ConfirmDialog
+        props={{ actionCallback, text: "Are you sure?" }}
+        state={{ open: true, closeDialog, openDialog: vi.fn() }}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/Enter "confirm"/), "confirm");
+    const button = screen.getByRole("button", { name: "Confirm" });
+    await user.click(button);
+
+    await waitFor(() => expect(actionCallback).toHaveBeenCalledTimes(1));
+
+    // closeDialog stays untouched on the error path so the user can retry from
+    // the same dialog without re-typing the magic word.
+    expect(closeDialog).not.toHaveBeenCalled();
+
+    // setIsPending(false) ran in `finally`, so the button is enabled again
+    // (confirmValue is still "confirm" because the dialog never reset it).
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it("closes the dialog when actionCallback resolves", async () => {
+    const closeDialog = vi.fn();
+    const actionCallback = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(
+      <ConfirmDialog
+        props={{ actionCallback, text: "Are you sure?" }}
+        state={{ open: true, closeDialog, openDialog: vi.fn() }}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/Enter "confirm"/), "confirm");
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => expect(actionCallback).toHaveBeenCalledTimes(1));
+    expect(closeDialog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/src/core/components/Confirm/index.tsx
+++ b/apps/client/src/core/components/Confirm/index.tsx
@@ -18,8 +18,11 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   state: { open, closeDialog },
 }) => {
   const [confirmValue, setConfirmValue] = React.useState("");
+  const [isPending, setIsPending] = React.useState(false);
 
-  const isSubmitNotAllowed = confirmValue !== "confirm";
+  // Disable Confirm both before the user has typed the magic word AND while the
+  // callback is in-flight, so rapid double-clicks cannot fire the action twice.
+  const isSubmitNotAllowed = confirmValue !== "confirm" || isPending;
 
   const handleClosePopup = React.useCallback(() => {
     closeDialog();
@@ -27,9 +30,15 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   }, [closeDialog]);
 
   const onSubmit = React.useCallback(async () => {
-    await actionCallback();
-    handleClosePopup();
-  }, [actionCallback, handleClosePopup]);
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      await actionCallback();
+      handleClosePopup();
+    } finally {
+      setIsPending(false);
+    }
+  }, [actionCallback, handleClosePopup, isPending]);
 
   return (
     <Dialog open={open} onOpenChange={(open) => !open && handleClosePopup()} data-testid="dialog">
@@ -59,7 +68,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
           <Button type="button" variant="ghost" onClick={handleClosePopup}>
             Cancel
           </Button>
-          <Button variant="default" onClick={onSubmit} disabled={isSubmitNotAllowed}>
+          <Button variant="default" onClick={onSubmit} disabled={isSubmitNotAllowed} aria-busy={isPending}>
             Confirm
           </Button>
         </DialogFooter>

--- a/apps/client/src/core/components/DeleteKubeObject/index.test.tsx
+++ b/apps/client/src/core/components/DeleteKubeObject/index.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import React from "react";
+
+const mutateMock = vi.fn();
+vi.mock("@/k8s/api/hooks/useResourceCRUDMutation", () => ({
+  useResourceCRUDMutation: () => ({
+    mutate: mutateMock,
+    // The dialog now calls mutateAsync so it can await the request before navigating
+    // — bare .mutate() resolves immediately and would navigate away on a failure.
+    mutateAsync: mutateMock,
+  }),
+}));
+vi.mock("@/core/router", () => ({ router: { navigate: vi.fn() } }));
+
+import { DeleteKubeObjectDialog } from "./index";
+
+const stubConfig = {
+  apiVersion: "v1",
+  kind: "Pod",
+  group: "",
+  version: "v1",
+  singularName: "pod",
+  pluralName: "pods",
+} as const;
+
+const stubResource = { metadata: { name: "x" } } as never;
+
+function makeDialogProps(description: React.ReactNode, overrides?: { closeDialog?: () => void }) {
+  return {
+    props: {
+      description,
+      objectName: "my-pod",
+      resourceConfig: stubConfig,
+      resource: stubResource,
+    },
+    state: { open: true, closeDialog: overrides?.closeDialog ?? vi.fn(), openDialog: vi.fn() },
+  };
+}
+
+describe("DeleteKubeObjectDialog description", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("accepts ReactNode and renders nested elements", () => {
+    render(
+      <DeleteKubeObjectDialog
+        {...makeDialogProps(
+          <>
+            <div>Delete CRD "my-crd".</div>
+            <div>Removes all instances cluster-wide.</div>
+          </>
+        )}
+      />
+    );
+    expect(screen.getByText(/Removes all instances cluster-wide/)).toBeInTheDocument();
+  });
+
+  it("still accepts plain string descriptions (backward compat)", () => {
+    render(<DeleteKubeObjectDialog {...makeDialogProps("Delete this pod")} />);
+    expect(screen.getByText("Delete this pod")).toBeInTheDocument();
+  });
+});
+
+describe("DeleteKubeObjectDialog submit flow", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("keeps Confirm disabled until the name input exactly matches the object name", async () => {
+    const user = userEvent.setup();
+    render(<DeleteKubeObjectDialog {...makeDialogProps("Delete this pod")} />);
+
+    const confirmBtn = screen.getByRole("button", { name: /confirm/i });
+    expect(confirmBtn).toBeDisabled();
+
+    const input = screen.getByLabelText(/Enter "my-pod" to delete/);
+    await user.type(input, "wrong");
+    expect(confirmBtn).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, "my-pod");
+    expect(confirmBtn).toBeEnabled();
+  });
+
+  it("invokes the delete mutation when the typed name matches and Confirm is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeleteKubeObjectDialog {...makeDialogProps("Delete this pod")} />);
+
+    await user.type(screen.getByLabelText(/Enter "my-pod" to delete/), "my-pod");
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    expect(mutateMock).toHaveBeenCalledWith({ resource: stubResource, resourceConfig: stubConfig });
+  });
+});

--- a/apps/client/src/core/components/DeleteKubeObject/index.tsx
+++ b/apps/client/src/core/components/DeleteKubeObject/index.tsx
@@ -47,15 +47,24 @@ export const DeleteKubeObjectDialog: React.FC<DeleteKubeObjectDialogProps> = (_p
       return;
     }
 
+    // Close the dialog first so the user sees the snackbar feedback unobscured;
+    // the toast is surfaced by useResourceCRUDMutation regardless of outcome.
     handleClosePopup();
 
-    await resourceDeleteMutation.mutate({
-      resource,
-      resourceConfig,
-    });
-
-    if (backRoute) {
-      router.navigate(backRoute);
+    try {
+      // mutateAsync (not mutate) is required to actually await the delete before navigating.
+      // The bare `.mutate(...)` returns void — `await` resolves immediately, navigating
+      // away while the request is still in flight and masking server-side failures.
+      await resourceDeleteMutation.mutateAsync({
+        resource,
+        resourceConfig,
+      });
+      if (backRoute) {
+        router.navigate(backRoute);
+      }
+    } catch {
+      // Toast is already surfaced by useResourceCRUDMutation. Stay on the current page
+      // (don't navigate to backRoute) so the user can re-open the dialog and retry.
     }
   }, [
     errorTemplate,
@@ -80,7 +89,7 @@ export const DeleteKubeObjectDialog: React.FC<DeleteKubeObjectDialogProps> = (_p
     })();
   }, [onBeforeSubmit, open]);
 
-  const isSubmitNotAllowed = nameValue !== objectName || !!errorTemplate;
+  const isSubmitNotAllowed = nameValue !== objectName || !!errorTemplate || resourceDeleteMutation.isPending;
   const dialogTitle = React.useMemo(() => getDialogTitle(errorTemplate, objectName || ""), [errorTemplate, objectName]);
 
   return (
@@ -93,7 +102,7 @@ export const DeleteKubeObjectDialog: React.FC<DeleteKubeObjectDialogProps> = (_p
           <div className="flex flex-col gap-2">
             {!loadingActive && !errorTemplate && (
               <div>
-                <p>{description}</p>
+                <div>{description}</div>
               </div>
             )}
             <div className="flex flex-col gap-2">
@@ -123,7 +132,13 @@ export const DeleteKubeObjectDialog: React.FC<DeleteKubeObjectDialogProps> = (_p
           <Button type="button" variant="ghost" onClick={handleClosePopup}>
             Cancel
           </Button>
-          <Button type="button" variant="default" onClick={onSubmit} disabled={isSubmitNotAllowed}>
+          <Button
+            type="button"
+            variant="default"
+            onClick={onSubmit}
+            disabled={isSubmitNotAllowed}
+            aria-busy={resourceDeleteMutation.isPending}
+          >
             Confirm
           </Button>
         </DialogFooter>

--- a/apps/client/src/core/components/DeleteKubeObject/types.ts
+++ b/apps/client/src/core/components/DeleteKubeObject/types.ts
@@ -16,7 +16,7 @@ type CustomMessages = {
 };
 
 export type DeleteKubeObjectDialogProps = DialogProps<{
-  description: string;
+  description: React.ReactNode;
   objectName: string | undefined;
   resourceConfig: K8sResourceConfig;
   resource: KubeObjectBase;

--- a/apps/client/src/core/components/HoverInfoLabel.tsx
+++ b/apps/client/src/core/components/HoverInfoLabel.tsx
@@ -1,0 +1,20 @@
+import { TooltipContent, TooltipRoot, TooltipTrigger } from "@/core/components/ui/tooltip";
+
+interface HoverInfoLabelProps {
+  label: string;
+  tooltip?: string;
+}
+
+export function HoverInfoLabel({ label, tooltip }: HoverInfoLabelProps) {
+  if (!tooltip) {
+    return <span className="text-muted-foreground text-xs tracking-wider uppercase">{label}</span>;
+  }
+  return (
+    <TooltipRoot>
+      <TooltipTrigger asChild>
+        <span className="text-muted-foreground border-b border-dotted text-xs tracking-wider uppercase">{label}</span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </TooltipRoot>
+  );
+}

--- a/apps/client/src/core/components/ServerSideTable/ServerSideTable.test.tsx
+++ b/apps/client/src/core/components/ServerSideTable/ServerSideTable.test.tsx
@@ -2,13 +2,18 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ServerSideTable } from "./index";
 
+const tableHeadColumnsSpy = vi.fn();
+
 // Mock components
 vi.mock("@/core/components/ui/table", () => ({
   TableUI: ({ children }: { children: React.ReactNode }) => <table>{children}</table>,
 }));
 
 vi.mock("../Table/components/TableHead", () => ({
-  TableHead: () => <thead data-testid="table-head" />,
+  TableHead: ({ columns }: { columns: { id: string }[] }) => {
+    tableHeadColumnsSpy(columns);
+    return <thead data-testid="table-head" />;
+  },
 }));
 
 vi.mock("../Table/components/TableBody", () => ({
@@ -209,5 +214,50 @@ describe("ServerSideTable - Page Out of Bounds", () => {
 
     expect(screen.getByTestId("custom-empty")).toBeInTheDocument();
     expect(screen.queryByText("Page not found")).not.toBeInTheDocument();
+  });
+
+  it("does NOT resync local column state on parent re-render with a fresh array reference but identical column ids", () => {
+    const columnsInitial = [
+      {
+        id: "name",
+        label: "Name",
+        data: { render: ({ data }: { data: { name: string } }) => data.name },
+        cell: { show: true, baseWidth: 50 },
+      },
+    ];
+    // Identical column ids/shape — but a brand new array reference, simulating
+    // a parent re-render that rebuilds the columns inline (e.g. on data refetch).
+    const columnsFreshReference = [
+      {
+        id: "name",
+        label: "Name",
+        data: { render: ({ data }: { data: { name: string } }) => data.name },
+        cell: { show: true, baseWidth: 50 },
+      },
+    ];
+
+    tableHeadColumnsSpy.mockClear();
+
+    const pagination = {
+      show: true,
+      page: 0,
+      rowsPerPage: 25,
+      totalCount: 0,
+      onPageChange: vi.fn(),
+      onRowsPerPageChange: vi.fn(),
+    };
+
+    const { rerender } = render(
+      <ServerSideTable id="test-table" data={[]} columns={columnsInitial} pagination={pagination} />
+    );
+    const initiallyRendered = tableHeadColumnsSpy.mock.calls.at(-1)?.[0];
+
+    rerender(<ServerSideTable id="test-table" data={[]} columns={columnsFreshReference} pagination={pagination} />);
+    const afterRerender = tableHeadColumnsSpy.mock.calls.at(-1)?.[0];
+
+    // Must still be the initial array reference: a per-render resync would wipe
+    // user-applied TableSettings visibility toggles on every server-side page
+    // change or refetch.
+    expect(afterRerender).toBe(initiallyRendered);
   });
 });

--- a/apps/client/src/core/components/ServerSideTable/index.tsx
+++ b/apps/client/src/core/components/ServerSideTable/index.tsx
@@ -5,8 +5,9 @@ import { TableHead } from "@/core/components/Table/components/TableHead";
 import { TablePagination } from "@/core/components/Table/components/TablePagination";
 import { TableSettings } from "@/core/components/Table/components/TableSettings";
 import { SORT_DEFAULTS, TABLE_SETTINGS_DEFAULTS } from "@/core/components/Table/constants";
-import { SortState, TableSort } from "@/core/components/Table/types";
-import { createSortFunction } from "@/core/components/Table/utils";
+import { TableSort } from "@/core/components/Table/types";
+import { useColumnSync } from "@/core/components/Table/hooks/useColumnSync";
+import { useSyncedSortState } from "@/core/components/Table/hooks/useSyncedSortState";
 import { cn } from "@/core/utils/classname";
 import { ServerSideTableProps } from "./types";
 import { useIsNarrow } from "@/core/hooks/use-narrow";
@@ -61,7 +62,7 @@ export const ServerSideTable = <DataType,>({
   outlined = true,
 }: ServerSideTableProps<DataType>) => {
   const isNarrow = useIsNarrow();
-  const [columns, setColumns] = React.useState(_columns);
+  const [columns, setColumns] = useColumnSync(_columns, id);
 
   const sortSettings: TableSort = React.useMemo(
     () => ({
@@ -78,11 +79,7 @@ export const ServerSideTable = <DataType,>({
     [settings?.show]
   );
 
-  const [sortState, setSortState] = React.useState<SortState<DataType>>({
-    order: sortSettings.order,
-    sortFn: createSortFunction(sortSettings.order, sortSettings.sortBy),
-    sortBy: sortSettings.sortBy,
-  });
+  const [sortState, setSortState] = useSyncedSortState<DataType>(sortSettings);
 
   // Check if current page is beyond total pages
   const isPageOutOfBounds = React.useMemo(() => {

--- a/apps/client/src/core/components/Table/Table.test.tsx
+++ b/apps/client/src/core/components/Table/Table.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { DataTable } from "./index";
 
+const tableHeadColumnsSpy = vi.fn();
+
 // Mock usePagination hook
 vi.mock("@/core/hooks/usePagination", () => ({
   usePagination: vi.fn(() => ({
@@ -18,7 +20,10 @@ vi.mock("@/core/components/ui/table", () => ({
 }));
 
 vi.mock("./components/TableHead", () => ({
-  TableHead: () => <thead data-testid="table-head" />,
+  TableHead: ({ columns }: { columns: { id: string }[] }) => {
+    tableHeadColumnsSpy(columns);
+    return <thead data-testid="table-head" />;
+  },
 }));
 
 vi.mock("./components/TableBody", () => ({
@@ -217,5 +222,93 @@ describe("DataTable - Page Out of Bounds", () => {
     render(<DataTable id="test-table" data={smallData} columns={mockColumns} pagination={{ show: true }} />);
 
     expect(screen.queryByText("Page not found")).not.toBeInTheDocument();
+  });
+});
+
+describe("DataTable - columns prop sync", () => {
+  it("renders the latest columns prop when the parent passes a new reference", async () => {
+    const { usePagination } = await import("@/core/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      page: 0,
+      rowsPerPage: 25,
+      handleChangePage: vi.fn(),
+      handleChangeRowsPerPage: vi.fn(),
+    });
+
+    const columnsA = [
+      {
+        id: "name",
+        label: "Name",
+        data: { render: ({ data }: { data: { name: string } }) => data.name },
+        cell: { show: true, baseWidth: 50 },
+      },
+    ];
+    const columnsB = [
+      {
+        id: "name",
+        label: "Name",
+        data: { render: ({ data }: { data: { name: string } }) => data.name },
+        cell: { show: true, baseWidth: 50 },
+      },
+      {
+        id: "provisioner",
+        label: "Provisioner",
+        data: { render: () => "p" },
+        cell: { show: true, baseWidth: 20 },
+      },
+    ];
+
+    tableHeadColumnsSpy.mockClear();
+
+    const { rerender } = render(<DataTable id="test-table" data={[]} columns={columnsA} />);
+    const initialColumns = tableHeadColumnsSpy.mock.calls.at(-1)?.[0];
+    expect(initialColumns).toHaveLength(1);
+
+    rerender(<DataTable id="test-table" data={[]} columns={columnsB} />);
+    const updatedColumns = tableHeadColumnsSpy.mock.calls.at(-1)?.[0];
+    expect(updatedColumns).toHaveLength(2);
+    expect(updatedColumns.map((c: { id: string }) => c.id)).toEqual(["name", "provisioner"]);
+  });
+
+  it("does NOT resync local column state on parent re-render with a fresh array reference but identical column ids", async () => {
+    const { usePagination } = await import("@/core/hooks/usePagination");
+    vi.mocked(usePagination).mockReturnValue({
+      page: 0,
+      rowsPerPage: 25,
+      handleChangePage: vi.fn(),
+      handleChangeRowsPerPage: vi.fn(),
+    });
+
+    const columnsInitial = [
+      {
+        id: "name",
+        label: "Name",
+        data: { render: ({ data }: { data: { name: string } }) => data.name },
+        cell: { show: true, baseWidth: 50 },
+      },
+    ];
+    // Identical column ids, identical shape — but a brand new array reference,
+    // simulating a parent re-render that rebuilds the columns inline.
+    const columnsFreshReference = [
+      {
+        id: "name",
+        label: "Name",
+        data: { render: ({ data }: { data: { name: string } }) => data.name },
+        cell: { show: true, baseWidth: 50 },
+      },
+    ];
+
+    tableHeadColumnsSpy.mockClear();
+
+    const { rerender } = render(<DataTable id="test-table" data={[]} columns={columnsInitial} />);
+    const initiallyRendered = tableHeadColumnsSpy.mock.calls.at(-1)?.[0];
+
+    rerender(<DataTable id="test-table" data={[]} columns={columnsFreshReference} />);
+    const afterRerender = tableHeadColumnsSpy.mock.calls.at(-1)?.[0];
+
+    // TableHead must still receive the initial array reference: if the effect
+    // had fired on every new `_columns` reference, user-applied TableSettings
+    // visibility toggles would be wiped on every parent refetch.
+    expect(afterRerender).toBe(initiallyRendered);
   });
 });

--- a/apps/client/src/core/components/Table/hooks/useColumnSync.ts
+++ b/apps/client/src/core/components/Table/hooks/useColumnSync.ts
@@ -1,0 +1,23 @@
+import React from "react";
+
+// Sync a local copy of `_columns` to internal state, refreshing only when the
+// table identity (`id`) or the set of column ids changes. Depending on the
+// `_columns` reference would wipe user-applied TableSettings visibility toggles
+// on every parent re-render that produces a fresh array (e.g. data refetch).
+// The ref holds the latest `_columns` so the effect can read it without
+// listing it as a dep.
+export function useColumnSync<C extends { id: string }>(
+  _columns: C[],
+  id: string
+): [C[], React.Dispatch<React.SetStateAction<C[]>>] {
+  const [columns, setColumns] = React.useState(_columns);
+  const columnIdsKey = React.useMemo(() => _columns.map((c) => c.id).join("|"), [_columns]);
+  const columnsRef = React.useRef(_columns);
+  columnsRef.current = _columns;
+
+  React.useEffect(() => {
+    setColumns(columnsRef.current);
+  }, [id, columnIdsKey]);
+
+  return [columns, setColumns];
+}

--- a/apps/client/src/core/components/Table/hooks/useSyncedSortState.ts
+++ b/apps/client/src/core/components/Table/hooks/useSyncedSortState.ts
@@ -15,7 +15,16 @@ export function useSyncedSortState<DataType>(
     sortBy: sortSettings.sortBy,
   }));
 
+  // The useState initializer already seeds the correct value on mount, so the
+  // effect only needs to run when `sortSettings` actually changes afterwards.
+  // Skipping the first run avoids a redundant extra render on every table mount
+  // (createSortFunction returns a new closure, so re-setting would not bail out).
+  const isFirstRender = React.useRef(true);
   React.useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
     setSortState({
       order: sortSettings.order,
       sortFn: createSortFunction(sortSettings.order, sortSettings.sortBy),

--- a/apps/client/src/core/components/Table/hooks/useSyncedSortState.ts
+++ b/apps/client/src/core/components/Table/hooks/useSyncedSortState.ts
@@ -1,0 +1,27 @@
+import React from "react";
+import type { SortState, TableSort } from "../types";
+import { createSortFunction } from "../utils";
+
+// Holds local sort state seeded from `sortSettings`, and resets it whenever the
+// parent passes a new default sort (e.g. switching resource kinds in
+// K8sListPage). Without the reset, the table holds onto the previous
+// resource's `sortBy` id and renders incorrectly against the new columns.
+export function useSyncedSortState<DataType>(
+  sortSettings: TableSort
+): [SortState<DataType>, React.Dispatch<React.SetStateAction<SortState<DataType>>>] {
+  const [sortState, setSortState] = React.useState<SortState<DataType>>(() => ({
+    order: sortSettings.order,
+    sortFn: createSortFunction(sortSettings.order, sortSettings.sortBy),
+    sortBy: sortSettings.sortBy,
+  }));
+
+  React.useEffect(() => {
+    setSortState({
+      order: sortSettings.order,
+      sortFn: createSortFunction(sortSettings.order, sortSettings.sortBy),
+      sortBy: sortSettings.sortBy,
+    });
+  }, [sortSettings.order, sortSettings.sortBy]);
+
+  return [sortState, setSortState];
+}

--- a/apps/client/src/core/components/Table/index.tsx
+++ b/apps/client/src/core/components/Table/index.tsx
@@ -12,15 +12,15 @@ import {
   TABLE_SETTINGS_DEFAULTS,
 } from "./constants";
 import { useFilteredData } from "./hooks/useFilteredData";
+import { useColumnSync } from "./hooks/useColumnSync";
+import { useSyncedSortState } from "./hooks/useSyncedSortState";
 import {
-  SortState,
   TablePagination as TablePaginationType,
   TableProps,
   TableSelection,
   TableSettings as TableSettingsType,
   TableSort,
 } from "./types";
-import { createSortFunction } from "./utils";
 import { usePagination } from "@/core/hooks/usePagination";
 import { useIsNarrow } from "@/core/hooks/use-narrow";
 import { cn } from "@/core/utils/classname";
@@ -49,7 +49,8 @@ export const DataTable = <DataType,>({
   containerProps,
 }: TableProps<DataType>) => {
   const isNarrow = useIsNarrow();
-  const [columns, setColumns] = React.useState(_columns);
+  const [columns, setColumns] = useColumnSync(_columns, id);
+
   const paginationSettings: TablePaginationType = React.useMemo(
     () => ({
       show: pagination?.show ?? PAGINATION_DEFAULTS.SHOW,
@@ -104,11 +105,7 @@ export const DataTable = <DataType,>({
     initialRowsPerPage: paginationSettings.rowsPerPage!,
   });
 
-  const [sortState, setSortState] = React.useState<SortState<DataType>>({
-    order: sortSettings.order,
-    sortFn: createSortFunction(sortSettings.order, sortSettings.sortBy),
-    sortBy: sortSettings.sortBy,
-  });
+  const [sortState, setSortState] = useSyncedSortState<DataType>(sortSettings);
 
   const filteredData = useFilteredData<DataType>({
     data,

--- a/apps/client/src/core/components/sidebar/SidebarCollapsibleSubGroupMenuItem.test.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarCollapsibleSubGroupMenuItem.test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SidebarProvider } from "../ui/sidebar";
+import type { NavCollapsibleSubGroupItem, SimpleNavItem } from "./types";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    to?: string;
+    onClick?: () => void;
+    // Other Link props (params, activeOptions, activeProps) are intentionally ignored in tests.
+    [key: string]: unknown;
+  }) => (
+    <a href={typeof to === "string" ? to : "#"} onClick={onClick}>
+      {children}
+    </a>
+  ),
+  useLocation: () => ({ pathname: "/" }),
+}));
+
+import { SidebarCollapsibleSubGroupMenuItem } from "./SidebarCollapsibleSubGroupMenuItem";
+
+const subGroup: NavCollapsibleSubGroupItem = {
+  kind: "collapsible-subgroup",
+  title: "tekton.dev",
+  children: [
+    { title: "PipelineRuns", route: { to: "/foo", params: {} } as unknown as SimpleNavItem["route"] },
+    { title: "Tasks", route: { to: "/bar", params: {} } as unknown as SimpleNavItem["route"] },
+  ],
+};
+
+function harness(props: Parameters<typeof SidebarCollapsibleSubGroupMenuItem>[0]) {
+  return (
+    <SidebarProvider>
+      <SidebarCollapsibleSubGroupMenuItem {...props} />
+    </SidebarProvider>
+  );
+}
+
+describe("SidebarCollapsibleSubGroupMenuItem", () => {
+  it("renders the title as a clickable trigger", () => {
+    render(harness({ subGroup }));
+    expect(screen.getByRole("button", { name: /tekton\.dev/i })).toBeInTheDocument();
+  });
+
+  it("hides children when defaultOpen is false", () => {
+    render(harness({ subGroup: { ...subGroup, defaultOpen: false } }));
+    expect(screen.queryByText("PipelineRuns")).not.toBeInTheDocument();
+  });
+
+  it("shows children when defaultOpen is true", () => {
+    render(harness({ subGroup: { ...subGroup, defaultOpen: true } }));
+    expect(screen.getByText("PipelineRuns")).toBeInTheDocument();
+    expect(screen.getByText("Tasks")).toBeInTheDocument();
+  });
+
+  it("has aria-expanded=false when collapsed", () => {
+    render(harness({ subGroup }));
+    expect(screen.getByRole("button", { name: /tekton\.dev/i })).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("has aria-expanded=true when defaultOpen is true", () => {
+    render(harness({ subGroup: { ...subGroup, defaultOpen: true } }));
+    expect(screen.getByRole("button", { name: /tekton\.dev/i })).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("toggles aria-expanded on click", () => {
+    render(harness({ subGroup }));
+    const btn = screen.getByRole("button", { name: /tekton\.dev/i });
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("toggles children on trigger click", () => {
+    render(harness({ subGroup }));
+    fireEvent.click(screen.getByRole("button", { name: /tekton\.dev/i }));
+    expect(screen.getByText("PipelineRuns")).toBeInTheDocument();
+  });
+
+  it("auto-expands and marks trigger active when a child matches isActiveFn", async () => {
+    vi.resetModules();
+    vi.doMock("@tanstack/react-router", () => ({
+      Link: ({
+        children,
+        to,
+        onClick,
+      }: {
+        children?: React.ReactNode;
+        to?: string;
+        onClick?: () => void;
+        [key: string]: unknown;
+      }) => (
+        <a href={typeof to === "string" ? to : "#"} onClick={onClick}>
+          {children}
+        </a>
+      ),
+      useLocation: () => ({ pathname: "/c/c1/k8s/cr/tekton.dev/v1/pipelineruns" }),
+    }));
+    const { SidebarCollapsibleSubGroupMenuItem: Reloaded } = await import("./SidebarCollapsibleSubGroupMenuItem");
+    const activeSubGroup: NavCollapsibleSubGroupItem = {
+      kind: "collapsible-subgroup",
+      title: "tekton.dev",
+      children: [
+        {
+          title: "PipelineRuns",
+          route: { to: "/foo", params: {} } as unknown as SimpleNavItem["route"],
+          isActiveFn: (p: string) => p.includes("pipelineruns"),
+        },
+      ],
+    };
+
+    render(
+      <SidebarProvider>
+        <Reloaded subGroup={activeSubGroup} />
+      </SidebarProvider>
+    );
+
+    // Auto-expanded (child visible)
+    expect(screen.getByText("PipelineRuns")).toBeInTheDocument();
+    // Trigger button carries the active styling class
+    const trigger = screen.getByRole("button", { name: /tekton\.dev/i });
+    expect(trigger.className).toMatch(/bg-accent/);
+  });
+});

--- a/apps/client/src/core/components/sidebar/SidebarCollapsibleSubGroupMenuItem.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarCollapsibleSubGroupMenuItem.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { Link, useLocation } from "@tanstack/react-router";
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/core/components/ui/collapsible";
+import { SidebarMenuSubButton, SidebarMenuSubItem } from "../ui/sidebar";
+import { cn } from "@/core/utils/classname";
+import type { NavCollapsibleSubGroupItem } from "./types";
+
+interface Props {
+  subGroup: NavCollapsibleSubGroupItem;
+  parentGroupId?: string;
+  onNavigate?: (groupId?: string) => void;
+}
+
+export function SidebarCollapsibleSubGroupMenuItem({ subGroup, parentGroupId, onNavigate }: Props) {
+  const { pathname } = useLocation();
+  const hasActiveChild = subGroup.children.some((c) => c.isActiveFn?.(pathname));
+  // Open by default if the user has navigated into this subgroup, or if explicitly configured.
+  const [open, setOpen] = useState(hasActiveChild || (subGroup.defaultOpen ?? false));
+
+  // If a navigation makes a child active while the subgroup was collapsed, expand it.
+  // `open` is intentionally omitted from deps: React bails out of setState(true) when
+  // already true, so the guard is implicit. Including `open` would re-run the effect
+  // on every user toggle for no behavior change.
+  useEffect(() => {
+    if (hasActiveChild) setOpen(true);
+  }, [hasActiveChild]);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          aria-expanded={open}
+          title={subGroup.title}
+          className={cn(
+            "hover:bg-accent hover:text-accent-foreground mb-1 flex w-full min-w-0 items-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium tracking-wider uppercase",
+            hasActiveChild ? "text-accent-foreground bg-accent/60" : "text-muted-foreground"
+          )}
+        >
+          {open ? <ChevronDown className="size-3 shrink-0" /> : <ChevronRight className="size-3 shrink-0" />}
+          <span className="min-w-0 flex-1 truncate text-left">{subGroup.title}</span>
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        {subGroup.children.map((child) => (
+          <SidebarMenuSubItem key={child.title}>
+            <SidebarMenuSubButton asChild size="sm">
+              <Link
+                to={child.route.to}
+                params={child.route.params}
+                onClick={() => onNavigate?.(parentGroupId)}
+                activeOptions={{ exact: true, includeSearch: false }}
+                activeProps={{ className: "bg-accent text-accent-foreground" }}
+                title={child.title}
+                className={cn("min-w-0", child.isActiveFn?.(pathname) && "bg-accent text-accent-foreground")}
+              >
+                {child.icon && <child.icon className="size-4 shrink-0" />}
+                <span className="min-w-0 flex-1 truncate">{child.title}</span>
+              </Link>
+            </SidebarMenuSubButton>
+          </SidebarMenuSubItem>
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/apps/client/src/core/components/sidebar/SidebarMenuContent.test.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarMenuContent.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SidebarProvider } from "../ui/sidebar";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    to?: string;
+    onClick?: () => void;
+    // Other Link props (params, activeOptions, activeProps) are intentionally ignored in tests.
+    [key: string]: unknown;
+  }) => (
+    <a href={typeof to === "string" ? to : "#"} onClick={onClick}>
+      {children}
+    </a>
+  ),
+  useLocation: () => ({ pathname: "/" }),
+}));
+
+// Pinned items hook is exercised inside SidebarSubGroupMenuItem and SidebarMenuItem; mock the
+// store away so the test doesn't need real provider state.
+vi.mock("@/core/hooks/usePinnedItems", () => ({
+  usePinnedItems: () => ({ isPinned: () => false, togglePin: () => undefined }),
+}));
+
+import type { SimpleNavItem, NavSubGroupItem, NavCollapsibleSubGroupItem } from "./types";
+import { SidebarMenuContent } from "./SidebarMenuContent";
+
+function wrap(ui: React.ReactNode) {
+  return <SidebarProvider>{ui}</SidebarProvider>;
+}
+
+function asRoute(to: string): SimpleNavItem["route"] {
+  return { to, params: {} } as unknown as SimpleNavItem["route"];
+}
+
+describe("SidebarMenuContent dispatch", () => {
+  it("routes a route-bearing child to SidebarMenuItem", () => {
+    const child: SimpleNavItem = { title: "Pods", route: asRoute("/pods") };
+    render(wrap(<SidebarMenuContent parentNavItem={{ title: "Workloads", children: [child] }} />));
+    expect(screen.getByRole("link", { name: /pods/i })).toBeInTheDocument();
+  });
+
+  it("routes a NavSubGroupItem (no kind) to the static divider", () => {
+    const child: NavSubGroupItem = {
+      title: "argocd",
+      children: [{ title: "Apps", route: asRoute("/a") }],
+    };
+    render(wrap(<SidebarMenuContent parentNavItem={{ title: "Custom Resources", children: [child] }} />));
+    // Static divider renders the title as an uppercase label, no button role
+    expect(screen.queryByRole("button", { name: /argocd/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/argocd/i)).toBeInTheDocument();
+  });
+
+  it("routes a collapsible-subgroup child to SidebarCollapsibleSubGroupMenuItem", () => {
+    const child: NavCollapsibleSubGroupItem = {
+      kind: "collapsible-subgroup",
+      title: "tekton.dev",
+      children: [{ title: "PipelineRuns", route: asRoute("/p") }],
+    };
+    render(wrap(<SidebarMenuContent parentNavItem={{ title: "Custom Resources", children: [child] }} />));
+    expect(screen.getByRole("button", { name: /tekton\.dev/i })).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/core/components/sidebar/SidebarMenuContent.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarMenuContent.tsx
@@ -1,6 +1,7 @@
 import { SidebarMenuItem } from "./SidebarMenuItem";
 import { SidebarSubGroupMenuItem } from "./SidebarSubGroupMenuItem";
-import type { NavGroupItem, SimpleNavItem, NavSubGroupItem } from "./types";
+import { SidebarCollapsibleSubGroupMenuItem } from "./SidebarCollapsibleSubGroupMenuItem";
+import type { NavGroupItem } from "./types";
 
 interface SidebarMenuContentProps {
   parentNavItem: NavGroupItem;
@@ -18,9 +19,15 @@ export function SidebarMenuContent({ parentNavItem, parentGroupId, onNavigate }:
       {parentNavItem.children.map((child) => {
         if ("route" in child && child.route) {
           return (
-            <SidebarMenuItem
+            <SidebarMenuItem key={child.title} item={child} parentGroupId={parentGroupId} onNavigate={onNavigate} />
+          );
+        }
+
+        if ("kind" in child && child.kind === "collapsible-subgroup") {
+          return (
+            <SidebarCollapsibleSubGroupMenuItem
               key={child.title}
-              item={child as SimpleNavItem}
+              subGroup={child}
               parentGroupId={parentGroupId}
               onNavigate={onNavigate}
             />
@@ -30,7 +37,7 @@ export function SidebarMenuContent({ parentNavItem, parentGroupId, onNavigate }:
         return (
           <SidebarSubGroupMenuItem
             key={child.title}
-            subGroup={child as NavSubGroupItem}
+            subGroup={child}
             parentGroupId={parentGroupId}
             onNavigate={onNavigate}
           />

--- a/apps/client/src/core/components/sidebar/SidebarMenuItemWithHover.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarMenuItemWithHover.tsx
@@ -7,7 +7,7 @@ import { cn } from "../../utils/classname";
 import { SidebarMenuContent } from "./SidebarMenuContent";
 import { usePinnedItems } from "@/core/hooks/usePinnedItems";
 import { createPinConfig } from "./utils";
-import type { NavItem, SimpleNavItem, NavSubGroupItem, NavGroupItem } from "./types";
+import type { NavItem, SimpleNavItem, NavSubGroupItem, NavCollapsibleSubGroupItem, NavGroupItem } from "./types";
 import type { RouteParams } from "@/core/router/types";
 
 interface SidebarMenuItemWithHoverProps {
@@ -19,38 +19,38 @@ interface SidebarMenuItemWithHoverProps {
   isMinimized?: boolean;
 }
 
+function getFirstMenuItemRoute(
+  children: (SimpleNavItem | NavSubGroupItem | NavCollapsibleSubGroupItem)[]
+): RouteParams {
+  for (const child of children) {
+    if ("route" in child && child.route) {
+      return {
+        to: child.route.to,
+        params: child.route.params,
+      };
+    } else if ("children" in child && child.children.length > 0) {
+      return {
+        to: child.children[0].route.to,
+        params: child.children[0].route.params,
+      };
+    }
+  }
+  return { to: "/" };
+}
+
 /**
  * Component for rendering sidebar menu items with hover effects and collapsible behavior
  * Handles both simple nav items and groups with children
  */
-export const SidebarMenuItemWithHover = ({
+export function SidebarMenuItemWithHover({
   item,
   isMenuOpen,
   onToggle,
   onOpenMenu,
   onNavigate,
   isMinimized = false,
-}: SidebarMenuItemWithHoverProps) => {
+}: SidebarMenuItemWithHoverProps) {
   const matches = useMatches();
-
-  const getFirstMenuItemRoute = (children: (SimpleNavItem | NavSubGroupItem)[]): RouteParams => {
-    for (const child of children) {
-      if ("route" in child && child.route) {
-        // This is a simple nav item
-        return {
-          to: child.route.to,
-          params: child.route.params,
-        };
-      } else if ("children" in child && child.children.length > 0) {
-        // This is a sub-group, get the first item from its children
-        return {
-          to: child.children[0].route.to,
-          params: child.children[0].route.params,
-        };
-      }
-    }
-    return { to: "/" };
-  };
 
   const { pathname } = useLocation();
 
@@ -103,6 +103,9 @@ export const SidebarMenuItemWithHover = ({
     if (!("children" in item) || !item.children) return false;
     return (item as NavGroupItem).children.some((child) => {
       if ("isActiveFn" in child && child.isActiveFn) return child.isActiveFn(pathname);
+      if ("kind" in child && child.kind === "collapsible-subgroup") {
+        return child.children.some((c) => c.isActiveFn?.(pathname));
+      }
       if ("children" in child) return (child.children ?? []).some((c) => c.isActiveFn?.(pathname));
       return false;
     });
@@ -205,4 +208,4 @@ export const SidebarMenuItemWithHover = ({
       </Collapsible>
     </SidebarMenuItem>
   );
-};
+}

--- a/apps/client/src/core/components/sidebar/SidebarMenuItemWithHover.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarMenuItemWithHover.tsx
@@ -6,7 +6,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/colla
 import { cn } from "../../utils/classname";
 import { SidebarMenuContent } from "./SidebarMenuContent";
 import { usePinnedItems } from "@/core/hooks/usePinnedItems";
-import { createPinConfig } from "./utils";
+import { createPinConfig, isNavGroupActiveForPathname } from "./utils";
 import type { NavItem, SimpleNavItem, NavSubGroupItem, NavCollapsibleSubGroupItem, NavGroupItem } from "./types";
 import type { RouteParams } from "@/core/router/types";
 
@@ -101,14 +101,7 @@ export function SidebarMenuItemWithHover({
   // Must be called unconditionally before any early return to satisfy rules-of-hooks.
   const isGroupActiveByFn = useMemo(() => {
     if (!("children" in item) || !item.children) return false;
-    return (item as NavGroupItem).children.some((child) => {
-      if ("isActiveFn" in child && child.isActiveFn) return child.isActiveFn(pathname);
-      if ("kind" in child && child.kind === "collapsible-subgroup") {
-        return child.children.some((c) => c.isActiveFn?.(pathname));
-      }
-      if ("children" in child) return (child.children ?? []).some((c) => c.isActiveFn?.(pathname));
-      return false;
-    });
+    return isNavGroupActiveForPathname(item as NavGroupItem, pathname);
   }, [item, pathname]);
 
   if (isSimpleItem && simpleItem) {

--- a/apps/client/src/core/components/sidebar/types.ts
+++ b/apps/client/src/core/components/sidebar/types.ts
@@ -19,7 +19,7 @@ export interface SimpleNavItem extends BaseNavItem {
 
 // Nav group item with children
 export interface NavGroupItem extends BaseNavItem {
-  children: (SimpleNavItem | NavSubGroupItem)[];
+  children: (SimpleNavItem | NavSubGroupItem | NavCollapsibleSubGroupItem)[];
   defaultRoute?: RouteParams; // Route to navigate to when clicking the group
   groupRoute?: AnyRoute; // Parent route for active state detection of groups
   route?: never;
@@ -27,8 +27,20 @@ export interface NavGroupItem extends BaseNavItem {
 
 // Sub-group item (second level) that contains simple nav items
 export interface NavSubGroupItem {
+  kind?: never;
   title: string;
   children: SimpleNavItem[];
+  icon?: never;
+  route?: never;
+  defaultRoute?: never;
+  groupRoute?: never;
+}
+
+export interface NavCollapsibleSubGroupItem {
+  kind: "collapsible-subgroup";
+  title: string;
+  children: SimpleNavItem[];
+  defaultOpen?: boolean;
   icon?: never;
   route?: never;
   defaultRoute?: never;

--- a/apps/client/src/core/components/sidebar/utils.ts
+++ b/apps/client/src/core/components/sidebar/utils.ts
@@ -1,6 +1,24 @@
 import { getIconTypeFromPath } from "@/core/constants/page-icons";
 import type { PinnedPage } from "@/core/hooks/usePinnedItems";
 import type { RouteParams } from "@/core/router/types";
+import type { NavGroupItem } from "./types";
+
+/**
+ * Returns true when `pathname` activates any child of a nav group — a simple
+ * item's `isActiveFn`, a collapsible-subgroup child, or a sub-group child.
+ * Shared by useSidebarMenu (auto-open state) and SidebarMenuItemWithHover
+ * (active highlight) so the two stay in sync.
+ */
+export function isNavGroupActiveForPathname(item: NavGroupItem, pathname: string): boolean {
+  return item.children.some((child) => {
+    if ("isActiveFn" in child && child.isActiveFn) return child.isActiveFn(pathname);
+    if ("kind" in child && child.kind === "collapsible-subgroup") {
+      return child.children.some((c) => c.isActiveFn?.(pathname));
+    }
+    if ("children" in child) return (child.children ?? []).some((c) => c.isActiveFn?.(pathname));
+    return false;
+  });
+}
 
 /**
  * Helper to create a pin config from route and title.

--- a/apps/client/src/core/components/ui/slider/index.tsx
+++ b/apps/client/src/core/components/ui/slider/index.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import { cn } from "@/core/utils/classname";
+
+type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+  thumbAriaLabel?: string | ((index: number) => string);
+};
+
+export const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, SliderProps>(
+  ({ className, value, defaultValue, thumbAriaLabel, ...props }, ref) => {
+    // Derive the number of thumbs from controlled `value` or uncontrolled `defaultValue`.
+    // Fall back to 1 so the primitive is always usable without explicit values.
+    const thumbCount = (value ?? defaultValue ?? [0]).length;
+    return (
+      <SliderPrimitive.Root
+        ref={ref}
+        value={value}
+        defaultValue={defaultValue}
+        className={cn("relative flex w-full touch-none items-center select-none", className)}
+        {...props}
+      >
+        <SliderPrimitive.Track className="bg-secondary relative h-1.5 w-full grow overflow-hidden rounded-full">
+          <SliderPrimitive.Range className="bg-primary absolute h-full" />
+        </SliderPrimitive.Track>
+        {Array.from({ length: thumbCount }, (_, i) => {
+          // For multi-thumb sliders, fall back to a generic "Value N" label so the
+          // primitive remains WCAG-compliant when callers forget to pass one.
+          // Single-thumb sliders inherit aria-label from the Root via Radix.
+          const ariaLabel =
+            typeof thumbAriaLabel === "function"
+              ? thumbAriaLabel(i)
+              : (thumbAriaLabel ?? (thumbCount > 1 ? `Value ${i + 1}` : undefined));
+          return (
+            <SliderPrimitive.Thumb
+              key={i}
+              aria-label={ariaLabel}
+              className="border-primary bg-background focus-visible:ring-ring block h-4 w-4 rounded-full border-2 shadow transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+            />
+          );
+        })}
+      </SliderPrimitive.Root>
+    );
+  }
+);
+
+Slider.displayName = "Slider";

--- a/apps/client/src/core/components/ui/slider/slider.stories.tsx
+++ b/apps/client/src/core/components/ui/slider/slider.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { Slider } from "./index";
+
+const meta = {
+  title: "Core/UI/Slider",
+  component: Slider,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Slider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    const [v, setV] = useState([3]);
+    return (
+      <div className="w-72">
+        <Slider value={v} onValueChange={setV} min={0} max={20} step={1} />
+        <p className="mt-2 text-sm">value: {v[0]}</p>
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="w-72">
+      {/* No-op onValueChange so the controlled-mode contract is explicit (Radix
+          silently ignores keyboard interaction on a controlled Slider without one). */}
+      <Slider value={[5]} onValueChange={() => {}} min={0} max={10} disabled />
+    </div>
+  ),
+};
+
+export const Range: Story = {
+  render: () => {
+    const [v, setV] = useState([2, 8]);
+    return (
+      <div className="w-72">
+        <Slider value={v} onValueChange={setV} min={0} max={10} step={1} />
+        <p className="mt-2 text-sm">
+          range: {v[0]} – {v[1]}
+        </p>
+      </div>
+    );
+  },
+};

--- a/apps/client/src/core/hooks/useSidebarMenu.test.ts
+++ b/apps/client/src/core/hooks/useSidebarMenu.test.ts
@@ -5,24 +5,8 @@ import type {
   NavSubGroupItem,
   SimpleNavItem,
 } from "../components/sidebar/types";
-
-// Re-export the private function under test by extracting it via a small helper
-// import. We test the exported function indirectly because it is not exported,
-// so we duplicate it here to keep the test self-contained and focused.
-function isGroupActiveForPathname(item: NavGroupItem, pathname: string): boolean {
-  return item.children.some((child) => {
-    if ("isActiveFn" in child && (child as SimpleNavItem).isActiveFn) {
-      return (child as SimpleNavItem).isActiveFn!(pathname);
-    }
-    if ((child as NavCollapsibleSubGroupItem).kind === "collapsible-subgroup") {
-      return (child as NavCollapsibleSubGroupItem).children.some((c) => c.isActiveFn?.(pathname));
-    }
-    if ("children" in child) {
-      return (child as NavSubGroupItem).children.some((c) => c.isActiveFn?.(pathname));
-    }
-    return false;
-  });
-}
+// The real, shared predicate (also used by useSidebarMenu and SidebarMenuItemWithHover).
+import { isNavGroupActiveForPathname } from "../components/sidebar/utils";
 
 const makeSimple = (matchPrefix: string): SimpleNavItem => ({
   title: matchPrefix,
@@ -30,7 +14,7 @@ const makeSimple = (matchPrefix: string): SimpleNavItem => ({
   isActiveFn: (p: string) => p.startsWith(`/${matchPrefix}`),
 });
 
-describe("isGroupActiveForPathname — NavCollapsibleSubGroupItem", () => {
+describe("isNavGroupActiveForPathname — NavCollapsibleSubGroupItem", () => {
   it("returns true when a collapsible-subgroup child's isActiveFn matches", () => {
     const collapsible: NavCollapsibleSubGroupItem = {
       kind: "collapsible-subgroup",
@@ -39,7 +23,7 @@ describe("isGroupActiveForPathname — NavCollapsibleSubGroupItem", () => {
     };
     const group: NavGroupItem = { title: "Custom Resources", children: [collapsible] };
 
-    expect(isGroupActiveForPathname(group, "/pipelines/my-run")).toBe(true);
+    expect(isNavGroupActiveForPathname(group, "/pipelines/my-run")).toBe(true);
   });
 
   it("returns false when no collapsible-subgroup child matches", () => {
@@ -50,7 +34,7 @@ describe("isGroupActiveForPathname — NavCollapsibleSubGroupItem", () => {
     };
     const group: NavGroupItem = { title: "Custom Resources", children: [collapsible] };
 
-    expect(isGroupActiveForPathname(group, "/unrelated/path")).toBe(false);
+    expect(isNavGroupActiveForPathname(group, "/unrelated/path")).toBe(false);
   });
 
   it("returns true when NavSubGroupItem side matches in a mixed group", () => {
@@ -66,7 +50,7 @@ describe("isGroupActiveForPathname — NavCollapsibleSubGroupItem", () => {
     const group: NavGroupItem = { title: "Mixed", children: [collapsible, subGroup] };
 
     // Only subGroup side matches
-    expect(isGroupActiveForPathname(group, "/pods/my-pod")).toBe(true);
+    expect(isNavGroupActiveForPathname(group, "/pods/my-pod")).toBe(true);
   });
 
   it("returns true when NavCollapsibleSubGroupItem side matches in a mixed group", () => {
@@ -82,7 +66,7 @@ describe("isGroupActiveForPathname — NavCollapsibleSubGroupItem", () => {
     const group: NavGroupItem = { title: "Mixed", children: [collapsible, subGroup] };
 
     // Only collapsible side matches
-    expect(isGroupActiveForPathname(group, "/pipelines/my-run")).toBe(true);
+    expect(isNavGroupActiveForPathname(group, "/pipelines/my-run")).toBe(true);
   });
 
   it("returns false when neither side matches in a mixed group", () => {
@@ -97,6 +81,6 @@ describe("isGroupActiveForPathname — NavCollapsibleSubGroupItem", () => {
     };
     const group: NavGroupItem = { title: "Mixed", children: [collapsible, subGroup] };
 
-    expect(isGroupActiveForPathname(group, "/unrelated")).toBe(false);
+    expect(isNavGroupActiveForPathname(group, "/unrelated")).toBe(false);
   });
 });

--- a/apps/client/src/core/hooks/useSidebarMenu.test.ts
+++ b/apps/client/src/core/hooks/useSidebarMenu.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type {
+  NavCollapsibleSubGroupItem,
+  NavGroupItem,
+  NavSubGroupItem,
+  SimpleNavItem,
+} from "../components/sidebar/types";
+
+// Re-export the private function under test by extracting it via a small helper
+// import. We test the exported function indirectly because it is not exported,
+// so we duplicate it here to keep the test self-contained and focused.
+function isGroupActiveForPathname(item: NavGroupItem, pathname: string): boolean {
+  return item.children.some((child) => {
+    if ("isActiveFn" in child && (child as SimpleNavItem).isActiveFn) {
+      return (child as SimpleNavItem).isActiveFn!(pathname);
+    }
+    if ((child as NavCollapsibleSubGroupItem).kind === "collapsible-subgroup") {
+      return (child as NavCollapsibleSubGroupItem).children.some((c) => c.isActiveFn?.(pathname));
+    }
+    if ("children" in child) {
+      return (child as NavSubGroupItem).children.some((c) => c.isActiveFn?.(pathname));
+    }
+    return false;
+  });
+}
+
+const makeSimple = (matchPrefix: string): SimpleNavItem => ({
+  title: matchPrefix,
+  route: { to: `/${matchPrefix}`, params: {} } as unknown as SimpleNavItem["route"],
+  isActiveFn: (p: string) => p.startsWith(`/${matchPrefix}`),
+});
+
+describe("isGroupActiveForPathname — NavCollapsibleSubGroupItem", () => {
+  it("returns true when a collapsible-subgroup child's isActiveFn matches", () => {
+    const collapsible: NavCollapsibleSubGroupItem = {
+      kind: "collapsible-subgroup",
+      title: "tekton.dev",
+      children: [makeSimple("pipelines"), makeSimple("tasks")],
+    };
+    const group: NavGroupItem = { title: "Custom Resources", children: [collapsible] };
+
+    expect(isGroupActiveForPathname(group, "/pipelines/my-run")).toBe(true);
+  });
+
+  it("returns false when no collapsible-subgroup child matches", () => {
+    const collapsible: NavCollapsibleSubGroupItem = {
+      kind: "collapsible-subgroup",
+      title: "tekton.dev",
+      children: [makeSimple("pipelines"), makeSimple("tasks")],
+    };
+    const group: NavGroupItem = { title: "Custom Resources", children: [collapsible] };
+
+    expect(isGroupActiveForPathname(group, "/unrelated/path")).toBe(false);
+  });
+
+  it("returns true when NavSubGroupItem side matches in a mixed group", () => {
+    const collapsible: NavCollapsibleSubGroupItem = {
+      kind: "collapsible-subgroup",
+      title: "tekton.dev",
+      children: [makeSimple("pipelines")],
+    };
+    const subGroup: NavSubGroupItem = {
+      title: "Workloads",
+      children: [makeSimple("pods")],
+    };
+    const group: NavGroupItem = { title: "Mixed", children: [collapsible, subGroup] };
+
+    // Only subGroup side matches
+    expect(isGroupActiveForPathname(group, "/pods/my-pod")).toBe(true);
+  });
+
+  it("returns true when NavCollapsibleSubGroupItem side matches in a mixed group", () => {
+    const collapsible: NavCollapsibleSubGroupItem = {
+      kind: "collapsible-subgroup",
+      title: "tekton.dev",
+      children: [makeSimple("pipelines")],
+    };
+    const subGroup: NavSubGroupItem = {
+      title: "Workloads",
+      children: [makeSimple("pods")],
+    };
+    const group: NavGroupItem = { title: "Mixed", children: [collapsible, subGroup] };
+
+    // Only collapsible side matches
+    expect(isGroupActiveForPathname(group, "/pipelines/my-run")).toBe(true);
+  });
+
+  it("returns false when neither side matches in a mixed group", () => {
+    const collapsible: NavCollapsibleSubGroupItem = {
+      kind: "collapsible-subgroup",
+      title: "tekton.dev",
+      children: [makeSimple("pipelines")],
+    };
+    const subGroup: NavSubGroupItem = {
+      title: "Workloads",
+      children: [makeSimple("pods")],
+    };
+    const group: NavGroupItem = { title: "Mixed", children: [collapsible, subGroup] };
+
+    expect(isGroupActiveForPathname(group, "/unrelated")).toBe(false);
+  });
+});

--- a/apps/client/src/core/hooks/useSidebarMenu.ts
+++ b/apps/client/src/core/hooks/useSidebarMenu.ts
@@ -2,12 +2,21 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { useMatches } from "@tanstack/react-router";
 import { useLocation } from "@tanstack/react-router";
 import { useSidebar } from "../components/ui/sidebar";
-import type { NavGroupItem, NavItem, NavSubGroupItem, SimpleNavItem } from "../components/sidebar/types";
+import type {
+  NavCollapsibleSubGroupItem,
+  NavGroupItem,
+  NavItem,
+  NavSubGroupItem,
+  SimpleNavItem,
+} from "../components/sidebar/types";
 
 function isGroupActiveForPathname(item: NavGroupItem, pathname: string): boolean {
   return item.children.some((child) => {
     if ("isActiveFn" in child && (child as SimpleNavItem).isActiveFn) {
       return (child as SimpleNavItem).isActiveFn!(pathname);
+    }
+    if ((child as NavCollapsibleSubGroupItem).kind === "collapsible-subgroup") {
+      return (child as NavCollapsibleSubGroupItem).children.some((c) => c.isActiveFn?.(pathname));
     }
     if ("children" in child) {
       return (child as NavSubGroupItem).children.some((c) => c.isActiveFn?.(pathname));

--- a/apps/client/src/core/hooks/useSidebarMenu.ts
+++ b/apps/client/src/core/hooks/useSidebarMenu.ts
@@ -2,28 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { useMatches } from "@tanstack/react-router";
 import { useLocation } from "@tanstack/react-router";
 import { useSidebar } from "../components/ui/sidebar";
-import type {
-  NavCollapsibleSubGroupItem,
-  NavGroupItem,
-  NavItem,
-  NavSubGroupItem,
-  SimpleNavItem,
-} from "../components/sidebar/types";
-
-function isGroupActiveForPathname(item: NavGroupItem, pathname: string): boolean {
-  return item.children.some((child) => {
-    if ("isActiveFn" in child && (child as SimpleNavItem).isActiveFn) {
-      return (child as SimpleNavItem).isActiveFn!(pathname);
-    }
-    if ((child as NavCollapsibleSubGroupItem).kind === "collapsible-subgroup") {
-      return (child as NavCollapsibleSubGroupItem).children.some((c) => c.isActiveFn?.(pathname));
-    }
-    if ("children" in child) {
-      return (child as NavSubGroupItem).children.some((c) => c.isActiveFn?.(pathname));
-    }
-    return false;
-  });
-}
+import type { NavGroupItem, NavItem } from "../components/sidebar/types";
+import { isNavGroupActiveForPathname } from "../components/sidebar/utils";
 
 /**
  * Custom hook for managing sidebar menu state
@@ -44,7 +24,7 @@ export function useSidebarMenu(nav: NavItem[], routerMatches: ReturnType<typeof 
         }
       }
 
-      return isGroupActiveForPathname(groupItem, pathname);
+      return isNavGroupActiveForPathname(groupItem, pathname);
     });
   }, [nav, routerMatches, pathname]);
 

--- a/apps/client/src/core/router/index.ts
+++ b/apps/client/src/core/router/index.ts
@@ -24,6 +24,11 @@ import { routeK8sOverview } from "@/modules/k8s/pages/overview/route";
 import { routeK8sList } from "@/modules/k8s/pages/list/route";
 import { routeK8sDetailNamespaced } from "@/modules/k8s/pages/detail-namespaced/route";
 import { routeK8sDetailCluster } from "@/modules/k8s/pages/detail-cluster/route";
+import { routeK8sCRDsDetail } from "@/modules/k8s/pages/crds/detail/route";
+import { routeK8sCRParent } from "@/modules/k8s/pages/custom-resources/cr-parent/route";
+import { routeK8sCRList } from "@/modules/k8s/pages/custom-resources/list/route";
+import { routeK8sCRDetailNs } from "@/modules/k8s/pages/custom-resources/detail-namespaced/route";
+import { routeK8sCRDetailCluster } from "@/modules/k8s/pages/custom-resources/detail-cluster/route";
 import { routeK8sPodsList } from "@/modules/k8s/pages/pods/list/route";
 import { routeK8sPodDetail } from "@/modules/k8s/pages/pods/detail/route";
 import { routeK8sNodesList } from "@/modules/k8s/pages/nodes/list/route";
@@ -194,6 +199,8 @@ const routeTree = rootRoute.addChildren([
         routeK8sList,
         routeK8sDetailNamespaced,
         routeK8sDetailCluster,
+        routeK8sCRDsDetail,
+        routeK8sCRParent.addChildren([routeK8sCRList, routeK8sCRDetailNs, routeK8sCRDetailCluster]),
         routeK8sPodsList,
         routeK8sPodDetail,
         routeK8sNodesList,

--- a/apps/client/src/k8s/api/hooks/usePermissions/index.test.tsx
+++ b/apps/client/src/k8s/api/hooks/usePermissions/index.test.tsx
@@ -5,14 +5,10 @@ import { usePermissions } from "./index";
 import { useTRPCClient } from "@/core/providers/trpc";
 import { createTestQueryClient } from "@/test/utils";
 import { defaultPermissions } from "@my-project/shared";
-import { getK8sAPIQueryCacheKey } from "../useWatch/query-keys";
 
 // Mock dependencies
 const mockTrpcClient = {
   k8s: {
-    apiVersions: {
-      query: vi.fn(),
-    },
     itemPermissions: {
       mutate: vi.fn(),
     },
@@ -58,8 +54,7 @@ describe("usePermissions", () => {
     mockClusterStoreState.defaultNamespace = "default";
   });
 
-  it("should fetch permissions with default apiVersion when not cached", async () => {
-    vi.mocked(mockTrpcClient.k8s.apiVersions.query).mockResolvedValue("v1");
+  it("should call itemPermissions.mutate with the resolved GVR + cluster + namespace", async () => {
     const mockPermissions = {
       create: { allowed: true, reason: "" },
       patch: { allowed: true, reason: "" },
@@ -87,9 +82,7 @@ describe("usePermissions", () => {
       { timeout: 5000 }
     );
 
-    expect(mockTrpcClient.k8s.apiVersions.query).toHaveBeenCalled();
     expect(mockTrpcClient.k8s.itemPermissions.mutate).toHaveBeenCalledWith({
-      apiVersion: "v1",
       clusterName: "test-cluster",
       group: "test.group",
       version: "v1",
@@ -98,101 +91,10 @@ describe("usePermissions", () => {
     });
   });
 
-  it("should use cached apiVersion when available", async () => {
-    // Set cached apiVersion
-    queryClient.setQueryData(getK8sAPIQueryCacheKey(), "v2");
-
-    const mockPermissions = {
-      create: { allowed: true, reason: "" },
-    };
-    vi.mocked(mockTrpcClient.k8s.itemPermissions.mutate).mockResolvedValue(mockPermissions);
-
-    const { result } = renderHook(
-      () =>
-        usePermissions({
-          group: "test.group",
-          version: "v1",
-          resourcePlural: "resources",
-        }),
-      {
-        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
-      }
-    );
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    // Should not call apiVersions.query when cached
-    expect(mockTrpcClient.k8s.apiVersions.query).not.toHaveBeenCalled();
-    expect(mockTrpcClient.k8s.itemPermissions.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiVersion: "v2",
-      })
-    );
-  });
-
-  it("should use default apiVersion when cache is empty and apiVersions query fails", async () => {
-    vi.mocked(mockTrpcClient.k8s.apiVersions.query).mockRejectedValue(new Error("Failed"));
-    const mockPermissions = {
-      create: { allowed: true, reason: "" },
-    };
-    vi.mocked(mockTrpcClient.k8s.itemPermissions.mutate).mockResolvedValue(mockPermissions);
-
-    const { result } = renderHook(
-      () =>
-        usePermissions({
-          group: "test.group",
-          version: "v1",
-          resourcePlural: "resources",
-        }),
-      {
-        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
-      }
-    );
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    // Should use default "v1" when apiVersions fails
-    expect(mockTrpcClient.k8s.itemPermissions.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiVersion: "v1",
-      })
-    );
-  });
-
-  it("should cache apiVersion after fetching", async () => {
-    vi.mocked(mockTrpcClient.k8s.apiVersions.query).mockResolvedValue("v2");
-    const mockPermissions = {
-      create: { allowed: true, reason: "" },
-    };
-    vi.mocked(mockTrpcClient.k8s.itemPermissions.mutate).mockResolvedValue(mockPermissions);
-
-    renderHook(
-      () =>
-        usePermissions({
-          group: "test.group",
-          version: "v1",
-          resourcePlural: "resources",
-        }),
-      {
-        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
-      }
-    );
-
-    await waitFor(() => {
-      const cachedApiVersion = queryClient.getQueryData<string>(getK8sAPIQueryCacheKey());
-      expect(cachedApiVersion).toBe("v2");
-    });
-  });
-
   it("should use cluster name and namespace from store", async () => {
     mockClusterStoreState.clusterName = "custom-cluster";
     mockClusterStoreState.defaultNamespace = "custom-namespace";
 
-    vi.mocked(mockTrpcClient.k8s.apiVersions.query).mockResolvedValue("v1");
     const mockPermissions = {
       create: { allowed: true, reason: "" },
     };
@@ -237,20 +139,20 @@ describe("usePermissions", () => {
     expect(result.current.data).toEqual(defaultPermissions);
   });
 
-  it("should have infinite stale time and gc time", () => {
-    const { result } = renderHook(
+  it("should skip the network call when enabled is false", () => {
+    renderHook(
       () =>
         usePermissions({
           group: "test.group",
           version: "v1",
           resourcePlural: "resources",
+          enabled: false,
         }),
       {
         wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
       }
     );
 
-    // Check query options - permissions query should have infinite stale time
-    expect(result.current.data).toBeDefined();
+    expect(mockTrpcClient.k8s.itemPermissions.mutate).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/src/k8s/api/hooks/usePermissions/index.ts
+++ b/apps/client/src/k8s/api/hooks/usePermissions/index.ts
@@ -1,9 +1,9 @@
-import { DefinedUseQueryResult, useQuery, useQueryClient } from "@tanstack/react-query";
+import { DefinedUseQueryResult, useQuery } from "@tanstack/react-query";
 import { defaultPermissions, DefaultPermissionListCheckResult } from "@my-project/shared";
 import { useShallow } from "zustand/react/shallow";
 import { useTRPCClient } from "@/core/providers/trpc";
 import { useClusterStore } from "@/k8s/store";
-import { getK8sItemPermissionsQueryCacheKey, getK8sAPIQueryCacheKey } from "../useWatch/query-keys";
+import { getK8sItemPermissionsQueryCacheKey } from "../useWatch/query-keys";
 
 /**
  * Returns create/update/delete permissions for the given resource in the user's
@@ -17,10 +17,17 @@ export const usePermissions = ({
   group,
   version,
   resourcePlural,
+  enabled = true,
 }: {
   group: string;
   version: string;
   resourcePlural: string;
+  /**
+   * Set to false to skip the network call entirely (e.g. while the resource type
+   * is still being resolved). The returned `data` falls back to `defaultPermissions`
+   * (all denied), keeping action buttons safely disabled until the type is known.
+   */
+  enabled?: boolean;
 }) => {
   const trpc = useTRPCClient();
   const { clusterName, defaultNamespace: namespace } = useClusterStore(
@@ -29,28 +36,15 @@ export const usePermissions = ({
       defaultNamespace: state.defaultNamespace,
     }))
   );
-  const queryClient = useQueryClient();
-  const k8sItemPermissionsCacheKey = getK8sItemPermissionsQueryCacheKey(clusterName, namespace, resourcePlural);
-  const k8sAPIQueryCacheKey = getK8sAPIQueryCacheKey();
+  const k8sItemPermissionsCacheKey = getK8sItemPermissionsQueryCacheKey(clusterName, namespace, group, resourcePlural);
 
   const permissionsQuery = useQuery({
     queryKey: k8sItemPermissionsCacheKey,
     queryFn: async () => {
-      const cachedApiVersion = queryClient.getQueryData<string>(k8sAPIQueryCacheKey);
-      let apiVersion = cachedApiVersion || "v1"; // default apiVersion
-
-      if (!cachedApiVersion) {
-        try {
-          apiVersion = await trpc.k8s.apiVersions.query();
-          queryClient.setQueryData(k8sAPIQueryCacheKey, apiVersion);
-        } catch {
-          // Fall back to default "v1" if query fails
-          apiVersion = "v1";
-        }
-      }
-
+      // The SSARS object's own apiVersion is always authorization.k8s.io/v1 — the
+      // server hardcodes it. We previously fetched the cluster's apiVersions endpoint
+      // and forwarded the result here, but the server silently discarded the value.
       const res = await trpc.k8s.itemPermissions.mutate({
-        apiVersion,
         clusterName,
         group,
         version,
@@ -62,6 +56,7 @@ export const usePermissions = ({
     placeholderData: defaultPermissions,
     staleTime: Infinity,
     gcTime: Infinity,
+    enabled,
   });
 
   // Ensure data is always defined, even on error (use defaultPermissions as fallback)

--- a/apps/client/src/k8s/api/hooks/useWatch/query-keys/index.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/query-keys/index.ts
@@ -2,39 +2,62 @@ import { ResourceLabels } from "@my-project/shared";
 
 const CLUSTER_SCOPE_KEY = "__cluster__";
 
-export function getK8sAPIQueryCacheKey(): string[] {
-  return ["k8s:api"];
-}
-
 export function getK8sItemPermissionsQueryCacheKey(
   clusterName: string,
   namespace: string,
+  group: string,
   resourcePlural: string
 ): string[] {
-  return ["k8s:itemPermissions", clusterName, namespace, resourcePlural];
+  // `group` is part of RBAC identity: a CRD whose plural collides with a built-in
+  // (e.g. `pods.mycompany.io` vs core `pods`) must not share a permissions cache entry.
+  return ["k8s:itemPermissions", clusterName, namespace, group, resourcePlural];
 }
 
 export function getK8sWatchListQueryCacheKey(
   clusterName: string,
   namespace: string | undefined,
+  group: string,
   resourcePlural: string,
   labels?: ResourceLabels
 ): (string | undefined)[] {
   const nsKey = namespace ?? CLUSTER_SCOPE_KEY;
   const hasLabels = labels && Object.keys(labels).length > 0;
 
+  // `group` is part of resource identity: a CRD whose plural collides with a
+  // built-in (e.g. `pods.mycompany.io` vs core `pods`) or another CRD must not
+  // share a watch cache entry.
   if (hasLabels) {
-    return ["k8s:watchList", clusterName, nsKey, resourcePlural, Object.entries(labels).toString()];
+    return ["k8s:watchList", clusterName, nsKey, group, resourcePlural, Object.entries(labels).toString()];
   }
 
-  return ["k8s:watchList", clusterName, nsKey, resourcePlural];
+  return ["k8s:watchList", clusterName, nsKey, group, resourcePlural];
 }
 
 export function getK8sWatchItemQueryCacheKey(
   clusterName: string,
   namespace: string | undefined,
+  group: string,
   resourcePlural: string,
   name: string | undefined
 ): (string | undefined)[] {
-  return ["k8s:watchItem", clusterName, namespace ?? CLUSTER_SCOPE_KEY, resourcePlural, name];
+  return ["k8s:watchItem", clusterName, namespace ?? CLUSTER_SCOPE_KEY, group, resourcePlural, name];
+}
+
+/**
+ * Returns the prefix key that matches ALL watchItem queries for a given
+ * cluster + namespace + group + resource plural, regardless of the item name.
+ * Use with {@link QueryClient.invalidateQueries} (prefix matching) to
+ * invalidate every open detail page for a resource type in one call.
+ */
+export function getK8sWatchItemQueryCacheKeyPrefix(
+  clusterName: string,
+  namespace: string | undefined,
+  group: string,
+  resourcePlural: string
+): string[] {
+  return ["k8s:watchItem", clusterName, namespace ?? CLUSTER_SCOPE_KEY, group, resourcePlural];
+}
+
+export function getK8sDeploymentRevisionsQueryCacheKey(clusterName: string, namespace: string, name: string): string[] {
+  return ["k8s:deploymentRevisions", clusterName, namespace, name];
 }

--- a/apps/client/src/k8s/api/hooks/useWatch/useWatchItem/index.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/useWatchItem/index.ts
@@ -49,13 +49,13 @@ export const useWatchItem = <I extends KubeObjectBase>({
   const queryClient = useQueryClient();
 
   const queryKey = React.useMemo(
-    () => getK8sWatchItemQueryCacheKey(clusterName, _namespace, resourceConfig.pluralName, name),
-    [clusterName, _namespace, resourceConfig.pluralName, name]
+    () => getK8sWatchItemQueryCacheKey(clusterName, _namespace, resourceConfig.group, resourceConfig.pluralName, name),
+    [clusterName, _namespace, resourceConfig.group, resourceConfig.pluralName, name]
   );
 
   const listQueryKey = React.useMemo(
-    () => getK8sWatchListQueryCacheKey(clusterName, _namespace, resourceConfig.pluralName),
-    [clusterName, _namespace, resourceConfig.pluralName]
+    () => getK8sWatchListQueryCacheKey(clusterName, _namespace, resourceConfig.group, resourceConfig.pluralName),
+    [clusterName, _namespace, resourceConfig.group, resourceConfig.pluralName]
   );
 
   const query = useQuery<I | undefined, RequestError>({

--- a/apps/client/src/k8s/api/hooks/useWatch/useWatchList/index.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/useWatchList/index.ts
@@ -49,9 +49,16 @@ export const useWatchList = <I extends KubeObjectBase>({
   const queryClient = useQueryClient();
 
   const queryKey = React.useMemo(
-    () => getK8sWatchListQueryCacheKey(clusterName, _namespace, resourceConfig.pluralName, labels),
+    () =>
+      getK8sWatchListQueryCacheKey(clusterName, _namespace, resourceConfig.group, resourceConfig.pluralName, labels),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [_namespace, clusterName, resourceConfig.pluralName, labels ? JSON.stringify(labels) : undefined]
+    [
+      _namespace,
+      clusterName,
+      resourceConfig.group,
+      resourceConfig.pluralName,
+      labels ? JSON.stringify(labels) : undefined,
+    ]
   );
 
   const query = useQuery<CustomKubeObjectList<I>, RequestError>({

--- a/apps/client/src/k8s/api/hooks/useWatch/useWatchListMultiple/index.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/useWatchListMultiple/index.ts
@@ -87,9 +87,12 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
 
   // Generate query keys for all namespaces
   const namespaceQueryKeys = useMemo(
-    () => _namespaces.map((ns) => getK8sWatchListQueryCacheKey(clusterName, ns, resourceConfig.pluralName, labels)),
+    () =>
+      _namespaces.map((ns) =>
+        getK8sWatchListQueryCacheKey(clusterName, ns, resourceConfig.group, resourceConfig.pluralName, labels)
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [clusterName, namespacesKey, resourceConfig.pluralName, labelsKey]
+    [clusterName, namespacesKey, resourceConfig.group, resourceConfig.pluralName, labelsKey]
   );
 
   // Create individual queries for each namespace

--- a/apps/client/src/modules/k8s/components/ConditionsTable/index.test.tsx
+++ b/apps/client/src/modules/k8s/components/ConditionsTable/index.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ConditionsTable } from "./index";
+
+const conds = [
+  {
+    type: "Established",
+    status: "True",
+    lastTransitionTime: "2026-05-15T10:00:00Z",
+    reason: "InitialNamesAccepted",
+    message: "the initial names have been accepted",
+  },
+  {
+    type: "NamesAccepted",
+    status: "False",
+    lastTransitionTime: "2026-05-15T11:00:00Z",
+    reason: "Conflict",
+    message: "name conflict with another CRD",
+  },
+];
+
+describe("ConditionsTable", () => {
+  it("renders an empty-state message when conditions array is empty", () => {
+    render(<ConditionsTable conditions={[]} />);
+    expect(screen.getByText(/no conditions reported/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders all 5 column headers and each condition row", () => {
+    render(<ConditionsTable conditions={conds} />);
+    for (const h of ["Type", "Status", "Last Transition", "Reason", "Message"]) {
+      const header = screen.getByRole("columnheader", { name: h });
+      expect(header).toBeInTheDocument();
+      expect(header).toHaveAttribute("scope", "col");
+    }
+    expect(screen.getByText("Established")).toBeInTheDocument();
+    expect(screen.getByText("NamesAccepted")).toBeInTheDocument();
+  });
+
+  it("color-codes positive Type badges (Established/True) as success", () => {
+    render(<ConditionsTable conditions={conds} />);
+    const established = screen.getByText("Established").closest("[data-variant]");
+    expect(established?.getAttribute("data-variant")).toBe("success");
+  });
+
+  it("color-codes False status of a positive Type as destructive", () => {
+    render(<ConditionsTable conditions={conds} />);
+    const namesAccepted = screen.getByText("NamesAccepted").closest("[data-variant]");
+    expect(namesAccepted?.getAttribute("data-variant")).toBe("destructive");
+  });
+
+  it("returns secondary variant for Unknown status regardless of Type", () => {
+    const unknown = [
+      {
+        type: "Established",
+        status: "Unknown",
+        lastTransitionTime: "2026-05-15T10:00:00Z",
+        reason: "",
+        message: "",
+      },
+      {
+        type: "SomethingCustom",
+        status: "Unknown",
+        lastTransitionTime: "2026-05-15T10:00:00Z",
+        reason: "",
+        message: "",
+      },
+    ];
+    render(<ConditionsTable conditions={unknown} />);
+    const established = screen.getByText("Established").closest("[data-variant]");
+    const custom = screen.getByText("SomethingCustom").closest("[data-variant]");
+    expect(established?.getAttribute("data-variant")).toBe("secondary");
+    expect(custom?.getAttribute("data-variant")).toBe("secondary");
+  });
+});

--- a/apps/client/src/modules/k8s/components/ConditionsTable/index.tsx
+++ b/apps/client/src/modules/k8s/components/ConditionsTable/index.tsx
@@ -1,0 +1,76 @@
+import { Badge } from "@/core/components/ui/badge";
+import { TableUI, TableBodyUI, TableCellUI, TableHeadUI, TableHeaderUI, TableRowUI } from "@/core/components/ui/table";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { formatRelativeTime } from "@/core/utils/date-humanize";
+import type { KubeCondition } from "@my-project/shared";
+
+type Variant = "success" | "destructive" | "secondary";
+
+// Condition types where status=True is the desirable outcome.
+// "Progressing" is included because for a Deployment a rolling rollout reports
+// Progressing=True as a healthy in-flight state; treating it as destructive
+// would surface a red badge during every routine deploy.
+const POSITIVE_TYPES = new Set([
+  "Established",
+  "NamesAccepted",
+  "Ready",
+  "Available",
+  "Initialized",
+  "ContainersReady",
+  "PodScheduled",
+  "Healthy",
+  "Progressing",
+]);
+
+function variantFor(type: string, status: string): Variant {
+  const positive = POSITIVE_TYPES.has(type);
+  if (status === "True") return positive ? "success" : "destructive";
+  if (status === "False") return positive ? "destructive" : "success";
+  return "secondary";
+}
+
+export interface ConditionsTableProps {
+  conditions: KubeCondition[];
+}
+
+export function ConditionsTable({ conditions }: ConditionsTableProps) {
+  if (conditions.length === 0) {
+    return <p className="text-muted-foreground py-4 text-sm">No conditions reported.</p>;
+  }
+
+  return (
+    <TableUI>
+      <TableHeaderUI>
+        <TableRowUI>
+          <TableHeadUI scope="col">Type</TableHeadUI>
+          <TableHeadUI scope="col">Status</TableHeadUI>
+          <TableHeadUI scope="col">Reason</TableHeadUI>
+          <TableHeadUI scope="col">Last Transition</TableHeadUI>
+          <TableHeadUI scope="col">Message</TableHeadUI>
+        </TableRowUI>
+      </TableHeaderUI>
+      <TableBodyUI>
+        {conditions.map((c, idx) => {
+          const variant = variantFor(c.type, c.status);
+          return (
+            <TableRowUI key={`${c.type}-${idx}`}>
+              <TableCellUI>
+                <span data-variant={variant}>
+                  <Badge variant={variant}>{c.type}</Badge>
+                </span>
+              </TableCellUI>
+              <TableCellUI>{c.status}</TableCellUI>
+              <TableCellUI>{c.reason ?? "—"}</TableCellUI>
+              <TableCellUI>{c.lastTransitionTime ? formatRelativeTime(c.lastTransitionTime) : "—"}</TableCellUI>
+              <TableCellUI className="max-w-md">
+                <div className="w-full min-w-0">
+                  <TextWithTooltip text={c.message ?? "—"} maxLineAmount={2} />
+                </div>
+              </TableCellUI>
+            </TableRowUI>
+          );
+        })}
+      </TableBodyUI>
+    </TableUI>
+  );
+}

--- a/apps/client/src/modules/k8s/components/K8sSidebar/index.tsx
+++ b/apps/client/src/modules/k8s/components/K8sSidebar/index.tsx
@@ -1,82 +1,26 @@
 import { useMatches, useParams } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { SidebarGroup, SidebarGroupLabel, SidebarMenu } from "@/core/components/ui/sidebar";
 import { SidebarMenuItemWithHover } from "@/core/components/sidebar/SidebarMenuItemWithHover";
 import { useSidebarMenu } from "@/core/hooks/useSidebarMenu";
-import { usePermissions } from "@/k8s/api/hooks/usePermissions";
-import { resourceRegistry } from "../../registry";
 import { createK8sNavigationConfig } from "../../constants/nav";
-
-/**
- * Invisible component that checks create/update/delete permissions for a single
- * K8s resource kind and reports the result back to the parent via `onResult`.
- *
- * Keeping the hook call at the top level of this component satisfies React's
- * Rules of Hooks — the parent renders one instance per registry entry.
- */
-function KindPermissionChecker({
-  resourceKey,
-  group,
-  version,
-  resourcePlural,
-  onResult,
-}: {
-  resourceKey: string;
-  group: string;
-  version: string;
-  resourcePlural: string;
-  onResult: (key: string, allowed: boolean) => void;
-}) {
-  const perms = usePermissions({ group, version, resourcePlural });
-
-  useEffect(() => {
-    const data = perms.data;
-    // While loading, treat as allowed so the sidebar populates immediately.
-    // The watchList call will surface a 403 if the user lacks list/get rights.
-    const anyAllowed = Boolean(data?.create?.allowed || data?.update?.allowed || data?.delete?.allowed);
-    const allowed = perms.isLoading || anyAllowed || !perms.isError;
-    onResult(resourceKey, allowed);
-  }, [resourceKey, perms.data, perms.isLoading, perms.isError, onResult]);
-
-  return null;
-}
+import { useCRSidebarItems } from "./useCRSidebarItems";
 
 export function K8sSidebar({ isMinimized }: { isMinimized: boolean }) {
   const { clusterName } = useParams({ strict: false }) as { clusterName?: string };
   const matches = useMatches();
 
-  // resourceRegistry is `as const`-frozen so entries are stable across renders.
-  const entries = useMemo(() => Object.entries(resourceRegistry), []);
-
-  // Accumulate per-kind permission results from child checkers.
-  // Initial state: all kinds are pre-allowed so the sidebar renders immediately.
-  const [permMap, setPermMap] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(entries.map(([key]) => [key, true]))
-  );
-
-  const onResult = useMemo(
-    () => (key: string, allowed: boolean) => {
-      setPermMap((prev) => {
-        if (prev[key] === allowed) return prev; // avoid unnecessary re-renders
-        return { ...prev, [key]: allowed };
-      });
-    },
-    []
-  );
-
-  const allowedKinds = useMemo(
-    () =>
-      new Set(
-        Object.entries(permMap)
-          .filter(([, allowed]) => allowed)
-          .map(([key]) => key)
-      ),
-    [permMap]
-  );
+  // Show every registered kind in the sidebar. We intentionally do NOT gate visibility
+  // on create/update/delete RBAC: most users only have list/get rights (no write verbs),
+  // and the per-kind SelfSubjectAccessReview can error transiently for kinds the API
+  // server returns 4xx on — both would hide kinds the user can actually browse.
+  // The watchList call on the destination page surfaces 403s when the user truly lacks
+  // list/get rights, so visibility is best handled there, not here.
+  const crSidebarItems = useCRSidebarItems(clusterName ?? "");
 
   const nav = useMemo(
-    () => (clusterName ? createK8sNavigationConfig(clusterName, allowedKinds) : []),
-    [clusterName, allowedKinds]
+    () => (clusterName ? createK8sNavigationConfig(clusterName, crSidebarItems) : []),
+    [clusterName, crSidebarItems]
   );
   const { isMenuOpen, toggleMenu, openMenu, closeMenusExcept } = useSidebarMenu(nav, matches);
 
@@ -85,17 +29,6 @@ export function K8sSidebar({ isMinimized }: { isMinimized: boolean }) {
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Kubernetes</SidebarGroupLabel>
-      {/* Render one invisible checker per registry kind (null renders, hooks at component top-level). */}
-      {entries.map(([key, descriptor]) => (
-        <KindPermissionChecker
-          key={key}
-          resourceKey={key}
-          group={descriptor.config.group}
-          version={descriptor.config.version}
-          resourcePlural={descriptor.config.pluralName}
-          onResult={onResult}
-        />
-      ))}
       <SidebarMenu>
         {nav.map((item) => (
           <SidebarMenuItemWithHover

--- a/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.test.ts
+++ b/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.test.ts
@@ -1,0 +1,167 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const crds = [
+  {
+    metadata: { name: "applications.argoproj.io", uid: "u1", creationTimestamp: "" },
+    spec: {
+      group: "argoproj.io",
+      scope: "Namespaced",
+      names: { kind: "Application", plural: "applications" },
+      versions: [{ name: "v1alpha1", storage: true, served: true }],
+    },
+  },
+  {
+    metadata: { name: "pipelineruns.tekton.dev", uid: "u2", creationTimestamp: "" },
+    spec: {
+      group: "tekton.dev",
+      scope: "Namespaced",
+      names: { kind: "PipelineRun", plural: "pipelineruns" },
+      versions: [{ name: "v1", storage: true, served: true }],
+    },
+  },
+  {
+    metadata: { name: "tasks.tekton.dev", uid: "u3", creationTimestamp: "" },
+    spec: {
+      group: "tekton.dev",
+      scope: "Namespaced",
+      names: { kind: "Task", plural: "tasks" },
+      versions: [{ name: "v1", storage: true, served: true }],
+    },
+  },
+];
+
+const mocked = {
+  ret: { data: { array: crds as never[], map: new Map() }, error: null, isReady: true, isLoading: false },
+};
+
+vi.mock("@/modules/k8s/hooks/useCRDList", () => ({
+  useCRDList: vi.fn(() => mocked.ret),
+}));
+
+import { useCRSidebarItems } from "./useCRSidebarItems";
+
+describe("useCRSidebarItems", () => {
+  it("groups CRDs by spec.group, sorts groups A-Z, sorts kinds A-Z within", () => {
+    const { result } = renderHook(() => useCRSidebarItems("c1"));
+    expect(result.current.map((g) => g.title)).toEqual(["argoproj.io", "tekton.dev"]);
+    expect(result.current[1].children.map((c) => c.title)).toEqual(["PipelineRun", "Task"]);
+  });
+
+  it("uses the storage version in the route URL", () => {
+    const { result } = renderHook(() => useCRSidebarItems("c1"));
+    const pr = result.current[1].children[0];
+    expect(pr.route.params).toMatchObject({ group: "tekton.dev", version: "v1", plural: "pipelineruns" });
+  });
+
+  it("returns empty array on watch error", () => {
+    mocked.ret = {
+      data: { array: [], map: new Map() },
+      error: new Error("boom"),
+      isReady: true,
+      isLoading: false,
+    } as never;
+    const { result } = renderHook(() => useCRSidebarItems("c1"));
+    expect(result.current).toEqual([]);
+    mocked.ret = { data: { array: crds as never[], map: new Map() }, error: null, isReady: true, isLoading: false };
+  });
+
+  it("returns stable identity across renders when CRD data is unchanged", () => {
+    const { result, rerender } = renderHook(() => useCRSidebarItems("c1"));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it("skips CRDs with an empty spec.group to avoid a broken regex", () => {
+    const crdWithEmptyGroup = {
+      metadata: { name: "broken.crd", uid: "u99", creationTimestamp: "" },
+      spec: {
+        group: "",
+        scope: "Namespaced",
+        names: { kind: "Broken", plural: "brokens" },
+        versions: [{ name: "v1", storage: true, served: true }],
+      },
+    };
+    mocked.ret = {
+      data: { array: [...crds, crdWithEmptyGroup] as never[], map: new Map() },
+      error: null,
+      isReady: true,
+      isLoading: false,
+    } as never;
+
+    const { result } = renderHook(() => useCRSidebarItems("c1"));
+    // The empty-group CRD must not appear in any group's children
+    const allChildren = result.current.flatMap((g) => g.children);
+    expect(allChildren.every((c) => c.title !== "Broken")).toBe(true);
+
+    // Restore original mock
+    mocked.ret = { data: { array: crds as never[], map: new Map() }, error: null, isReady: true, isLoading: false };
+  });
+
+  it("does NOT emit a subgroup with an empty title when multiple CRDs have empty spec.group", () => {
+    // Two CRDs with empty group — before the fix, byGroup would create a '' key and
+    // the outer map would emit a collapsible-subgroup with title:''. After the fix the
+    // skip happens at groupBy time so no such entry exists.
+    const emptyGroup1 = {
+      metadata: { name: "alpha.crd", uid: "u100", creationTimestamp: "" },
+      spec: {
+        group: "",
+        scope: "Namespaced",
+        names: { kind: "Alpha", plural: "alphas" },
+        versions: [{ name: "v1", storage: true, served: true }],
+      },
+    };
+    const emptyGroup2 = {
+      metadata: { name: "beta.crd", uid: "u101", creationTimestamp: "" },
+      spec: {
+        group: "",
+        scope: "Namespaced",
+        names: { kind: "Beta", plural: "betas" },
+        versions: [{ name: "v1", storage: true, served: true }],
+      },
+    };
+    mocked.ret = {
+      data: { array: [...crds, emptyGroup1, emptyGroup2] as never[], map: new Map() },
+      error: null,
+      isReady: true,
+      isLoading: false,
+    } as never;
+
+    const { result } = renderHook(() => useCRSidebarItems("c1"));
+    // No subgroup with an empty title must appear
+    expect(result.current.every((g) => g.title !== "")).toBe(true);
+    // Total subgroup count must equal the number of real groups (argoproj.io + tekton.dev = 2)
+    expect(result.current).toHaveLength(2);
+
+    // Restore original mock
+    mocked.ret = { data: { array: crds as never[], map: new Map() }, error: null, isReady: true, isLoading: false };
+  });
+
+  describe("isActiveFn matches list and detail paths", () => {
+    it("matches the CR list path", () => {
+      const { result } = renderHook(() => useCRSidebarItems("c1"));
+      const pr = result.current[1].children[0]; // tekton.dev > PipelineRun
+      expect(pr.isActiveFn!("/c/c1/k8s/cr/tekton.dev/v1/pipelineruns")).toBe(true);
+    });
+
+    it("matches the namespaced CR detail path (ns/...)", () => {
+      const { result } = renderHook(() => useCRSidebarItems("c1"));
+      const pr = result.current[1].children[0];
+      expect(pr.isActiveFn!("/c/c1/k8s/cr/ns/tekton.dev/v1/pipelineruns/default/my-run")).toBe(true);
+    });
+
+    it("matches the cluster-scoped CR detail path (cluster/...)", () => {
+      const { result } = renderHook(() => useCRSidebarItems("c1"));
+      const app = result.current[0].children[0]; // argoproj.io > Application
+      expect(app.isActiveFn!("/c/c1/k8s/cr/cluster/argoproj.io/v1alpha1/applications/my-app")).toBe(true);
+    });
+
+    it("does NOT match paths for a different group or plural", () => {
+      const { result } = renderHook(() => useCRSidebarItems("c1"));
+      const pr = result.current[1].children[0];
+      expect(pr.isActiveFn!("/c/c1/k8s/cr/tekton.dev/v1/tasks")).toBe(false);
+      expect(pr.isActiveFn!("/c/c1/k8s/cr/argoproj.io/v1/pipelineruns")).toBe(false);
+    });
+  });
+});

--- a/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.ts
+++ b/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.ts
@@ -1,0 +1,74 @@
+import { useMemo } from "react";
+import { Puzzle } from "lucide-react";
+import { useCRDList } from "@/modules/k8s/hooks/useCRDList";
+import { storageVersionName, escapeRe } from "@/modules/k8s/registry/dynamic/crdUtils";
+import { PATH_K8S_CR_LIST_FULL } from "@/modules/k8s/constants/paths";
+import type { NavCollapsibleSubGroupItem, SimpleNavItem } from "@/core/components/sidebar/types";
+import type { CRDObject } from "@my-project/shared";
+
+export function useCRSidebarItems(clusterName: string): NavCollapsibleSubGroupItem[] {
+  const { data, error } = useCRDList();
+  return useMemo(() => {
+    if (error || !data.array.length) return [];
+
+    const byGroup = new Map<string, CRDObject[]>();
+    for (const crd of data.array) {
+      // CRD spec.group is a required field per the Kubernetes API spec.
+      // Skip at the groupBy step so no empty-title subgroup header is emitted in the sidebar.
+      // An empty group would also produce a regex like `//` that never matches real URLs.
+      if (!crd.spec.group) {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(`[useCRSidebarItems] CRD "${crd.metadata.name}" has an empty spec.group; skipping.`);
+        }
+        continue;
+      }
+      const arr = byGroup.get(crd.spec.group) ?? [];
+      arr.push(crd);
+      byGroup.set(crd.spec.group, arr);
+    }
+
+    return Array.from(byGroup.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([group, crdsInGroup]) => ({
+        kind: "collapsible-subgroup" as const,
+        title: group,
+        defaultOpen: false,
+        children: crdsInGroup
+          .slice()
+          .sort((a, b) => a.spec.names.kind.localeCompare(b.spec.names.kind))
+          .flatMap<SimpleNavItem>((crd) => {
+            // storageVersionName throws when crd.spec.versions is empty (malformed CRD).
+            // Skip the offending CRD instead of crashing the entire sidebar render tree.
+            let version: string;
+            try {
+              version = storageVersionName(crd);
+            } catch {
+              return [];
+            }
+            // Matches list, namespaced detail (ns/), and cluster-scoped detail (cluster/) paths:
+            //   /k8s/cr/$group/$version/$plural
+            //   /k8s/cr/ns/$group/$version/$plural/$namespace/$name
+            //   /k8s/cr/cluster/$group/$version/$plural/$name
+            const activeRe = new RegExp(
+              `/k8s/cr/(cluster/|ns/)?${escapeRe(crd.spec.group)}/[^/]+/${escapeRe(crd.spec.names.plural)}(/|$)`
+            );
+            return [
+              {
+                title: crd.spec.names.kind,
+                icon: Puzzle,
+                route: {
+                  to: PATH_K8S_CR_LIST_FULL,
+                  params: {
+                    clusterName,
+                    group: crd.spec.group,
+                    version,
+                    plural: crd.spec.names.plural,
+                  },
+                } as unknown as SimpleNavItem["route"],
+                isActiveFn: (pathname: string) => activeRe.test(pathname),
+              },
+            ];
+          }),
+      }));
+  }, [data.array, error, clusterName]);
+}

--- a/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.ts
+++ b/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.ts
@@ -64,7 +64,7 @@ export function useCRSidebarItems(clusterName: string): NavCollapsibleSubGroupIt
                     version,
                     plural: crd.spec.names.plural,
                   },
-                } as unknown as SimpleNavItem["route"],
+                } as SimpleNavItem["route"],
                 isActiveFn: (pathname: string) => activeRe.test(pathname),
               },
             ];

--- a/apps/client/src/modules/k8s/components/PrinterColumnValue/index.test.tsx
+++ b/apps/client/src/modules/k8s/components/PrinterColumnValue/index.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PrinterColumnValue } from "./index";
+
+const item = {
+  metadata: { name: "pr-1", creationTimestamp: "2026-05-15T10:00:00Z" },
+  spec: { replicas: 3, paused: false },
+  status: { phase: "Running", number: 42.7 },
+};
+
+describe("PrinterColumnValue", () => {
+  it("renders string values", () => {
+    render(<PrinterColumnValue item={item as never} jsonPath=".status.phase" type="string" />);
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("renders integer values", () => {
+    render(<PrinterColumnValue item={item as never} jsonPath=".spec.replicas" type="integer" />);
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders number values", () => {
+    render(<PrinterColumnValue item={item as never} jsonPath=".status.number" type="number" />);
+    expect(screen.getByText("42.7")).toBeInTheDocument();
+  });
+
+  it("renders boolean false as False", () => {
+    render(<PrinterColumnValue item={item as never} jsonPath=".spec.paused" type="boolean" />);
+    expect(screen.getByText("False")).toBeInTheDocument();
+  });
+
+  it("renders boolean true as True", () => {
+    const trueItem = { ...item, spec: { ...item.spec, paused: true } };
+    render(<PrinterColumnValue item={trueItem as never} jsonPath=".spec.paused" type="boolean" />);
+    expect(screen.getByText("True")).toBeInTheDocument();
+  });
+
+  it("renders string 'true' as True (case-insensitive)", () => {
+    const strItem = { ...item, spec: { ...item.spec, paused: "true" } };
+    render(<PrinterColumnValue item={strItem as never} jsonPath=".spec.paused" type="boolean" />);
+    expect(screen.getByText("True")).toBeInTheDocument();
+  });
+
+  it("renders string 'TRUE' as True (case-insensitive)", () => {
+    const strItem = { ...item, spec: { ...item.spec, paused: "TRUE" } };
+    render(<PrinterColumnValue item={strItem as never} jsonPath=".spec.paused" type="boolean" />);
+    expect(screen.getByText("True")).toBeInTheDocument();
+  });
+
+  it("renders string 'false' as False (not True — string 'false' is JS-truthy)", () => {
+    const strItem = { ...item, spec: { ...item.spec, paused: "false" } };
+    render(<PrinterColumnValue item={strItem as never} jsonPath=".spec.paused" type="boolean" />);
+    expect(screen.getByText("False")).toBeInTheDocument();
+  });
+
+  it("renders string 'False' as False (case-insensitive)", () => {
+    const strItem = { ...item, spec: { ...item.spec, paused: "False" } };
+    render(<PrinterColumnValue item={strItem as never} jsonPath=".spec.paused" type="boolean" />);
+    expect(screen.getByText("False")).toBeInTheDocument();
+  });
+
+  it("renders em-dash for a non-boolean string value in a boolean column ('yes')", () => {
+    const strItem = { ...item, spec: { ...item.spec, paused: "yes" } };
+    render(<PrinterColumnValue item={strItem as never} jsonPath=".spec.paused" type="boolean" />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("returns null for creationTimestamp jsonPath (defense-in-depth)", () => {
+    const { container } = render(
+      <PrinterColumnValue item={item as never} jsonPath=".metadata.creationTimestamp" type="date" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns em-dash on missing JSONPath segments", () => {
+    render(<PrinterColumnValue item={item as never} jsonPath=".missing.field" type="string" />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("returns em-dash for filter-expression JSONPath (unsupported)", () => {
+    render(
+      <PrinterColumnValue
+        item={item as never}
+        jsonPath={'.status.conditions[?(@.type=="Ready")].status'}
+        type="string"
+      />
+    );
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders the value when label-selector bracket syntax targets a present label", () => {
+    const itemWithLabels = {
+      ...item,
+      metadata: { ...item.metadata, labels: { app: "demo" } },
+    };
+    render(<PrinterColumnValue item={itemWithLabels as never} jsonPath=".metadata.labels['app']" type="string" />);
+    expect(screen.getByText("demo")).toBeInTheDocument();
+  });
+
+  it("returns em-dash when label-selector bracket key is absent on the item", () => {
+    render(<PrinterColumnValue item={item as never} jsonPath=".metadata.labels['missing']" type="string" />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders a relative-time string for type=date with a valid ISO timestamp", () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const itemWithDate = { ...item, status: { ...item.status, ts: oneHourAgo } };
+    render(<PrinterColumnValue item={itemWithDate as never} jsonPath=".status.ts" type="date" />);
+    // formatRelativeTime produces variants like "1h ago", "60m ago", etc. — match loosely.
+    expect(screen.getByText(/ago|now|just/i)).toBeInTheDocument();
+  });
+
+  it("renders formatRelativeTime's hyphen fallback for type=date with a non-parseable timestamp", () => {
+    // formatRelativeTime returns "-" (not the em-dash "—") for invalid inputs and never throws,
+    // so the component's catch branch is unreachable; the rendered text is the bare hyphen.
+    const itemWithBadDate = { ...item, status: { ...item.status, ts: "not-a-date" } };
+    render(<PrinterColumnValue item={itemWithBadDate as never} jsonPath=".status.ts" type="date" />);
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/modules/k8s/components/PrinterColumnValue/index.tsx
+++ b/apps/client/src/modules/k8s/components/PrinterColumnValue/index.tsx
@@ -1,0 +1,58 @@
+import { Badge } from "@/core/components/ui/badge";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { formatRelativeTime } from "@/core/utils/date-humanize";
+import { extractByJsonPath } from "@/modules/k8s/utils/extractByJsonPath";
+import { CREATION_TIMESTAMP_PRINTER_COL_PATH } from "@/modules/k8s/registry/dynamic/crdUtils";
+import type { CRDVersion, KubeObjectBase } from "@my-project/shared";
+
+type PrinterColumnType = NonNullable<CRDVersion["additionalPrinterColumns"]>[number]["type"];
+
+export interface PrinterColumnValueProps {
+  item: KubeObjectBase;
+  jsonPath: string;
+  type: PrinterColumnType;
+}
+
+const EM_DASH = "—";
+
+export function PrinterColumnValue({ item, jsonPath, type }: PrinterColumnValueProps) {
+  // Defense-in-depth: column generation already skips creationTimestamp.
+  if (jsonPath === CREATION_TIMESTAMP_PRINTER_COL_PATH) return null;
+
+  const value = extractByJsonPath(item, jsonPath);
+  if (value == null) return <>{EM_DASH}</>;
+
+  switch (type) {
+    case "string":
+      // Printer columns frequently surface unbreakable strings (URLs, hashes); the
+      // table's cell wrapper is a flex container with default `min-width: auto`, so
+      // without an explicit `min-w-0` block here line-clamp can't kick in and the
+      // string pushes past the fixed column width into the next column.
+      return (
+        <div className="w-full min-w-0">
+          <TextWithTooltip text={String(value)} maxLineAmount={2} />
+        </div>
+      );
+    case "integer":
+    case "number": {
+      // Render a dash if the CRD declares a numeric type but the value isn't numeric
+      // (malformed CRD or schema/jsonPath mismatch) — String(NaN) === "NaN" otherwise.
+      const n = Number(value);
+      return <>{Number.isFinite(n) ? String(n) : EM_DASH}</>;
+    }
+    case "boolean": {
+      // Normalize to a tri-state: true | false | unknown.
+      // CRD operators commonly serialize booleans as strings ('true'/'false'),
+      // so JS truthiness alone is incorrect — 'false' (truthy string) would render as True.
+      const isTrue = value === true || (typeof value === "string" && value.toLowerCase() === "true");
+      const isFalse = value === false || (typeof value === "string" && value.toLowerCase() === "false");
+      if (!isTrue && !isFalse) return <>{EM_DASH}</>;
+      return <Badge variant={isTrue ? "success" : "secondary"}>{isTrue ? "True" : "False"}</Badge>;
+    }
+    case "date":
+      // formatRelativeTime returns "-" for invalid timestamps and never throws.
+      return <>{formatRelativeTime(String(value))}</>;
+    default:
+      return <>{EM_DASH}</>;
+  }
+}

--- a/apps/client/src/modules/k8s/components/ResourceTable/ResourceTable.test.tsx
+++ b/apps/client/src/modules/k8s/components/ResourceTable/ResourceTable.test.tsx
@@ -5,11 +5,22 @@ import type { ResourceDescriptor } from "../../registry/types";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
 
+// Capture rendered `to` props from Link so test assertions can check the route.
 vi.mock("@tanstack/react-router", async (orig) => ({
   ...(await (orig as () => Promise<Record<string, unknown>>)()),
   useNavigate: () => () => {},
   useParams: () => ({}),
-  Link: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  Link: ({ children, to, params }: { children: React.ReactNode; to?: string; params?: Record<string, string> }) => {
+    // Build a deterministic href from the `to` template + `params` so tests can
+    // assert on the exact URL without relying on TanStack Router internals.
+    let href = to ?? "";
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        href = href.replace(`$${key}`, encodeURIComponent(value));
+      });
+    }
+    return <a href={href}>{children}</a>;
+  },
 }));
 
 vi.mock("@/core/components/Table", () => ({
@@ -30,6 +41,16 @@ vi.mock("@/core/components/Table", () => ({
 
 vi.mock("@/k8s/store", () => ({
   useClusterStore: () => "test-cluster",
+}));
+
+// PrinterColumnValue is used in CR descriptor columns; stub it out to avoid
+// jsonpath/deep-render overhead in unit tests.
+vi.mock("@/modules/k8s/components/PrinterColumnValue", () => ({
+  PrinterColumnValue: ({ item, jsonPath }: { item: unknown; jsonPath: string }) => (
+    <span data-testid="printer-col" data-jsonpath={jsonPath}>
+      {JSON.stringify(item)}
+    </span>
+  ),
 }));
 
 describe("ResourceTable", () => {
@@ -75,5 +96,80 @@ describe("ResourceTable", () => {
     render(<ResourceTable items={items} descriptor={descriptor} isLoading={false} error={null} />);
     expect(screen.getByText("alpha")).toBeInTheDocument();
     expect(screen.getByText("beta")).toBeInTheDocument();
+  });
+
+  describe("CR descriptor (customResource=true) with printer columns", () => {
+    // Minimal CRD fixture — namespaced with one priority=0 printer column so
+    // visible.length >= 1 and the yamlIconColumn branch is NOT taken.
+    const crItems: KubeObjectBase[] = [
+      {
+        kind: "PipelineRun",
+        apiVersion: "tekton.dev/v1",
+        metadata: { name: "pr-1", uid: "cr-u1", namespace: "dev", creationTimestamp: "" },
+      },
+    ];
+
+    const crDescriptor: ResourceDescriptor = {
+      config: {
+        kind: "PipelineRun",
+        group: "tekton.dev",
+        version: "v1",
+        apiVersion: "tekton.dev/v1",
+        singularName: "pipelinerun",
+        pluralName: "pipelineruns",
+      },
+      label: "PipelineRuns",
+      detailVariant: "namespaced",
+      customResource: true,
+      sidebarGroup: "CustomResources",
+      defaultSort: { sortBy: "name", order: "asc" },
+      columns: (renderName) => [
+        {
+          id: "name",
+          label: "Name",
+          data: {
+            render: ({ data }) => renderName(data),
+            columnSortableValuePath: "metadata.name",
+          },
+          cell: { baseWidth: 30 },
+        },
+        // Simulate the printer column that buildCRDescriptor would add
+        {
+          id: "Status-0",
+          label: "Status",
+          data: {
+            render: ({ data }) => (
+              <span data-testid="printer-col" data-jsonpath=".status.phase">
+                {JSON.stringify(data)}
+              </span>
+            ),
+          },
+          cell: { baseWidth: 20 },
+        },
+      ],
+    };
+
+    it("routes the name link to PATH_K8S_CR_DETAIL_NS_FULL for namespaced CR with printer columns", () => {
+      render(<ResourceTable items={crItems} descriptor={crDescriptor} isLoading={false} error={null} />);
+
+      // The name "pr-1" should be rendered as a link
+      const link = screen.getByRole("link", { name: "pr-1" });
+      expect(link).toBeInTheDocument();
+
+      // The href must use the CR namespaced detail route pattern:
+      // /c/$clusterName/k8s/cr/ns/$group/$version/$plural/$namespace/$name
+      // with resolved params: clusterName=test-cluster, group=tekton.dev,
+      // version=v1, plural=pipelineruns, namespace=dev, name=pr-1
+      const href = link.getAttribute("href") ?? "";
+      expect(href).toContain("/k8s/cr/ns/");
+      expect(href).toContain("tekton.dev");
+      expect(href).toContain("v1");
+      expect(href).toContain("pipelineruns");
+      expect(href).toContain("dev");
+      expect(href).toContain("pr-1");
+
+      // Must NOT use the standard built-in kind route
+      expect(href).not.toContain("/k8s/ns/");
+    });
   });
 });

--- a/apps/client/src/modules/k8s/components/ResourceTable/index.tsx
+++ b/apps/client/src/modules/k8s/components/ResourceTable/index.tsx
@@ -53,7 +53,7 @@ function NameLink({
       return (
         <Button variant="link" asChild className="w-full justify-start p-0">
           <Link
-            to={PATH_K8S_CR_DETAIL_CLUSTER_FULL as never}
+            to={PATH_K8S_CR_DETAIL_CLUSTER_FULL}
             params={{ clusterName, group, version, plural: pluralName, name } as never}
           >
             <TextWithTooltip text={name || "—"} />
@@ -73,7 +73,7 @@ function NameLink({
     return (
       <Button variant="link" asChild className="w-full justify-start p-0">
         <Link
-          to={PATH_K8S_CR_DETAIL_NS_FULL as never}
+          to={PATH_K8S_CR_DETAIL_NS_FULL}
           params={{ clusterName, group, version, plural: pluralName, namespace, name } as never}
         >
           <TextWithTooltip text={name || "—"} />

--- a/apps/client/src/modules/k8s/components/ResourceTable/index.tsx
+++ b/apps/client/src/modules/k8s/components/ResourceTable/index.tsx
@@ -6,7 +6,12 @@ import { DataTable } from "@/core/components/Table";
 import { EmptyList } from "@/core/components/EmptyList";
 import { TextWithTooltip } from "@/core/components/TextWithTooltip";
 import { useClusterStore } from "@/k8s/store";
-import { PATH_K8S_DETAIL_CLUSTER_FULL, PATH_K8S_DETAIL_NS_FULL } from "../../constants/paths";
+import {
+  PATH_K8S_DETAIL_CLUSTER_FULL,
+  PATH_K8S_DETAIL_NS_FULL,
+  PATH_K8S_CR_DETAIL_CLUSTER_FULL,
+  PATH_K8S_CR_DETAIL_NS_FULL,
+} from "../../constants/paths";
 import type { TableProps } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
 import type { ResourceDescriptor } from "../../registry/types";
@@ -34,6 +39,48 @@ function NameLink({
 }) {
   const name = item.metadata?.name ?? "";
   const namespace = item.metadata?.namespace ?? "";
+
+  // Custom Resources use dedicated CR detail routes that carry group/version/plural.
+  if (descriptor.customResource) {
+    const { group, version, pluralName } = descriptor.config;
+    if (!group || !version || !pluralName) {
+      throw new Error(
+        `ResourceDescriptor with customResource=true must have non-empty group, version, and pluralName (kind: ${descriptor.config.kind})`
+      );
+    }
+
+    if (descriptor.detailVariant === "cluster") {
+      return (
+        <Button variant="link" asChild className="w-full justify-start p-0">
+          <Link
+            to={PATH_K8S_CR_DETAIL_CLUSTER_FULL as never}
+            params={{ clusterName, group, version, plural: pluralName, name } as never}
+          >
+            <TextWithTooltip text={name || "—"} />
+          </Link>
+        </Button>
+      );
+    }
+
+    if (!namespace) {
+      return (
+        <span className="text-sm">
+          <TextWithTooltip text={name || "—"} />
+        </span>
+      );
+    }
+
+    return (
+      <Button variant="link" asChild className="w-full justify-start p-0">
+        <Link
+          to={PATH_K8S_CR_DETAIL_NS_FULL as never}
+          params={{ clusterName, group, version, plural: pluralName, namespace, name } as never}
+        >
+          <TextWithTooltip text={name || "—"} />
+        </Link>
+      </Button>
+    );
+  }
 
   if (descriptor.detailVariant === "cluster") {
     return (

--- a/apps/client/src/modules/k8s/components/RestartAction/index.stories.tsx
+++ b/apps/client/src/modules/k8s/components/RestartAction/index.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { k8sDeploymentConfig } from "@my-project/shared";
+import { withAppProviders } from "@sb/index";
+import { RestartAction } from "./index";
+
+const meta = {
+  title: "k8s/Actions/RestartAction",
+  component: RestartAction,
+  decorators: [withAppProviders()],
+} satisfies Meta<typeof RestartAction>;
+export default meta;
+
+const item = {
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: { name: "frontend", namespace: "default", uid: "1", creationTimestamp: "" },
+};
+
+export const Default: StoryObj<typeof RestartAction> = {
+  args: { item, config: k8sDeploymentConfig },
+};

--- a/apps/client/src/modules/k8s/components/RestartAction/index.tsx
+++ b/apps/client/src/modules/k8s/components/RestartAction/index.tsx
@@ -1,0 +1,40 @@
+import { RotateCcw } from "lucide-react";
+import type { KubeObjectBase } from "@my-project/shared";
+import { ButtonWithPermission } from "@/core/components/ButtonWithPermission";
+import { useUpdatePermission } from "@/modules/k8s/hooks/useUpdatePermission";
+import { useDialogOpener } from "@/core/providers/Dialog/hooks";
+import { ConfirmDialog } from "@/core/components/Confirm";
+import { useK8sRestart, type RestartableConfig } from "@/modules/k8s/hooks/useK8sRestart";
+
+interface Props {
+  item: KubeObjectBase;
+  config: RestartableConfig;
+}
+
+export function RestartAction({ item, config }: Props) {
+  const { allowed, reason } = useUpdatePermission(config);
+  const restart = useK8sRestart(config);
+  const openConfirm = useDialogOpener(ConfirmDialog);
+
+  const namespace = item.metadata?.namespace ?? "";
+  const name = item.metadata?.name ?? "";
+
+  const handleClick = () => {
+    openConfirm({
+      text: `Restart ${config.kind} ${name} rollout? This will trigger a rolling update of all pods.`,
+      actionCallback: async () => {
+        restart.mutate({ namespace, name });
+      },
+    });
+  };
+
+  return (
+    <ButtonWithPermission
+      allowed={allowed}
+      reason={reason}
+      ButtonProps={{ variant: "outline", size: "sm", onClick: handleClick }}
+    >
+      <RotateCcw size={14} className="mr-1.5" /> Restart
+    </ButtonWithPermission>
+  );
+}

--- a/apps/client/src/modules/k8s/components/RollbackAction/RollbackDialog.tsx
+++ b/apps/client/src/modules/k8s/components/RollbackAction/RollbackDialog.tsx
@@ -1,0 +1,172 @@
+import { useEffect } from "react";
+import { useStore } from "@tanstack/react-form";
+import z from "zod";
+import { useAppForm } from "@/core/components/form";
+import { Button } from "@/core/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/core/components/ui/dialog";
+import { LoadingSpinner } from "@/core/components/ui/LoadingSpinner";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { TableBodyUI, TableCellUI, TableHeadUI, TableHeaderUI, TableRowUI, TableUI } from "@/core/components/ui/table";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { useDeploymentRevisions } from "@/modules/k8s/hooks/useDeploymentRevisions";
+import { useK8sRollback } from "@/modules/k8s/hooks/useK8sRollback";
+import { formatRelativeTime } from "@/core/utils/date-humanize";
+import type { RollbackDialogProps } from "./types";
+
+const rollbackSchema = z.object({
+  replicaSetUid: z.string().min(1, "Select a revision to roll back to"),
+});
+
+export function RollbackDialog({ props: { namespace, name }, state: { open, closeDialog } }: RollbackDialogProps) {
+  const revisions = useDeploymentRevisions({ namespace, name });
+  const rollback = useK8sRollback();
+
+  // Derive the default revision to select (latest non-current revision).
+  const defaultUid = (revisions.data ?? []).find((r) => !r.isCurrent)?.replicaSetUid ?? "";
+
+  const form = useAppForm({
+    defaultValues: { replicaSetUid: "" },
+    validators: {
+      onChange: rollbackSchema,
+    },
+    onSubmit: async ({ value }) => {
+      closeDialog();
+      rollback.mutate({ namespace, name, replicaSetUid: value.replicaSetUid });
+    },
+  });
+
+  // Reset selection to empty whenever the dialog closes, and adopt the default
+  // revision when the dialog is open and revisions have loaded. This also handles
+  // the late-arrival case: the dialog opens before the first fetch resolves, then
+  // defaultUid transitions from "" to a real UID and the effect re-runs to set it.
+  useEffect(() => {
+    if (!open) {
+      form.reset({ replicaSetUid: "" });
+      return;
+    }
+    if (defaultUid) {
+      const current = form.getFieldValue("replicaSetUid");
+      if (!current) {
+        form.setFieldValue("replicaSetUid", defaultUid);
+      }
+    }
+  }, [open, defaultUid]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const selectedUid = useStore(form.store, (state) => state.values.replicaSetUid);
+  const isSubmitting = useStore(form.store, (state) => state.isSubmitting);
+
+  const hasRevisions = (revisions.data?.length ?? 0) >= 2;
+  // Verify selectedUid is still in the (possibly background-refetched) revisions list,
+  // and is not the current revision — a stale dialog won't let the user submit a UID
+  // that no longer corresponds to a rollback-able ReplicaSet.
+  const selectedIsValid =
+    !!selectedUid && (revisions.data ?? []).some((r) => !r.isCurrent && r.replicaSetUid === selectedUid);
+  const canSubmit = selectedIsValid && hasRevisions && !revisions.isLoading && !revisions.isError;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void form.handleSubmit();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && closeDialog()}>
+      <DialogContent className="w-full max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Roll back {name}</DialogTitle>
+          <DialogDescription>
+            Select a previous revision to restore. The current revision is disabled.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <DialogBody>
+            {revisions.isLoading && (
+              <div className="flex justify-center py-6">
+                <LoadingSpinner />
+              </div>
+            )}
+            {revisions.isError && <ErrorContent error={revisions.error ?? null} />}
+            {!revisions.isLoading && !revisions.isError && !hasRevisions && (
+              <p className="text-muted-foreground text-sm">No previous revisions available.</p>
+            )}
+            {!revisions.isLoading && !revisions.isError && hasRevisions && (
+              <form.AppField name="replicaSetUid">
+                {(field) => (
+                  <div role="radiogroup" aria-label="Revisions" className="max-h-96 overflow-y-auto">
+                    <TableUI>
+                      <TableHeaderUI>
+                        <TableRowUI>
+                          <TableHeadUI scope="col" className="px-2 py-1">
+                            <span className="sr-only">Select</span>
+                          </TableHeadUI>
+                          <TableHeadUI scope="col" className="px-2 py-1">
+                            Revision
+                          </TableHeadUI>
+                          <TableHeadUI scope="col" className="px-2 py-1">
+                            Created
+                          </TableHeadUI>
+                          <TableHeadUI scope="col" className="px-2 py-1">
+                            Images
+                          </TableHeadUI>
+                        </TableRowUI>
+                      </TableHeaderUI>
+                      <TableBodyUI>
+                        {revisions.data!.map((r) => (
+                          <TableRowUI key={r.replicaSetUid}>
+                            <TableCellUI className="px-2 py-1">
+                              <input
+                                type="radio"
+                                name="revision"
+                                value={r.replicaSetUid}
+                                checked={field.state.value === r.replicaSetUid}
+                                onChange={() => {
+                                  field.handleChange(r.replicaSetUid);
+                                }}
+                                onBlur={field.handleBlur}
+                                disabled={r.isCurrent}
+                                aria-label={`Revision ${r.revision}`}
+                              />
+                            </TableCellUI>
+                            <TableCellUI className="px-2 py-1 font-mono">
+                              {r.revision}{" "}
+                              {r.isCurrent && <span className="ml-1 text-xs text-emerald-600">(current)</span>}
+                            </TableCellUI>
+                            <TableCellUI className="px-2 py-1">{formatRelativeTime(r.creationTimestamp)}</TableCellUI>
+                            <TableCellUI className="px-2 py-1 font-mono text-xs">
+                              <div className="w-full min-w-0">
+                                <TextWithTooltip text={r.images.join(", ")} maxLineAmount={2} />
+                              </div>
+                            </TableCellUI>
+                          </TableRowUI>
+                        ))}
+                      </TableBodyUI>
+                    </TableUI>
+                  </div>
+                )}
+              </form.AppField>
+            )}
+          </DialogBody>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => closeDialog()}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!canSubmit || isSubmitting || rollback.isPending}
+              aria-busy={isSubmitting || rollback.isPending}
+            >
+              Rollback
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/client/src/modules/k8s/components/RollbackAction/index.stories.tsx
+++ b/apps/client/src/modules/k8s/components/RollbackAction/index.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withAppProviders } from "@sb/index";
+import { RollbackDialog } from "./RollbackDialog";
+
+const meta = {
+  title: "k8s/Actions/RollbackAction",
+  component: RollbackDialog,
+  decorators: [withAppProviders()],
+} satisfies Meta<typeof RollbackDialog>;
+export default meta;
+
+const noopState = { open: true, openDialog: () => {}, closeDialog: () => {} };
+const dialogProps = { namespace: "default", name: "frontend" };
+
+export const Loading: StoryObj = {
+  parameters: { note: "Mock useDeploymentRevisions to return { isLoading: true }." },
+  render: () => <RollbackDialog props={dialogProps} state={noopState} />,
+};
+
+export const ErrorState: StoryObj = {
+  parameters: {
+    note: "Mock useDeploymentRevisions to return { isError: true, error: new Error('boom') }.",
+  },
+  render: () => <RollbackDialog props={dialogProps} state={noopState} />,
+};
+
+export const Empty: StoryObj = {
+  parameters: {
+    note: "Mock useDeploymentRevisions to return [{revision:1, isCurrent:true,...}].",
+  },
+  render: () => <RollbackDialog props={dialogProps} state={noopState} />,
+};
+
+export const Populated: StoryObj = {
+  parameters: {
+    note: "Mock useDeploymentRevisions to return 3 revisions, latest non-current pre-selected.",
+  },
+  render: () => <RollbackDialog props={dialogProps} state={noopState} />,
+};
+
+export const LongList: StoryObj = {
+  parameters: { note: "Mock useDeploymentRevisions to return 10 revisions." },
+  render: () => <RollbackDialog props={dialogProps} state={noopState} />,
+};

--- a/apps/client/src/modules/k8s/components/RollbackAction/index.tsx
+++ b/apps/client/src/modules/k8s/components/RollbackAction/index.tsx
@@ -1,0 +1,39 @@
+import { Undo2 } from "lucide-react";
+import type { K8sResourceConfig, KubeObjectBase } from "@my-project/shared";
+import { ButtonWithPermission } from "@/core/components/ButtonWithPermission";
+import { useDialogOpener } from "@/core/providers/Dialog/hooks";
+import { useUpdatePermission } from "@/modules/k8s/hooks/useUpdatePermission";
+import { useDeploymentRevisions } from "@/modules/k8s/hooks/useDeploymentRevisions";
+import { RollbackDialog } from "./RollbackDialog";
+
+interface Props {
+  item: KubeObjectBase;
+  config: K8sResourceConfig;
+}
+
+export function RollbackAction({ item, config }: Props) {
+  const { allowed, reason } = useUpdatePermission(config);
+  const openRollback = useDialogOpener(RollbackDialog);
+
+  const namespace = item.metadata?.namespace ?? "";
+  const name = item.metadata?.name ?? "";
+
+  const revisions = useDeploymentRevisions({ namespace, name });
+  const hasRevisions = (revisions.data?.length ?? 0) >= 2;
+  const disabledReason = !hasRevisions ? "No previous revisions available" : reason;
+
+  return (
+    <ButtonWithPermission
+      allowed={allowed && hasRevisions}
+      reason={disabledReason}
+      ButtonProps={{
+        variant: "outline",
+        size: "sm",
+        onClick: () => openRollback({ namespace, name }),
+        disabled: revisions.isLoading,
+      }}
+    >
+      <Undo2 size={14} className="mr-1.5" /> Rollback
+    </ButtonWithPermission>
+  );
+}

--- a/apps/client/src/modules/k8s/components/RollbackAction/types.ts
+++ b/apps/client/src/modules/k8s/components/RollbackAction/types.ts
@@ -1,0 +1,6 @@
+import type { DialogProps } from "@/core/providers/Dialog/types";
+
+export type RollbackDialogProps = DialogProps<{
+  namespace: string;
+  name: string;
+}>;

--- a/apps/client/src/modules/k8s/components/ScaleAction/ScaleDialog.tsx
+++ b/apps/client/src/modules/k8s/components/ScaleAction/ScaleDialog.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useStore } from "@tanstack/react-form";
+import { Minus, Plus, TriangleAlert } from "lucide-react";
+import z from "zod";
+import { useAppForm } from "@/core/components/form";
+import { extractErrorMessage } from "@/core/components/form/utils/extractErrorMessage";
+import { Button } from "@/core/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/core/components/ui/dialog";
+import { Input } from "@/core/components/ui/input";
+import { Label } from "@/core/components/ui/label";
+import { Slider } from "@/core/components/ui/slider";
+import { useK8sScale } from "@/modules/k8s/hooks/useK8sScale";
+import { useHpaForTarget } from "@/modules/k8s/hooks/useHpaForTarget";
+import type { ScaleDialogProps } from "./types";
+
+// Soft cap for the manual replica input when no HPA bounds are available.
+// Used purely as a UI guardrail to keep the slider/input scale finite; the K8s
+// API and server-side Zod schema enforce the real limits.
+const MAX_REPLICAS_WITHOUT_HPA = 10_000;
+
+export function ScaleDialog({ props: { item, config }, state: { open, closeDialog } }: ScaleDialogProps) {
+  const current = item.spec?.replicas ?? 0;
+  const ready = item.status?.readyReplicas ?? 0;
+  const unavailable = Math.max(0, current - (item.status?.availableReplicas ?? 0));
+  const scale = useK8sScale(config);
+
+  const namespace = item.metadata?.namespace ?? "";
+  const name = item.metadata?.name ?? "";
+
+  const { hpa } = useHpaForTarget({
+    namespace,
+    kind: config.kind,
+    apiVersion: config.apiVersion,
+    name,
+  });
+
+  // If an HPA owns this workload, cap the slider/input at its maxReplicas (and floor at minReplicas).
+  // Otherwise use a heuristic: 4× current, with a minimum of 20.
+  const hpaMin = hpa?.spec?.minReplicas;
+  const hpaMax = hpa?.spec?.maxReplicas;
+  const hpaPinned = hpaMin !== undefined && hpaMax !== undefined && hpaMin === hpaMax;
+  const heuristicMax = Math.max(current * 4, 20);
+  const inputMin = hpaMin ?? 0;
+  // When an HPA is present but maxReplicas is missing (malformed manifest), the HPA-managed
+  // banner promises strict bounds. Falling back to 10000 would let the user type a value that
+  // contradicts the banner. Use the heuristic instead so the cap stays sensible, and warn so
+  // the malformed HPA is observable to developers.
+  // The warn is moved into a useEffect so it fires only when the condition transitions to true,
+  // not on every render or every HPA watch tick.
+  const inputMax = hpaMax ?? (hpa ? heuristicMax : MAX_REPLICAS_WITHOUT_HPA);
+  const sliderMax = hpaMax ?? heuristicMax;
+
+  // Warn (dev-only) when an HPA is present but has no maxReplicas. Using useEffect
+  // ensures the warn fires only when the condition transitions to true — not on every
+  // render in React Strict Mode or on every HPA watch tick.
+  useEffect(() => {
+    if (hpa && hpaMax === undefined) {
+      console.warn(`HPA ${hpa.metadata?.name ?? "<unnamed>"} for ${config.kind}/${name} has no spec.maxReplicas`);
+    }
+  }, [hpa?.metadata?.name, hpaMax, config.kind, name]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const scaleSchema = useMemo(
+    () =>
+      z.object({
+        replicas: z
+          .number()
+          .int("Replicas must be a whole number")
+          .min(inputMin, `Minimum replicas: ${inputMin}`)
+          .max(inputMax, `Maximum replicas: ${inputMax}`),
+      }),
+    [inputMin, inputMax]
+  );
+
+  const form = useAppForm({
+    defaultValues: { replicas: current },
+    validators: {
+      onChange: scaleSchema,
+    },
+    onSubmit: async ({ value }) => {
+      closeDialog();
+      scale.mutate({ namespace, name, replicas: value.replicas });
+    },
+  });
+
+  // Reset form to the workload's current replicas only on the open→true transition.
+  // `current` stays in the deps so the next open reads the latest watch value, but the
+  // `wasOpen` ref blocks the reset while the dialog is already open — otherwise a live
+  // watch update (another actor scaled the workload) would silently overwrite whatever
+  // value the user has typed.
+  const wasOpen = useRef(false);
+  useEffect(() => {
+    if (open && !wasOpen.current) {
+      form.reset({ replicas: current });
+    }
+    wasOpen.current = open;
+  }, [open, current]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Once the HPA FIRST loads, snap value into the HPA's [min,max] window so the input
+  // doesn't display a value below its own min/max. Subsequent watch updates to the HPA
+  // (an admin editing bounds while the dialog is open) must NOT overwrite what the user
+  // is currently typing — that would silently corrupt user intent.
+  // hasClampedRef tracks whether the initial clamp has already run for this dialog open;
+  // it is reset to false whenever the dialog transitions from closed → open (same moment
+  // wasOpen flips false→true), so re-opening the dialog triggers a fresh clamp.
+  const hasClampedRef = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      // Reset so the next open performs the initial clamp again.
+      hasClampedRef.current = false;
+      return;
+    }
+    if (!hpa || hasClampedRef.current) return;
+    hasClampedRef.current = true;
+    const existing = form.getFieldValue("replicas");
+    const clamped = Math.max(inputMin, Math.min(inputMax, existing));
+    if (clamped !== existing) {
+      form.setFieldValue("replicas", clamped);
+    }
+  }, [open, hpa, inputMin, inputMax]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const desired = useStore(form.store, (state) => state.values.replicas);
+  const isSubmitting = useStore(form.store, (state) => state.isSubmitting);
+  const isDirty = useStore(form.store, (state) => state.isDirty);
+
+  // Local string buffer that decouples the displayed text from the form's numeric value.
+  // This lets the user clear the field and type a new number without the controlled input
+  // snapping back to the previous value on every key press.
+  const [localStr, setLocalStr] = useState(() => String(current));
+
+  // Keep localStr in sync when the form value changes via +/- buttons, slider,
+  // HPA clamp, or onBlur restore — but only when the user is not mid-edit
+  // (i.e. when the parsed representation of localStr already differs from desired).
+  useEffect(() => {
+    if (Number(localStr) !== desired) {
+      setLocalStr(String(desired));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [desired]);
+
+  const ratio = current > 0 ? desired / current : 0;
+  const showGuardrail = desired >= 100 || (current > 0 && ratio > 4);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // When the HPA pins min===max the Scale button is hidden, so keyboard Enter must
+    // also be a no-op — otherwise form submission still fires via the native submit event.
+    if (hpaPinned) return;
+    void form.handleSubmit();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && closeDialog()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Scale {config.kind} {name}
+          </DialogTitle>
+          <DialogDescription>
+            Adjust the desired replica count for this workload. Changes take effect immediately.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <DialogBody>
+            <div className="flex flex-col gap-4">
+              <p className="text-muted-foreground text-sm">
+                Current: <strong>{current}</strong> desired, <strong>{ready}</strong> ready,{" "}
+                <strong>{unavailable}</strong> unavailable
+              </p>
+
+              {hpa && (
+                <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-50 p-3 text-sm text-amber-900 dark:bg-amber-950/40 dark:text-amber-100">
+                  <TriangleAlert size={16} className="mt-0.5 shrink-0" />
+                  <span>
+                    {hpaPinned ? (
+                      <>
+                        HPA <strong>{hpa.metadata?.name}</strong> pins replicas to <strong>{hpaMin}</strong>. Use HPA
+                        controls to change the replica count.
+                      </>
+                    ) : (
+                      <>
+                        This {config.kind} is managed by HorizontalPodAutoscaler <strong>{hpa.metadata?.name}</strong>.
+                        Manual replica changes will be overridden on the next reconciliation.
+                      </>
+                    )}
+                  </span>
+                </div>
+              )}
+
+              <form.AppField name="replicas">
+                {(field) => {
+                  const value = field.state.value;
+                  return (
+                    <div className="flex flex-col gap-2">
+                      <Label htmlFor="scale-desired">Desired replicas</Label>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => field.handleChange(Math.max(inputMin, value - 1))}
+                          aria-label="Decrease"
+                        >
+                          <Minus size={14} />
+                        </Button>
+                        <Input
+                          id="scale-desired"
+                          type="number"
+                          min={inputMin}
+                          max={inputMax}
+                          step={1}
+                          value={localStr}
+                          onChange={(e) => {
+                            // Always update the local string buffer so the field doesn't snap back
+                            // when the user clears it to retype.
+                            setLocalStr(e.target.value);
+                            if (e.target.value === "") {
+                              // Do not write anything to the form — wait for the user to finish typing.
+                              return;
+                            }
+                            const raw = Number(e.target.value);
+                            if (Number.isFinite(raw)) {
+                              // Floor — Zod's .int() would catch a decimal at validation time, but
+                              // the form store would still hold the float, so the Slider visualizes
+                              // a fractional position and the Submit guard (desired === current)
+                              // can be defeated by an integer current vs a 3.7 desired.
+                              const intVal = Math.floor(raw);
+                              field.handleChange(Math.max(inputMin, Math.min(inputMax, intVal)));
+                            }
+                          }}
+                          onBlur={(e) => {
+                            // If the user leaves the field empty, restore the display from the
+                            // current form value so the input is never left blank after blur.
+                            if (e.target.value === "") {
+                              setLocalStr(String(value));
+                            }
+                            field.handleBlur();
+                          }}
+                          className="w-24 text-center"
+                          // Only describe the input by the HPA bounds line when that line is
+                          // actually rendered (see condition on the <p id="scale-hpa-bounds"/>
+                          // below). Without this guard the attribute points to a non-existent
+                          // id when no HPA is present, breaking the AT contract silently.
+                          aria-describedby={
+                            hpa && (hpaMin !== undefined || hpaMax !== undefined) ? "scale-hpa-bounds" : undefined
+                          }
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => field.handleChange(Math.min(inputMax, value + 1))}
+                          aria-label="Increase"
+                        >
+                          <Plus size={14} />
+                        </Button>
+                      </div>
+                      <Slider
+                        value={[Math.min(value, sliderMax)]}
+                        onValueChange={(v) => field.handleChange(v[0])}
+                        min={inputMin}
+                        max={sliderMax}
+                        step={1}
+                        aria-label="Desired replicas"
+                      />
+                      {hpa && (hpaMin !== undefined || hpaMax !== undefined) && (
+                        <p id="scale-hpa-bounds" className="text-muted-foreground text-xs">
+                          HPA bounds: min <strong>{hpaMin ?? "—"}</strong>, max <strong>{hpaMax ?? "—"}</strong>
+                        </p>
+                      )}
+                      {field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
+                        <p role="alert" className="text-destructive text-xs">
+                          {extractErrorMessage(field.state.meta.errors)}
+                        </p>
+                      )}
+                    </div>
+                  );
+                }}
+              </form.AppField>
+
+              {showGuardrail && (
+                <div className="flex items-center gap-2 rounded-md border border-orange-500/40 bg-orange-50 p-2 text-xs text-orange-900 dark:bg-orange-950/40 dark:text-orange-100">
+                  <TriangleAlert size={14} />
+                  {current > 0
+                    ? `Scaling up by ${ratio.toFixed(1)}× — verify cluster capacity`
+                    : `Scaling to ${desired} replicas — verify cluster capacity`}
+                </div>
+              )}
+            </div>
+          </DialogBody>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => closeDialog()}>
+              Cancel
+            </Button>
+            {!hpaPinned && (
+              <Button
+                type="submit"
+                disabled={!isDirty || isSubmitting || scale.isPending}
+                aria-busy={isSubmitting || scale.isPending}
+              >
+                Scale
+              </Button>
+            )}
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/client/src/modules/k8s/components/ScaleAction/index.stories.tsx
+++ b/apps/client/src/modules/k8s/components/ScaleAction/index.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { KubeObjectBase } from "@my-project/shared";
+import { k8sDeploymentConfig } from "@my-project/shared";
+import { withAppProviders } from "@sb/index";
+import { ScaleAction } from "./index";
+import { ScaleDialog } from "./ScaleDialog";
+
+const meta = {
+  title: "k8s/Actions/ScaleAction",
+  component: ScaleAction,
+  decorators: [withAppProviders()],
+} satisfies Meta<typeof ScaleAction>;
+export default meta;
+
+const item = {
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: { name: "frontend", namespace: "default", uid: "1", creationTimestamp: "" },
+  spec: { replicas: 3 },
+  status: { readyReplicas: 3, availableReplicas: 3 },
+} as KubeObjectBase & { spec?: { replicas?: number }; status?: { readyReplicas?: number; availableReplicas?: number } };
+
+const noopState = { open: true, openDialog: () => {}, closeDialog: () => {} };
+
+export const ButtonOnly: StoryObj = {
+  render: () => <ScaleAction item={item} config={k8sDeploymentConfig} />,
+};
+
+export const DialogOpenNoHpa: StoryObj = {
+  render: () => <ScaleDialog props={{ item, config: k8sDeploymentConfig }} state={noopState} />,
+};
+
+export const DialogAtGuardrail: StoryObj = {
+  parameters: {
+    note: "Initial render has desired === current; raise the desired value above 100 (or above 4× current) in the UI to see the guardrail banner.",
+  },
+  render: () => {
+    const big = { ...item, spec: { replicas: 5 } };
+    return <ScaleDialog props={{ item: big, config: k8sDeploymentConfig }} state={noopState} />;
+  },
+};

--- a/apps/client/src/modules/k8s/components/ScaleAction/index.tsx
+++ b/apps/client/src/modules/k8s/components/ScaleAction/index.tsx
@@ -1,0 +1,30 @@
+import { Maximize2 } from "lucide-react";
+import type { KubeObjectBase } from "@my-project/shared";
+import { ButtonWithPermission } from "@/core/components/ButtonWithPermission";
+import { useDialogOpener } from "@/core/providers/Dialog/hooks";
+import { useUpdatePermission } from "@/modules/k8s/hooks/useUpdatePermission";
+import type { ScalableConfig } from "@/modules/k8s/hooks/useK8sScale";
+import { ScaleDialog } from "./ScaleDialog";
+
+interface Props {
+  item: KubeObjectBase & {
+    spec?: { replicas?: number };
+    status?: { readyReplicas?: number; availableReplicas?: number };
+  };
+  config: ScalableConfig;
+}
+
+export function ScaleAction({ item, config }: Props) {
+  const { allowed, reason } = useUpdatePermission(config);
+  const openScale = useDialogOpener(ScaleDialog);
+
+  return (
+    <ButtonWithPermission
+      allowed={allowed}
+      reason={reason}
+      ButtonProps={{ variant: "outline", size: "sm", onClick: () => openScale({ item, config }) }}
+    >
+      <Maximize2 size={14} className="mr-1.5" /> Scale
+    </ButtonWithPermission>
+  );
+}

--- a/apps/client/src/modules/k8s/components/ScaleAction/types.ts
+++ b/apps/client/src/modules/k8s/components/ScaleAction/types.ts
@@ -1,0 +1,11 @@
+import type { KubeObjectBase } from "@my-project/shared";
+import type { DialogProps } from "@/core/providers/Dialog/types";
+import type { ScalableConfig } from "@/modules/k8s/hooks/useK8sScale";
+
+export type ScaleDialogProps = DialogProps<{
+  item: KubeObjectBase & {
+    spec?: { replicas?: number };
+    status?: { readyReplicas?: number; availableReplicas?: number };
+  };
+  config: ScalableConfig;
+}>;

--- a/apps/client/src/modules/k8s/constants/nav.ts
+++ b/apps/client/src/modules/k8s/constants/nav.ts
@@ -1,4 +1,4 @@
-import { Bell, Folder, Globe, HardDrive, Layers, PanelsTopLeft, Server, Shield } from "lucide-react";
+import { Bell, Folder, Globe, HardDrive, Layers, PanelsTopLeft, Puzzle, Server, Shield } from "lucide-react";
 import type { NavItem, SimpleNavItem } from "@/core/components/sidebar/types";
 import { resourceRegistry } from "../registry";
 import type { SidebarGroup as RegistrySidebarGroup } from "../registry/types";
@@ -13,6 +13,7 @@ const groupIconMap: Record<RegistrySidebarGroup, typeof Layers> = {
   Config: Folder,
   Security: Shield,
   Cluster: Server,
+  CustomResources: Puzzle,
 };
 
 export function createK8sNavigationConfig(clusterName: string, allowedKinds: Set<string>): NavItem[] {

--- a/apps/client/src/modules/k8s/constants/nav.ts
+++ b/apps/client/src/modules/k8s/constants/nav.ts
@@ -1,10 +1,9 @@
 import { Bell, Folder, Globe, HardDrive, Layers, PanelsTopLeft, Puzzle, Server, Shield } from "lucide-react";
-import type { NavItem, SimpleNavItem } from "@/core/components/sidebar/types";
+import type { NavCollapsibleSubGroupItem, NavItem, SimpleNavItem } from "@/core/components/sidebar/types";
 import { resourceRegistry } from "../registry";
+import { listRouteSlug } from "../registry/resolve";
 import type { SidebarGroup as RegistrySidebarGroup } from "../registry/types";
-import { PATH_K8S_OVERVIEW_FULL } from "../pages/overview/route";
-import { PATH_K8S_LIST_FULL } from "../pages/list/route";
-import { PATH_K8S_EVENTS_FULL } from "../pages/events/route";
+import { PATH_K8S_CRDS_FULL, PATH_K8S_EVENTS_FULL, PATH_K8S_LIST_FULL, PATH_K8S_OVERVIEW_FULL } from "./paths";
 
 const groupIconMap: Record<RegistrySidebarGroup, typeof Layers> = {
   Workloads: Layers,
@@ -16,25 +15,54 @@ const groupIconMap: Record<RegistrySidebarGroup, typeof Layers> = {
   CustomResources: Puzzle,
 };
 
-export function createK8sNavigationConfig(clusterName: string, allowedKinds: Set<string>): NavItem[] {
+export function createK8sNavigationConfig(
+  clusterName: string,
+  crSidebarItems: NavCollapsibleSubGroupItem[] = []
+): NavItem[] {
   const params = { clusterName };
   const items: NavItem[] = [{ title: "Overview", icon: PanelsTopLeft, route: { to: PATH_K8S_OVERVIEW_FULL, params } }];
 
-  const groups: RegistrySidebarGroup[] = ["Workloads", "Network", "Storage", "Config", "Security", "Cluster"];
+  const groups: RegistrySidebarGroup[] = [
+    "Workloads",
+    "Network",
+    "Storage",
+    "Config",
+    "Security",
+    "Cluster",
+    "CustomResources",
+  ];
 
   for (const group of groups) {
     const groupChildren = Object.entries(resourceRegistry)
-      .filter(([key, d]) => d.sidebarGroup === group && !d.sidebarHidden && allowedKinds.has(key))
-      .map(([key, d]) => ({
-        title: d.label,
-        icon: d.sidebarIcon ?? groupIconMap[group] ?? Layers,
-        route: (d.listRoute
-          ? { to: d.listRoute, params }
-          : { to: PATH_K8S_LIST_FULL, params: { ...params, kind: key } }) as unknown as SimpleNavItem["route"],
-        isActiveFn: (pathname: string) => new RegExp(`/k8s/(ns/|cluster/)?${key}(/|$)`).test(pathname),
-      }));
+      .filter(([, d]) => d.sidebarGroup === group && !d.sidebarHidden)
+      .map(([key, d]) => {
+        const slug = listRouteSlug(d.listRoute) ?? key;
+        // Compile once per item (this factory runs inside a useMemo), not on every
+        // isActiveFn call — the sidebar tests isActiveFn on each navigation event.
+        const activeRe = new RegExp(`/k8s/(ns/|cluster/)?${slug}(/|$)`);
+        return {
+          title: d.label,
+          icon: d.sidebarIcon ?? groupIconMap[group] ?? Layers,
+          route: (d.listRoute
+            ? { to: d.listRoute, params }
+            : { to: PATH_K8S_LIST_FULL, params: { ...params, kind: key } }) as unknown as SimpleNavItem["route"],
+          isActiveFn: (pathname: string) => activeRe.test(pathname),
+        };
+      });
 
-    if (groupChildren.length > 0) {
+    if (group === "CustomResources") {
+      // The "CRDs" descriptor is sidebarHidden so the parent header doesn't visually
+      // duplicate it; the group itself links to the CRDs list page via `defaultRoute`.
+      const mergedChildren = [...groupChildren, ...crSidebarItems];
+      if (mergedChildren.length > 0) {
+        items.push({
+          title: "Custom Resources",
+          icon: groupIconMap.CustomResources ?? Layers,
+          defaultRoute: { to: PATH_K8S_CRDS_FULL, params } as unknown as SimpleNavItem["route"],
+          children: mergedChildren,
+        });
+      }
+    } else if (groupChildren.length > 0) {
       items.push({ title: group, icon: groupIconMap[group] ?? Layers, children: groupChildren });
     }
   }

--- a/apps/client/src/modules/k8s/constants/paths.ts
+++ b/apps/client/src/modules/k8s/constants/paths.ts
@@ -1,4 +1,22 @@
+export const PATH_K8S_OVERVIEW_FULL = "/c/$clusterName/k8s/overview" as const;
+export const PATH_K8S_LIST_FULL = "/c/$clusterName/k8s/$kind" as const;
+export const PATH_K8S_EVENTS_FULL = "/c/$clusterName/k8s/events" as const;
 export const PATH_K8S_PODS_FULL = "/c/$clusterName/k8s/pods" as const;
 export const PATH_K8S_NODES_FULL = "/c/$clusterName/k8s/nodes" as const;
 export const PATH_K8S_DETAIL_NS_FULL = "/c/$clusterName/k8s/ns/$kind/$namespace/$name" as const;
 export const PATH_K8S_DETAIL_CLUSTER_FULL = "/c/$clusterName/k8s/cluster/$kind/$name" as const;
+
+// Custom Resource Definitions (cluster-scoped, custom detail page)
+export const PATH_K8S_CRDS = "crds" as const;
+export const PATH_K8S_CRDS_FULL = "/c/$clusterName/k8s/crds" as const;
+export const PATH_K8S_CRDS_DETAIL = "crds/$name" as const;
+export const PATH_K8S_CRDS_DETAIL_FULL = "/c/$clusterName/k8s/crds/$name" as const;
+
+// Generic Custom Resource viewer (under a static cr/ parent)
+export const PATH_K8S_CR = "cr" as const;
+export const PATH_K8S_CR_LIST = "$group/$version/$plural" as const;
+export const PATH_K8S_CR_LIST_FULL = "/c/$clusterName/k8s/cr/$group/$version/$plural" as const;
+export const PATH_K8S_CR_DETAIL_NS = "ns/$group/$version/$plural/$namespace/$name" as const;
+export const PATH_K8S_CR_DETAIL_NS_FULL = "/c/$clusterName/k8s/cr/ns/$group/$version/$plural/$namespace/$name" as const;
+export const PATH_K8S_CR_DETAIL_CLUSTER = "cluster/$group/$version/$plural/$name" as const;
+export const PATH_K8S_CR_DETAIL_CLUSTER_FULL = "/c/$clusterName/k8s/cr/cluster/$group/$version/$plural/$name" as const;

--- a/apps/client/src/modules/k8s/hooks/useCR.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useCR.test.ts
@@ -1,0 +1,107 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CRDObject } from "@my-project/shared";
+
+vi.mock("@/k8s/api/hooks/useWatch/useWatchItem", () => ({
+  useWatchItem: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isReady: true,
+    resourceVersion: undefined,
+    query: { isPending: false, isSuccess: true, error: null, isError: false } as never,
+  })),
+}));
+
+import { useCR } from "./useCR";
+
+const namespacedCrd: CRDObject = {
+  apiVersion: "apiextensions.k8s.io/v1",
+  kind: "CustomResourceDefinition",
+  metadata: { name: "pipelineruns.tekton.dev", uid: "u", creationTimestamp: "" },
+  spec: {
+    group: "tekton.dev",
+    scope: "Namespaced",
+    names: { kind: "PipelineRun", plural: "pipelineruns", singular: "pipelinerun" },
+    versions: [
+      { name: "v1beta1", served: true, storage: false },
+      { name: "v1", served: true, storage: true },
+    ],
+  },
+};
+
+describe("useCR", () => {
+  it("forwards resourceConfig built from the CRD with storage version when no preferredVersion is given", async () => {
+    const { useWatchItem } = await import("@/k8s/api/hooks/useWatch/useWatchItem");
+    renderHook(() => useCR(namespacedCrd, "ns", "pr-1"));
+    const args = (useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(args.resourceConfig).toMatchObject({
+      group: "tekton.dev",
+      version: "v1",
+      pluralName: "pipelineruns",
+      kind: "PipelineRun",
+    });
+    expect(args.namespace).toBe("ns");
+    expect(args.name).toBe("pr-1");
+  });
+
+  it("uses preferredVersion when supplied and present in the CRD", async () => {
+    const { useWatchItem } = await import("@/k8s/api/hooks/useWatch/useWatchItem");
+    renderHook(() => useCR(namespacedCrd, "ns", "pr-1", "v1beta1"));
+    expect((useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0].resourceConfig.version).toBe(
+      "v1beta1"
+    );
+  });
+
+  it("returns a stable resourceConfig reference when crd and preferredVersion are unchanged", async () => {
+    const { useWatchItem } = await import("@/k8s/api/hooks/useWatch/useWatchItem");
+    (useWatchItem as unknown as ReturnType<typeof vi.fn>).mockClear();
+    const { rerender } = renderHook(({ ns }: { ns: string }) => useCR(namespacedCrd, ns, "pr-1"), {
+      initialProps: { ns: "ns" },
+    });
+    const firstConfig = (useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].resourceConfig;
+    rerender({ ns: "ns" });
+    const secondConfig = (useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0].resourceConfig;
+    expect(secondConfig).toBe(firstConfig);
+  });
+
+  it("memo is stable when a fresh CRD object has the same resourceVersion (watch-tick churn guard)", async () => {
+    const { useWatchItem } = await import("@/k8s/api/hooks/useWatch/useWatchItem");
+    (useWatchItem as unknown as ReturnType<typeof vi.fn>).mockClear();
+    const crd1: CRDObject = {
+      ...namespacedCrd,
+      metadata: { ...namespacedCrd.metadata, resourceVersion: "100" },
+    };
+    const crd2: CRDObject = {
+      ...namespacedCrd,
+      metadata: { ...namespacedCrd.metadata, resourceVersion: "100" },
+    };
+    expect(crd1).not.toBe(crd2);
+    const { rerender } = renderHook(({ c }: { c: CRDObject }) => useCR(c, "ns", "pr-1"), {
+      initialProps: { c: crd1 },
+    });
+    const firstConfig = (useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].resourceConfig;
+    rerender({ c: crd2 });
+    const secondConfig = (useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0].resourceConfig;
+    expect(secondConfig).toBe(firstConfig);
+  });
+
+  it("memo rebuilds when resourceVersion changes", async () => {
+    const { useWatchItem } = await import("@/k8s/api/hooks/useWatch/useWatchItem");
+    (useWatchItem as unknown as ReturnType<typeof vi.fn>).mockClear();
+    const crdV1: CRDObject = {
+      ...namespacedCrd,
+      metadata: { ...namespacedCrd.metadata, resourceVersion: "100" },
+    };
+    const crdV2: CRDObject = {
+      ...namespacedCrd,
+      metadata: { ...namespacedCrd.metadata, resourceVersion: "101" },
+    };
+    const { rerender } = renderHook(({ c }: { c: CRDObject }) => useCR(c, "ns", "pr-1"), {
+      initialProps: { c: crdV1 },
+    });
+    const firstConfig = (useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].resourceConfig;
+    rerender({ c: crdV2 });
+    const secondConfig = (useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0].resourceConfig;
+    expect(secondConfig).not.toBe(firstConfig);
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useCR.ts
+++ b/apps/client/src/modules/k8s/hooks/useCR.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import { useWatchItem } from "@/k8s/api/hooks/useWatch/useWatchItem";
+import type { CRDObject, KubeObjectBase } from "@my-project/shared";
+import { buildCRDescriptor } from "../registry/dynamic/buildCRDescriptor";
+
+export function useCR(
+  crd: CRDObject,
+  namespace: string,
+  name: string,
+  preferredVersion?: string,
+  options?: { enabled?: boolean }
+) {
+  // Narrow dep to resourceVersion: useWatchList rebuilds the CRD array on every
+  // watch tick, so closing over `crd` would re-run buildCRDescriptor on each event.
+  // CRD identity is tracked by resourceVersion; nothing else here depends on the
+  // object reference itself.
+  const config = useMemo(
+    () => buildCRDescriptor(crd, preferredVersion).config,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [crd.metadata?.resourceVersion, crd.metadata?.uid, preferredVersion]
+  );
+  return useWatchItem<KubeObjectBase>({
+    resourceConfig: config,
+    namespace,
+    name,
+    queryOptions: { enabled: options?.enabled ?? true },
+  });
+}

--- a/apps/client/src/modules/k8s/hooks/useCRD.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRD.test.ts
@@ -1,0 +1,26 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { k8sCustomResourceDefinitionConfig } from "@my-project/shared";
+
+vi.mock("@/k8s/api/hooks/useWatch/useWatchItem", () => ({
+  useWatchItem: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isReady: true,
+    resourceVersion: undefined,
+    query: { isPending: false, isSuccess: true, error: null, isError: false } as never,
+  })),
+}));
+
+import { useCRD } from "./useCRD";
+
+describe("useCRD", () => {
+  it("calls useWatchItem with the CRD resource config and the provided name", async () => {
+    const { useWatchItem } = await import("@/k8s/api/hooks/useWatch/useWatchItem");
+    renderHook(() => useCRD("argoprojects.argoproj.io"));
+    expect((useWatchItem as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+      resourceConfig: k8sCustomResourceDefinitionConfig,
+      name: "argoprojects.argoproj.io",
+    });
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useCRD.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRD.ts
@@ -1,0 +1,12 @@
+import { k8sCustomResourceDefinitionConfig, type CRDObject } from "@my-project/shared";
+import { useWatchItem } from "@/k8s/api/hooks/useWatch/useWatchItem";
+
+/**
+ * Watches a single CRD by name. CRDs are cluster-scoped, so no namespace is needed.
+ */
+export function useCRD(name: string) {
+  return useWatchItem<CRDObject>({
+    resourceConfig: k8sCustomResourceDefinitionConfig,
+    name,
+  });
+}

--- a/apps/client/src/modules/k8s/hooks/useCRDByGVR.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDByGVR.test.ts
@@ -1,0 +1,54 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const fakeCrd = {
+  metadata: { name: "pipelineruns.tekton.dev" },
+  spec: {
+    group: "tekton.dev",
+    versions: [{ name: "v1", storage: true, served: true }],
+    names: { plural: "pipelineruns", kind: "PipelineRun" },
+    scope: "Namespaced",
+  },
+};
+
+vi.mock("./useCRDList", () => ({
+  useCRDList: vi.fn(() => ({
+    data: { array: [fakeCrd], map: new Map([[fakeCrd.metadata.name, fakeCrd]]) },
+    isLoading: false,
+    isReady: true,
+    error: null,
+  })),
+}));
+
+import { useCRDByGVR } from "./useCRDByGVR";
+
+describe("useCRDByGVR", () => {
+  it("resolves the matching CRD", () => {
+    const { result } = renderHook(() => useCRDByGVR("tekton.dev", "v1", "pipelineruns"));
+    expect(result.current.crd).toEqual(fakeCrd);
+  });
+
+  it("returns undefined when no CRD matches the GVR", () => {
+    const { result } = renderHook(() => useCRDByGVR("missing.io", "v1", "things"));
+    expect(result.current.crd).toBeUndefined();
+  });
+
+  it("does NOT match a version that is served: false (deprecated)", async () => {
+    const { useCRDList } = await import("./useCRDList");
+    const deprecatedCrd = {
+      ...fakeCrd,
+      spec: {
+        ...fakeCrd.spec,
+        versions: [{ name: "v1beta1", storage: false, served: false }],
+      },
+    };
+    (useCRDList as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      data: { array: [deprecatedCrd], map: new Map() },
+      isLoading: false,
+      isReady: true,
+      error: null,
+    });
+    const { result } = renderHook(() => useCRDByGVR("tekton.dev", "v1beta1", "pipelineruns"));
+    expect(result.current.crd).toBeUndefined();
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useCRDByGVR.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDByGVR.ts
@@ -1,0 +1,26 @@
+import { useMemo } from "react";
+import { useCRDList } from "./useCRDList";
+import type { CRDObject } from "@my-project/shared";
+
+export interface UseCRDByGVRResult {
+  crd: CRDObject | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useCRDByGVR(group: string, version: string, plural: string): UseCRDByGVRResult {
+  const watch = useCRDList();
+  const crd = useMemo(
+    () =>
+      watch.data.array.find(
+        (c) =>
+          c.spec.group === group &&
+          c.spec.names.plural === plural &&
+          // Only match versions that the API server is currently serving — a deprecated
+          // (served: false) version would return 405/404 on subsequent CR requests.
+          c.spec.versions.some((v) => v.name === version && v.served !== false)
+      ),
+    [watch.data.array, group, version, plural]
+  );
+  return { crd, isLoading: watch.isLoading, error: watch.error };
+}

--- a/apps/client/src/modules/k8s/hooks/useCRDList.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDList.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/k8s/api/hooks/useWatch/useWatchList", () => ({
+  useWatchList: vi.fn(() => ({
+    data: { array: [], map: new Map() },
+    query: { isPending: false, isSuccess: true, error: null, isError: false } as never,
+    resourceVersion: "1",
+    isEmpty: true,
+    isLoading: false,
+    isReady: true,
+    error: null,
+  })),
+}));
+
+import { useCRDList } from "./useCRDList";
+
+describe("useCRDList", () => {
+  it("returns the watch result for CRDs", () => {
+    const { result } = renderHook(() => useCRDList());
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.data.array).toEqual([]);
+  });
+
+  it("does NOT pass labels (watch-sharing invariant)", async () => {
+    const { useWatchList } = await import("@/k8s/api/hooks/useWatch/useWatchList");
+    renderHook(() => useCRDList());
+    expect((useWatchList as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].labels).toBeUndefined();
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useCRDList.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDList.ts
@@ -1,0 +1,11 @@
+import { k8sCustomResourceDefinitionConfig, type CRDObject } from "@my-project/shared";
+import { useWatchList } from "@/k8s/api/hooks/useWatch/useWatchList";
+
+/**
+ * Watches every CRD in the cluster. Used by the CR sidebar hook and by
+ * useCRDByGVR. Both callers MUST NOT pass labels — the watch-sharing
+ * invariant requires identical TanStack Query keys.
+ */
+export function useCRDList() {
+  return useWatchList<CRDObject>({ resourceConfig: k8sCustomResourceDefinitionConfig });
+}

--- a/apps/client/src/modules/k8s/hooks/useCRList.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRList.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CRDObject } from "@my-project/shared";
+
+vi.mock("@/k8s/api/hooks/useWatch/useWatchList", () => ({
+  useWatchList: vi.fn(() => ({
+    data: { array: [], map: new Map() },
+    isLoading: false,
+    isReady: true,
+    isEmpty: true,
+    resourceVersion: "1",
+    error: null,
+    query: { isPending: false, isSuccess: true, error: null, isError: false } as never,
+  })),
+}));
+
+import { useCRList } from "./useCRList";
+
+const clusterScopedCrd: CRDObject = {
+  apiVersion: "apiextensions.k8s.io/v1",
+  kind: "CustomResourceDefinition",
+  metadata: { name: "clusterrules.example.io", uid: "u", creationTimestamp: "" },
+  spec: {
+    group: "example.io",
+    scope: "Cluster",
+    names: { kind: "ClusterRule", plural: "clusterrules" },
+    versions: [{ name: "v1", served: true, storage: true }],
+  },
+};
+
+describe("useCRList", () => {
+  it("forwards the built resourceConfig and namespace to useWatchList", async () => {
+    const { useWatchList } = await import("@/k8s/api/hooks/useWatch/useWatchList");
+    renderHook(() => useCRList(clusterScopedCrd, undefined));
+    const args = (useWatchList as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(args.resourceConfig).toMatchObject({
+      group: "example.io",
+      version: "v1",
+      pluralName: "clusterrules",
+      clusterScoped: true,
+    });
+    expect(args.namespace).toBeUndefined();
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useCRList.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRList.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import { useWatchList } from "@/k8s/api/hooks/useWatch/useWatchList";
+import type { CRDObject, KubeObjectBase } from "@my-project/shared";
+import { buildCRDescriptor } from "../registry/dynamic/buildCRDescriptor";
+
+export function useCRList(crd: CRDObject, namespace?: string, preferredVersion?: string) {
+  // Narrow dep to resourceVersion: useWatchList rebuilds the CRD array on every
+  // watch tick, so closing over `crd` would re-run buildCRDescriptor on each event.
+  const config = useMemo(
+    () => buildCRDescriptor(crd, preferredVersion).config,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [crd.metadata?.resourceVersion, crd.metadata?.uid, preferredVersion]
+  );
+  return useWatchList<KubeObjectBase>({ resourceConfig: config, namespace });
+}

--- a/apps/client/src/modules/k8s/hooks/useDeploymentRevisions.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useDeploymentRevisions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+const queryMock = vi.fn();
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({ k8s: { listDeploymentRevisions: { query: queryMock } } }),
+}));
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: (sel: (s: { clusterName: string }) => unknown) => sel({ clusterName: "test-cluster" }),
+}));
+
+import { useDeploymentRevisions } from "./useDeploymentRevisions";
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    QueryClientProvider,
+    { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+    children
+  );
+
+describe("useDeploymentRevisions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls listDeploymentRevisions.query with the right input", async () => {
+    queryMock.mockResolvedValueOnce([{ revision: 1 }]);
+    const { result } = renderHook(() => useDeploymentRevisions({ namespace: "ns", name: "foo" }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual([{ revision: 1 }]));
+    expect(queryMock).toHaveBeenCalledWith({ namespace: "ns", name: "foo" });
+  });
+
+  it("is disabled when name is empty", () => {
+    const { result } = renderHook(() => useDeploymentRevisions({ namespace: "ns", name: "" }), {
+      wrapper,
+    });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it("is disabled when namespace is empty", () => {
+    const { result } = renderHook(() => useDeploymentRevisions({ namespace: "", name: "foo" }), {
+      wrapper,
+    });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it("is disabled when both name and namespace are empty", () => {
+    const { result } = renderHook(() => useDeploymentRevisions({ namespace: "", name: "" }), {
+      wrapper,
+    });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(true);
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useDeploymentRevisions.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useDeploymentRevisions.test.ts
@@ -56,4 +56,29 @@ describe("useDeploymentRevisions", () => {
     expect(queryMock).not.toHaveBeenCalled();
     expect(result.current.isPending).toBe(true);
   });
+
+  it("refetches on every remount even when the client defaults to refetchOnMount:false", async () => {
+    // Mirror the global QueryClient (refetchOnMount:false). Without refetchOnMount:"always"
+    // the rollback dialog would show a stale revision list cached by RollbackAction.
+    queryMock.mockResolvedValue([{ revision: 1 }]);
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnMount: false } },
+    });
+    const sharedWrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client }, children);
+
+    const first = renderHook(() => useDeploymentRevisions({ namespace: "ns", name: "foo" }), {
+      wrapper: sharedWrapper,
+    });
+    await waitFor(() => expect(first.result.current.data).toEqual([{ revision: 1 }]));
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    // Remount with the SAME (warm) client — must trigger a fresh fetch.
+    const second = renderHook(() => useDeploymentRevisions({ namespace: "ns", name: "foo" }), {
+      wrapper: sharedWrapper,
+    });
+    await waitFor(() => expect(queryMock).toHaveBeenCalledTimes(2));
+    second.unmount();
+  });
 });

--- a/apps/client/src/modules/k8s/hooks/useDeploymentRevisions.ts
+++ b/apps/client/src/modules/k8s/hooks/useDeploymentRevisions.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import { getK8sDeploymentRevisionsQueryCacheKey } from "@/k8s/api/hooks/useWatch/query-keys";
+import type { RequestError } from "@/core/types/global";
+
+interface Params {
+  namespace: string;
+  name: string;
+}
+
+export function useDeploymentRevisions({ namespace, name }: Params) {
+  const trpc = useTRPCClient();
+  const clusterName = useClusterStore((s) => s.clusterName);
+
+  return useQuery<Awaited<ReturnType<typeof trpc.k8s.listDeploymentRevisions.query>>, RequestError>({
+    queryKey: getK8sDeploymentRevisionsQueryCacheKey(clusterName, namespace, name),
+    queryFn: () => trpc.k8s.listDeploymentRevisions.query({ namespace, name }),
+    enabled: !!name && !!namespace,
+    // Always-stale: the rollback dialog mounts on demand and must reflect the live revision list
+    // (newly added or pruned ReplicaSets between dialog opens).
+    staleTime: 0,
+  });
+}

--- a/apps/client/src/modules/k8s/hooks/useDeploymentRevisions.ts
+++ b/apps/client/src/modules/k8s/hooks/useDeploymentRevisions.ts
@@ -17,8 +17,12 @@ export function useDeploymentRevisions({ namespace, name }: Params) {
     queryKey: getK8sDeploymentRevisionsQueryCacheKey(clusterName, namespace, name),
     queryFn: () => trpc.k8s.listDeploymentRevisions.query({ namespace, name }),
     enabled: !!name && !!namespace,
-    // Always-stale: the rollback dialog mounts on demand and must reflect the live revision list
-    // (newly added or pruned ReplicaSets between dialog opens).
+    // The rollback dialog mounts on demand and must reflect the live revision list
+    // (newly added or pruned ReplicaSets between dialog opens). staleTime:0 alone is not
+    // enough: the global QueryClient sets refetchOnMount:false, and RollbackAction keeps this
+    // query subscribed for the button state, so the dialog would otherwise show cached data.
+    // refetchOnMount:"always" forces a fresh fetch every time the dialog mounts.
     staleTime: 0,
+    refetchOnMount: "always",
   });
 }

--- a/apps/client/src/modules/k8s/hooks/useDetailTabs.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useDetailTabs.test.ts
@@ -1,0 +1,58 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const navigateMock = vi.fn();
+const searchValue: { tab?: string } = {};
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearch: () => searchValue,
+}));
+
+import { useDetailTabs } from "./useDetailTabs";
+
+const TABS = ["overview", "yaml", "events"] as const;
+
+describe("useDetailTabs", () => {
+  it("defaults to the first tab when search.tab is missing", () => {
+    delete searchValue.tab;
+    const { result } = renderHook(() => useDetailTabs(TABS));
+    expect(result.current.activeTab).toBe("overview");
+    expect(result.current.activeTabIdx).toBe(0);
+  });
+
+  it("uses the search.tab value when it matches a known tab", () => {
+    searchValue.tab = "yaml";
+    const { result } = renderHook(() => useDetailTabs(TABS));
+    expect(result.current.activeTab).toBe("yaml");
+    expect(result.current.activeTabIdx).toBe(1);
+  });
+
+  it("falls back to the first tab when search.tab is unknown", () => {
+    searchValue.tab = "bogus";
+    const { result } = renderHook(() => useDetailTabs(TABS));
+    expect(result.current.activeTab).toBe("overview");
+  });
+
+  it("setTab navigates with merged search params", () => {
+    navigateMock.mockClear();
+    searchValue.tab = "overview";
+    const { result } = renderHook(() => useDetailTabs(TABS));
+    act(() => result.current.setTab("events"));
+    expect(navigateMock).toHaveBeenCalledWith({ search: { tab: "events" } });
+  });
+
+  it("onTabChange maps numeric index back to tab id", () => {
+    navigateMock.mockClear();
+    const { result } = renderHook(() => useDetailTabs(TABS));
+    act(() => result.current.onTabChange(null, 2));
+    expect(navigateMock).toHaveBeenCalledWith({ search: expect.objectContaining({ tab: "events" }) });
+  });
+
+  it("onTabChange falls back to the first tab when index is out of range", () => {
+    navigateMock.mockClear();
+    const { result } = renderHook(() => useDetailTabs(TABS));
+    act(() => result.current.onTabChange(null, 99));
+    expect(navigateMock).toHaveBeenCalledWith({ search: expect.objectContaining({ tab: "overview" }) });
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useDetailTabs.ts
+++ b/apps/client/src/modules/k8s/hooks/useDetailTabs.ts
@@ -1,0 +1,27 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+
+/**
+ * The tab id set shared by the standard resource detail pages (generic K8s detail,
+ * CRD detail, and custom-resource detail). Pages that need extra tabs (e.g. Node's
+ * conditions/charts) declare their own list instead.
+ */
+export const DEFAULT_DETAIL_TABS = ["overview", "yaml", "events"] as const;
+
+export interface UseDetailTabsResult<T extends string> {
+  activeTab: T;
+  activeTabIdx: number;
+  setTab: (t: T) => void;
+  onTabChange: (_event: unknown, idx: number) => void;
+}
+
+export function useDetailTabs<T extends string>(tabIds: readonly T[]): UseDetailTabsResult<T> {
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as { tab?: string };
+
+  const activeTab: T = (tabIds as readonly string[]).includes(search.tab ?? "") ? (search.tab as T) : tabIds[0];
+  const activeTabIdx = tabIds.indexOf(activeTab);
+  const setTab = (t: T) => void navigate({ search: { ...search, tab: t } as never });
+  const onTabChange = (_event: unknown, idx: number) => setTab(tabIds[idx] ?? tabIds[0]);
+
+  return { activeTab, activeTabIdx, setTab, onTabChange };
+}

--- a/apps/client/src/modules/k8s/hooks/useHpaForTarget.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useHpaForTarget.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const useWatchListMock = vi.fn();
+vi.mock("@/k8s/api/hooks/useWatch/useWatchList", () => ({
+  useWatchList: (params: unknown) => useWatchListMock(params),
+}));
+
+import { useHpaForTarget } from "./useHpaForTarget";
+
+const makeHpa = (ref: { kind: string; name: string; apiVersion: string }, name = "h") => ({
+  metadata: { name, uid: name },
+  spec: { scaleTargetRef: ref },
+});
+
+describe("useHpaForTarget", () => {
+  it("returns the matching HPA when one targets the resource", () => {
+    useWatchListMock.mockReturnValue({
+      data: {
+        map: new Map([
+          ["1", makeHpa({ kind: "Deployment", name: "foo", apiVersion: "apps/v1" }, "hpa-foo")],
+          ["2", makeHpa({ kind: "Deployment", name: "bar", apiVersion: "apps/v1" }, "hpa-bar")],
+        ]),
+      },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useHpaForTarget({ namespace: "ns", kind: "Deployment", name: "foo", apiVersion: "apps/v1" })
+    );
+
+    expect(result.current.hpa?.metadata.name).toBe("hpa-foo");
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("returns null when no HPA matches", () => {
+    useWatchListMock.mockReturnValue({
+      data: { map: new Map([["1", makeHpa({ kind: "Deployment", name: "other", apiVersion: "apps/v1" })]]) },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useHpaForTarget({ namespace: "ns", kind: "Deployment", name: "foo", apiVersion: "apps/v1" })
+    );
+
+    expect(result.current.hpa).toBeNull();
+  });
+
+  it("returns null when the list is empty", () => {
+    useWatchListMock.mockReturnValue({ data: { map: new Map() }, isLoading: false });
+    const { result } = renderHook(() =>
+      useHpaForTarget({ namespace: "ns", kind: "Deployment", name: "foo", apiVersion: "apps/v1" })
+    );
+    expect(result.current.hpa).toBeNull();
+  });
+
+  it("matches when HPA's scaleTargetRef.apiVersion is undefined (tolerant fallback)", () => {
+    const hpa = {
+      metadata: { name: "hpa-foo", uid: "u" },
+      spec: { scaleTargetRef: { kind: "Deployment", name: "foo" } },
+    };
+    useWatchListMock.mockReturnValue({
+      data: { map: new Map([["1", hpa]]) },
+      isLoading: false,
+    });
+    const { result } = renderHook(() =>
+      useHpaForTarget({ namespace: "ns", kind: "Deployment", name: "foo", apiVersion: "apps/v1" })
+    );
+    expect(result.current.hpa?.metadata.name).toBe("hpa-foo");
+  });
+
+  it("matches when HPA's apiVersion differs by version within the same group (apps/v1beta1 vs apps/v1)", () => {
+    const hpa = {
+      metadata: { name: "hpa-foo", uid: "u" },
+      spec: { scaleTargetRef: { kind: "Deployment", name: "foo", apiVersion: "apps/v1beta1" } },
+    };
+    useWatchListMock.mockReturnValue({
+      data: { map: new Map([["1", hpa]]) },
+      isLoading: false,
+    });
+    const { result } = renderHook(() =>
+      useHpaForTarget({ namespace: "ns", kind: "Deployment", name: "foo", apiVersion: "apps/v1" })
+    );
+    expect(result.current.hpa?.metadata.name).toBe("hpa-foo");
+  });
+
+  it("does NOT match when groups differ (other/v1 vs apps/v1)", () => {
+    const hpa = {
+      metadata: { name: "hpa-foo", uid: "u" },
+      spec: { scaleTargetRef: { kind: "Deployment", name: "foo", apiVersion: "other/v1" } },
+    };
+    useWatchListMock.mockReturnValue({
+      data: { map: new Map([["1", hpa]]) },
+      isLoading: false,
+    });
+    const { result } = renderHook(() =>
+      useHpaForTarget({ namespace: "ns", kind: "Deployment", name: "foo", apiVersion: "apps/v1" })
+    );
+    expect(result.current.hpa).toBeNull();
+  });
+
+  it("matches when HPA's scaleTargetRef.apiVersion is undefined and workload uses apps/v1 (well-known)", () => {
+    const hpa = {
+      metadata: { name: "hpa-foo", uid: "u" },
+      spec: { scaleTargetRef: { kind: "Deployment", name: "foo" } },
+    };
+    useWatchListMock.mockReturnValue({
+      data: { map: new Map([["1", hpa]]) },
+      isLoading: false,
+    });
+    const { result } = renderHook(() =>
+      useHpaForTarget({ namespace: "ns", kind: "Deployment", name: "foo", apiVersion: "apps/v1" })
+    );
+    expect(result.current.hpa?.metadata.name).toBe("hpa-foo");
+  });
+
+  it("does NOT match when HPA's scaleTargetRef.apiVersion is undefined and workload uses a non-standard apiVersion", () => {
+    // An HPA without an explicit apiVersion should NOT match a custom operator workload
+    // (e.g. apiVersion 'custom.example.com/v1') — the omission likely means the HPA author
+    // assumed a standard kind and a cross-group name collision should not silently link.
+    const hpa = {
+      metadata: { name: "hpa-custom", uid: "u" },
+      spec: { scaleTargetRef: { kind: "MyWorkload", name: "foo" } },
+    };
+    useWatchListMock.mockReturnValue({
+      data: { map: new Map([["1", hpa]]) },
+      isLoading: false,
+    });
+    const { result } = renderHook(() =>
+      useHpaForTarget({
+        namespace: "ns",
+        kind: "MyWorkload" as never,
+        name: "foo",
+        apiVersion: "custom.example.com/v1",
+      })
+    );
+    expect(result.current.hpa).toBeNull();
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useHpaForTarget.ts
+++ b/apps/client/src/modules/k8s/hooks/useHpaForTarget.ts
@@ -1,0 +1,74 @@
+import { useMemo } from "react";
+import { k8sHorizontalPodAutoscalerConfig, type KubeObjectBase } from "@my-project/shared";
+import { useWatchList } from "@/k8s/api/hooks/useWatch/useWatchList";
+import type { ScalableKind } from "@/modules/k8s/hooks/useK8sScale";
+
+interface Params {
+  namespace: string;
+  kind: ScalableKind;
+  apiVersion: string;
+  name: string;
+}
+
+interface HpaItem extends KubeObjectBase {
+  spec?: {
+    scaleTargetRef?: {
+      kind?: string;
+      name?: string;
+      apiVersion?: string;
+    };
+    minReplicas?: number;
+    maxReplicas?: number;
+  };
+}
+
+// Well-known apiVersions for the workload kinds that HPAs are allowed to target.
+// Used as a fallback when the HPA's scaleTargetRef.apiVersion is absent.
+const WELL_KNOWN_SCALABLE_API_VERSIONS = new Set(["apps/v1", "v1"]);
+
+// Compare two apiVersion strings tolerantly: equal if both fully match, OR if
+// they refer to the same API group (e.g. "apps/v1" vs "apps" vs "v1" elided).
+// Kubernetes does not normalize scaleTargetRef.apiVersion, so user-authored HPAs
+// may write the group alone, the version alone, or the full form.
+//
+// When `a` (the HPA's scaleTargetRef.apiVersion) is absent, we cannot confirm the
+// group from the HPA side. Instead of unconditionally returning true (which would
+// let any same-namespace (kind, name) collision match), we require `b` (the
+// workload's apiVersion) to be one of the well-known scalable API versions. Custom
+// operator workloads with non-standard apiVersions are unlikely to appear in an HPA
+// scaleTargetRef without the apiVersion field, so this is a safe conservative bound.
+function apiVersionsCompatible(a: string | undefined, b: string): boolean {
+  if (!a) {
+    // HPA omitted apiVersion: accept only well-known scalable targets to avoid
+    // false matches across API groups on same-namespace name collisions.
+    return WELL_KNOWN_SCALABLE_API_VERSIONS.has(b);
+  }
+  if (a === b) return true;
+  // If a string has no "/", treat the whole value as the group name —
+  // this accepts "apps" or "apps/v1" interchangeably as scaleTargetRef.apiVersion.
+  const groupOf = (s: string) => (s.includes("/") ? s.split("/")[0] : s);
+  return groupOf(a) === groupOf(b);
+}
+
+export function useHpaForTarget({ namespace, kind, apiVersion, name }: Params): {
+  hpa: HpaItem | null;
+  isLoading: boolean;
+} {
+  const query = useWatchList<HpaItem>({ resourceConfig: k8sHorizontalPodAutoscalerConfig, namespace });
+
+  const hpa = useMemo(() => {
+    const items = query.data?.map;
+    if (!items) return null;
+    for (const item of items.values()) {
+      const ref = item.spec?.scaleTargetRef;
+      // Within a namespace, (kind, name) uniquely identifies the target. apiVersion
+      // is verified loosely as a defensive guard against cross-group name collisions.
+      if (ref?.kind === kind && ref?.name === name && apiVersionsCompatible(ref?.apiVersion, apiVersion)) {
+        return item;
+      }
+    }
+    return null;
+  }, [query.data, kind, name, apiVersion]);
+
+  return { hpa, isLoading: query.isLoading };
+}

--- a/apps/client/src/modules/k8s/hooks/useK8sActionMutation.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sActionMutation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useK8sActionMutation } from "./useK8sActionMutation";
+
+vi.mock("@/core/components/Snackbar", () => ({
+  showToast: vi.fn().mockReturnValue("toast-id"),
+}));
+
+import { showToast } from "@/core/components/Snackbar";
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useK8sActionMutation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  it("shows loading -> success toast and invalidates ONLY the provided query keys on success", async () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(
+      () =>
+        useK8sActionMutation<{ name: string }, { ok: true }>({
+          mutationKey: "test",
+          mutationFn: async () => ({ ok: true }),
+          messages: {
+            loading: ({ name }) => `Doing ${name}…`,
+            success: ({ name }) => `${name} done`,
+            error: ({ name }, err) => `${name} failed: ${err.message}`,
+          },
+          invalidationKeys: ({ name }) => [
+            ["k8s:watchList", "cluster", "ns", "deployments"],
+            ["k8s:watchItem", "cluster", "ns", "deployments", name],
+          ],
+        }),
+      { wrapper: makeWrapper(queryClient) }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "foo" });
+    });
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith("Doing foo…", "loading");
+      expect(showToast).toHaveBeenCalledWith("foo done", "success", expect.objectContaining({ id: "toast-id" }));
+      expect(invalidateSpy).toHaveBeenCalledTimes(2);
+      expect(invalidateSpy).toHaveBeenNthCalledWith(1, {
+        queryKey: ["k8s:watchList", "cluster", "ns", "deployments"],
+      });
+      expect(invalidateSpy).toHaveBeenNthCalledWith(2, {
+        queryKey: ["k8s:watchItem", "cluster", "ns", "deployments", "foo"],
+      });
+    });
+  });
+
+  it("does NOT invalidate any queries when the mutation fails", async () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(
+      () =>
+        useK8sActionMutation<{ name: string }, never>({
+          mutationKey: "test",
+          mutationFn: async () => {
+            throw new Error("boom");
+          },
+          messages: {
+            loading: ({ name }) => `Doing ${name}…`,
+            success: () => "ok",
+            error: ({ name }) => `${name} failed`,
+          },
+          invalidationKeys: () => [["k8s:watchList", "cluster"]],
+        }),
+      { wrapper: makeWrapper(queryClient) }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "foo" }).catch(() => {});
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire the error toast when query invalidation rejects after a successful mutation", async () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockRejectedValueOnce(new Error("cache error"));
+
+    const { result } = renderHook(
+      () =>
+        useK8sActionMutation<{ name: string }, { ok: true }>({
+          mutationKey: "test",
+          mutationFn: async () => ({ ok: true }),
+          messages: {
+            loading: ({ name }) => `Doing ${name}…`,
+            success: ({ name }) => `${name} done`,
+            error: ({ name }) => `${name} failed`,
+          },
+          invalidationKeys: () => [["k8s:watchList", "cluster", "ns", "deployments"]],
+        }),
+      { wrapper: makeWrapper(queryClient) }
+    );
+
+    // Mutation should resolve successfully despite invalidation throwing
+    await act(async () => {
+      await result.current.mutateAsync({ name: "foo" });
+    });
+
+    await waitFor(() => {
+      // Success toast must appear
+      expect(showToast).toHaveBeenCalledWith("foo done", "success", expect.anything());
+      // Error toast must NOT appear
+      const calls = (showToast as ReturnType<typeof vi.fn>).mock.calls;
+      const errorCalls = calls.filter(([, type]) => type === "error");
+      expect(errorCalls).toHaveLength(0);
+      // Invalidation was attempted
+      expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows loading -> error toast with err.message in description on failure", async () => {
+    const { result } = renderHook(
+      () =>
+        useK8sActionMutation<{ name: string }, never>({
+          mutationKey: "test",
+          mutationFn: async () => {
+            throw new Error("boom");
+          },
+          messages: {
+            loading: ({ name }) => `Doing ${name}…`,
+            success: () => "ok",
+            error: ({ name }) => `${name} failed`,
+          },
+          invalidationKeys: () => [],
+        }),
+      { wrapper: makeWrapper(queryClient) }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "foo" }).catch(() => {});
+    });
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(
+        "foo failed",
+        "error",
+        expect.objectContaining({ id: "toast-id", description: "boom" })
+      );
+    });
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useK8sActionMutation.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sActionMutation.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { showToast } from "@/core/components/Snackbar";
+
+export interface UseK8sActionMutationOptions<TInput, TOutput> {
+  mutationKey: string;
+  mutationFn: (input: TInput) => Promise<TOutput>;
+  messages: {
+    loading: (input: TInput) => string;
+    success: (input: TInput, output: TOutput) => string;
+    error: (input: TInput, err: Error) => string;
+  };
+  /**
+   * Query-key prefixes to invalidate on success. Each entry is matched as a TanStack
+   * Query prefix (queries whose key starts with this array are invalidated).
+   * Required to prevent the previous behavior of invalidating the entire cache.
+   */
+  invalidationKeys: (input: TInput, output: TOutput) => Array<readonly unknown[]>;
+}
+
+export function useK8sActionMutation<TInput, TOutput>(options: UseK8sActionMutationOptions<TInput, TOutput>) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: [options.mutationKey],
+    mutationFn: async (input: TInput) => {
+      const loadingId = showToast(options.messages.loading(input), "loading");
+
+      let output: TOutput;
+      try {
+        output = await options.mutationFn(input);
+        showToast(options.messages.success(input, output), "success", { id: loadingId });
+      } catch (rawErr) {
+        const err = rawErr instanceof Error ? rawErr : new Error(String(rawErr));
+        showToast(options.messages.error(input, err), "error", {
+          id: loadingId,
+          description: err.message,
+          duration: 10000,
+        });
+        throw err;
+      }
+
+      // Invalidate after the success toast so a failed invalidation does not fire the
+      // error toast — the K8s PATCH already succeeded and the user should not see a
+      // misleading failure message because of a cache bookkeeping issue.
+      try {
+        await Promise.all(
+          options
+            .invalidationKeys(input, output)
+            .map((key) => queryClient.invalidateQueries({ queryKey: key as unknown[] }))
+        );
+      } catch (invalidationErr) {
+        console.warn("[useK8sActionMutation] query invalidation failed (non-fatal):", invalidationErr);
+      }
+
+      return output;
+    },
+  });
+}

--- a/apps/client/src/modules/k8s/hooks/useK8sRestart.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sRestart.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+const mutateMock = vi.fn();
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({ k8s: { restartWorkload: { mutate: mutateMock } } }),
+}));
+vi.mock("@/core/components/Snackbar", () => ({ showToast: vi.fn().mockReturnValue("id") }));
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: (sel: (s: { clusterName: string }) => unknown) => sel({ clusterName: "test-cluster" }),
+}));
+
+import { useK8sRestart } from "./useK8sRestart";
+import { showToast } from "@/core/components/Snackbar";
+
+const config = {
+  group: "apps",
+  version: "v1",
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  singularName: "deployment",
+  pluralName: "deployments",
+} as const;
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useK8sRestart", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls restartWorkload.mutate with the right payload", async () => {
+    mutateMock.mockResolvedValueOnce({});
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useK8sRestart(config), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "foo" });
+    });
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalledWith({
+        namespace: "ns",
+        name: "foo",
+        resourceConfig: config,
+      });
+    });
+  });
+
+  it("invalidates only the exact watchItem key for the restarted resource (name-targeted)", async () => {
+    mutateMock.mockResolvedValueOnce({});
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useK8sRestart(config), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "my-deploy" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["k8s:watchItem", "test-cluster", "ns", "apps", "deployments", "my-deploy"],
+      });
+      // Must NOT use a bare prefix without the resource name for the target kind
+      expect(invalidateSpy).not.toHaveBeenCalledWith({
+        queryKey: ["k8s:watchItem", "test-cluster", "ns", "apps", "deployments"],
+      });
+    });
+  });
+
+  it("fires an error toast with the resource name and underlying error message when the mutation throws", async () => {
+    mutateMock.mockRejectedValueOnce(new Error("restart rejected by server"));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const { result } = renderHook(() => useK8sRestart(config), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "foo" }).catch(() => {});
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+        "Failed to restart Deployment foo",
+        "error",
+        expect.objectContaining({ description: "restart rejected by server", duration: 10000 })
+      );
+    });
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useK8sRestart.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sRestart.ts
@@ -1,0 +1,52 @@
+import { K8sResourceConfig, k8sPodConfig } from "@my-project/shared";
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import {
+  getK8sWatchItemQueryCacheKey,
+  getK8sWatchItemQueryCacheKeyPrefix,
+  getK8sWatchListQueryCacheKey,
+} from "@/k8s/api/hooks/useWatch/query-keys";
+import { useK8sActionMutation } from "./useK8sActionMutation";
+
+// Mirror of the server-side enum in restartWorkload — kinds that own pods via spec.template.
+export const RESTARTABLE_KINDS = ["Deployment", "StatefulSet", "DaemonSet"] as const;
+export type RestartableKind = (typeof RESTARTABLE_KINDS)[number];
+export type RestartableConfig = Omit<K8sResourceConfig, "kind"> & { kind: RestartableKind };
+
+interface RestartInput {
+  namespace: string;
+  name: string;
+}
+
+export function useK8sRestart(config: RestartableConfig) {
+  const trpc = useTRPCClient();
+  const clusterName = useClusterStore((s) => s.clusterName);
+
+  return useK8sActionMutation<RestartInput, unknown>({
+    mutationKey: `restart:${config.kind}`,
+    mutationFn: ({ namespace, name }) =>
+      trpc.k8s.restartWorkload.mutate({
+        namespace,
+        name,
+        resourceConfig: config,
+      }),
+    messages: {
+      loading: ({ name }) => `Restarting ${config.kind} ${name}…`,
+      success: ({ name }) => `${config.kind} ${name} rollout restarted`,
+      error: ({ name }) => `Failed to restart ${config.kind} ${name}`,
+    },
+    invalidationKeys: ({ namespace, name }) => [
+      getK8sWatchListQueryCacheKey(clusterName, namespace, config.group, config.pluralName),
+      getK8sWatchItemQueryCacheKey(clusterName, namespace, config.group, config.pluralName, name),
+      // Invalidate the pod list so the rollout's new restartedAt is visible immediately.
+      getK8sWatchListQueryCacheKey(clusterName, namespace, k8sPodConfig.group, k8sPodConfig.pluralName),
+      // Invalidate ALL open pod detail pages in this namespace via a partial prefix key.
+      // TanStack Query's invalidateQueries uses prefix matching by default (exact: false),
+      // so every ["k8s:watchItem", clusterName, namespace, "", "pods", <podName>] entry is
+      // invalidated without having to enumerate individual pod names.
+      // The prefix stops at "pods" so no other resource types (e.g. replicasets) are
+      // affected by this invalidation.
+      getK8sWatchItemQueryCacheKeyPrefix(clusterName, namespace, k8sPodConfig.group, k8sPodConfig.pluralName),
+    ],
+  });
+}

--- a/apps/client/src/modules/k8s/hooks/useK8sRollback.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sRollback.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+const mutateMock = vi.fn();
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({ k8s: { rollbackDeployment: { mutate: mutateMock } } }),
+}));
+vi.mock("@/core/components/Snackbar", () => ({ showToast: vi.fn().mockReturnValue("id") }));
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: (sel: (s: { clusterName: string }) => unknown) => sel({ clusterName: "test-cluster" }),
+}));
+
+import { useK8sRollback } from "./useK8sRollback";
+import * as Snackbar from "@/core/components/Snackbar";
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useK8sRollback", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls rollbackDeployment.mutate with replicaSetUid", async () => {
+    mutateMock.mockResolvedValueOnce({});
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useK8sRollback(), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "foo", replicaSetUid: "rs-1" });
+    });
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalledWith({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "rs-1",
+      });
+    });
+  });
+
+  it("invalidates the revision-dialog query under the k8s: namespace prefix", async () => {
+    // Regression guard: useDeploymentRevisions registers under "k8s:deploymentRevisions".
+    // A previous unprefixed "deploymentRevisions" key silently bypassed cache invalidation
+    // so the revision list would not refresh after a successful rollback.
+    mutateMock.mockResolvedValueOnce({});
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useK8sRollback(), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "foo", replicaSetUid: "rs-1" });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["k8s:deploymentRevisions", "test-cluster", "ns", "foo"],
+      });
+      expect(invalidateSpy).not.toHaveBeenCalledWith({
+        queryKey: ["deploymentRevisions", "test-cluster", "ns", "foo"],
+      });
+    });
+  });
+
+  it("fires an error toast with the resource name and underlying error message when the mutation throws", async () => {
+    mutateMock.mockRejectedValueOnce(new Error("rollback rejected by server"));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const { result } = renderHook(() => useK8sRollback(), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "foo", replicaSetUid: "rs-1" }).catch(() => {});
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(Snackbar.showToast)).toHaveBeenCalledWith(
+        "Failed to roll back Deployment foo",
+        "error",
+        expect.objectContaining({ description: "rollback rejected by server", duration: 10000 })
+      );
+    });
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useK8sRollback.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sRollback.ts
@@ -1,0 +1,46 @@
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import { k8sDeploymentConfig, k8sPodConfig, k8sReplicaSetConfig } from "@my-project/shared";
+import {
+  getK8sDeploymentRevisionsQueryCacheKey,
+  getK8sWatchItemQueryCacheKey,
+  getK8sWatchListQueryCacheKey,
+} from "@/k8s/api/hooks/useWatch/query-keys";
+import { useK8sActionMutation } from "./useK8sActionMutation";
+
+interface RollbackInput {
+  namespace: string;
+  name: string;
+  replicaSetUid: string;
+}
+
+export function useK8sRollback() {
+  const trpc = useTRPCClient();
+  const clusterName = useClusterStore((s) => s.clusterName);
+
+  return useK8sActionMutation<RollbackInput, unknown>({
+    mutationKey: "rollback:Deployment",
+    mutationFn: ({ namespace, name, replicaSetUid }) =>
+      trpc.k8s.rollbackDeployment.mutate({ namespace, name, replicaSetUid }),
+    messages: {
+      loading: ({ name }) => `Rolling back Deployment ${name}…`,
+      success: ({ name }) => `Deployment ${name} rolled back`,
+      error: ({ name }) => `Failed to roll back Deployment ${name}`,
+    },
+    invalidationKeys: ({ namespace, name }) => [
+      getK8sWatchListQueryCacheKey(clusterName, namespace, k8sDeploymentConfig.group, k8sDeploymentConfig.pluralName),
+      getK8sWatchItemQueryCacheKey(
+        clusterName,
+        namespace,
+        k8sDeploymentConfig.group,
+        k8sDeploymentConfig.pluralName,
+        name
+      ),
+      // ReplicaSet revisions and pod template change after rollback
+      getK8sWatchListQueryCacheKey(clusterName, namespace, k8sReplicaSetConfig.group, k8sReplicaSetConfig.pluralName),
+      getK8sWatchListQueryCacheKey(clusterName, namespace, k8sPodConfig.group, k8sPodConfig.pluralName),
+      // Revision dialog query refreshes immediately
+      getK8sDeploymentRevisionsQueryCacheKey(clusterName, namespace, name),
+    ],
+  });
+}

--- a/apps/client/src/modules/k8s/hooks/useK8sScale.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sScale.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+const mutateMock = vi.fn();
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({ k8s: { scaleWorkload: { mutate: mutateMock } } }),
+}));
+vi.mock("@/core/components/Snackbar", () => ({ showToast: vi.fn().mockReturnValue("id") }));
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: (sel: (s: { clusterName: string }) => unknown) => sel({ clusterName: "test-cluster" }),
+}));
+
+import { useK8sScale } from "./useK8sScale";
+import { showToast } from "@/core/components/Snackbar";
+
+const config = {
+  group: "apps",
+  version: "v1",
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  singularName: "deployment",
+  pluralName: "deployments",
+} as const;
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useK8sScale", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls scaleWorkload.mutate with the right payload", async () => {
+    mutateMock.mockResolvedValueOnce({ spec: { replicas: 5 } });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useK8sScale(config), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "foo", replicas: 5 });
+    });
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalledWith({
+        namespace: "ns",
+        name: "foo",
+        resourceConfig: config,
+        replicas: 5,
+      });
+    });
+  });
+
+  it("invalidates only the exact watchItem key for the scaled resource (name-targeted)", async () => {
+    mutateMock.mockResolvedValueOnce({ spec: { replicas: 3 } });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useK8sScale(config), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "my-deploy", replicas: 3 });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["k8s:watchItem", "test-cluster", "ns", "apps", "deployments", "my-deploy"],
+      });
+      // Must NOT invalidate items for other resources under the same namespace prefix
+      expect(invalidateSpy).not.toHaveBeenCalledWith({
+        queryKey: ["k8s:watchItem", "test-cluster", "ns", "apps", "deployments"],
+      });
+    });
+  });
+
+  it("fires an error toast with the resource name and underlying error message when the mutation throws", async () => {
+    mutateMock.mockRejectedValueOnce(new Error("scale rejected by server"));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const { result } = renderHook(() => useK8sScale(config), { wrapper: makeWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ namespace: "ns", name: "foo", replicas: 5 }).catch(() => {});
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(showToast)).toHaveBeenCalledWith(
+        "Failed to scale Deployment foo",
+        "error",
+        expect.objectContaining({ description: "scale rejected by server", duration: 10000 })
+      );
+    });
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useK8sScale.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sScale.ts
@@ -1,0 +1,49 @@
+import { K8sResourceConfig, k8sHorizontalPodAutoscalerConfig } from "@my-project/shared";
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import { getK8sWatchItemQueryCacheKey, getK8sWatchListQueryCacheKey } from "@/k8s/api/hooks/useWatch/query-keys";
+import { useK8sActionMutation } from "./useK8sActionMutation";
+
+// Mirror of the server-side enum in scaleWorkload — kinds exposing the /scale subresource.
+export const SCALABLE_KINDS = ["Deployment", "StatefulSet", "ReplicaSet", "ReplicationController"] as const;
+export type ScalableKind = (typeof SCALABLE_KINDS)[number];
+export type ScalableConfig = Omit<K8sResourceConfig, "kind"> & { kind: ScalableKind };
+
+interface ScaleInput {
+  namespace: string;
+  name: string;
+  replicas: number;
+}
+
+export function useK8sScale(config: ScalableConfig) {
+  const trpc = useTRPCClient();
+  const clusterName = useClusterStore((s) => s.clusterName);
+
+  return useK8sActionMutation<ScaleInput, unknown>({
+    mutationKey: `scale:${config.kind}`,
+    mutationFn: ({ namespace, name, replicas }) =>
+      trpc.k8s.scaleWorkload.mutate({
+        namespace,
+        name,
+        resourceConfig: config,
+        replicas,
+      }),
+    messages: {
+      loading: ({ name, replicas }) => `Scaling ${config.kind} ${name} to ${replicas}…`,
+      success: ({ name, replicas }) => `${config.kind} ${name} scaled to ${replicas}`,
+      error: ({ name }) => `Failed to scale ${config.kind} ${name}`,
+    },
+    invalidationKeys: ({ namespace, name }) => [
+      getK8sWatchListQueryCacheKey(clusterName, namespace, config.group, config.pluralName),
+      getK8sWatchItemQueryCacheKey(clusterName, namespace, config.group, config.pluralName, name),
+      // HPA list refresh covers the visible replica count; the bare watchItem prefix
+      // is intentionally omitted to avoid refetching every open HPA detail page in the namespace.
+      getK8sWatchListQueryCacheKey(
+        clusterName,
+        namespace,
+        k8sHorizontalPodAutoscalerConfig.group,
+        k8sHorizontalPodAutoscalerConfig.pluralName
+      ),
+    ],
+  });
+}

--- a/apps/client/src/modules/k8s/hooks/useUpdatePermission.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useUpdatePermission.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks (hoisted before imports)
+// ---------------------------------------------------------------------------
+
+const itemPermissionsMutateMock = vi.fn();
+
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({
+    k8s: { itemPermissions: { mutate: itemPermissionsMutateMock } },
+  }),
+}));
+
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: (sel: (s: { clusterName: string; defaultNamespace: string }) => unknown) =>
+    sel({ clusterName: "test-cluster", defaultNamespace: "default" }),
+}));
+
+import { useUpdatePermission } from "./useUpdatePermission";
+
+const config = {
+  group: "apps",
+  version: "v1",
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  singularName: "deployment",
+  pluralName: "deployments",
+} as const;
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useUpdatePermission", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns allowed=true when the patch verb is permitted", async () => {
+    itemPermissionsMutateMock.mockResolvedValueOnce({
+      create: { allowed: false, reason: "" },
+      update: { allowed: true, reason: "" },
+      patch: { allowed: true, reason: "" },
+      delete: { allowed: false, reason: "" },
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useUpdatePermission(config), { wrapper: makeWrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(result.current.allowed).toBe(true);
+      expect(result.current.reason).toBeFalsy();
+    });
+  });
+
+  it("returns allowed=true when patch is permitted but update is denied (PATCH-only operators)", async () => {
+    // Scale/restart/rollback use HTTP PATCH; operators granted patch-only on a
+    // workload must not be blocked by a missing "update" verb.
+    itemPermissionsMutateMock.mockResolvedValueOnce({
+      create: { allowed: false, reason: "" },
+      update: { allowed: false, reason: "update not permitted" },
+      patch: { allowed: true, reason: "" },
+      delete: { allowed: false, reason: "" },
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useUpdatePermission(config), { wrapper: makeWrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(result.current.allowed).toBe(true);
+    });
+  });
+
+  it("returns allowed=false and surfaces the patch reason when the patch verb is denied", async () => {
+    itemPermissionsMutateMock.mockResolvedValueOnce({
+      create: { allowed: false, reason: "" },
+      update: { allowed: true, reason: "" },
+      patch: { allowed: false, reason: "patch not permitted" },
+      delete: { allowed: false, reason: "" },
+    });
+    // update.allowed=true here intentionally does NOT make the action allowed —
+    // workloads PATCH, not PUT, so only the patch verb matters.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useUpdatePermission(config), { wrapper: makeWrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(result.current.allowed).toBe(false);
+      expect(result.current.reason).toBe("patch not permitted");
+    });
+  });
+
+  it("returns allowed=false (placeholder) before the permission query resolves", () => {
+    // itemPermissionsMutateMock never resolves — the hook must fall back to
+    // defaultPermissions (all denied) so action buttons stay safely disabled.
+    itemPermissionsMutateMock.mockReturnValue(new Promise(() => {}));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useUpdatePermission(config), { wrapper: makeWrapper(queryClient) });
+
+    // Synchronous assertion: placeholder data means denied
+    expect(result.current.allowed).toBe(false);
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useUpdatePermission.ts
+++ b/apps/client/src/modules/k8s/hooks/useUpdatePermission.ts
@@ -1,0 +1,21 @@
+import type { K8sResourceConfig } from "@my-project/shared";
+import { usePermissions } from "@/k8s/api/hooks/usePermissions";
+
+/**
+ * Permission check for any K8s workload action (scale, restart, rollback) that
+ * mutates an existing resource via HTTP PATCH. K8s RBAC controls PATCH solely
+ * via the "patch" verb; "update" gates HTTP PUT (replaceResource) which none of
+ * these actions invoke. Requiring "update" here would over-restrict operators
+ * granted patch-only on a workload (a common least-privilege pattern).
+ */
+export function useUpdatePermission(config: K8sResourceConfig) {
+  const perms = usePermissions({
+    group: config.group,
+    version: config.version,
+    resourcePlural: config.pluralName,
+  });
+  return {
+    allowed: perms.data.patch.allowed,
+    reason: perms.data.patch.reason,
+  };
+}

--- a/apps/client/src/modules/k8s/pages/crds/detail/components/NamesCard.tsx
+++ b/apps/client/src/modules/k8s/pages/crds/detail/components/NamesCard.tsx
@@ -1,0 +1,34 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/core/components/ui/card";
+import { TableUI, TableBodyUI, TableCellUI, TableHeadUI, TableHeaderUI, TableRowUI } from "@/core/components/ui/table";
+import type { CRDObject } from "@my-project/shared";
+
+export function NamesCard({ crd }: { crd: CRDObject }) {
+  const n = crd.spec.names;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Names</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <TableUI>
+          <TableHeaderUI>
+            <TableRowUI>
+              <TableHeadUI scope="col">Kind</TableHeadUI>
+              <TableHeadUI scope="col">Plural</TableHeadUI>
+              <TableHeadUI scope="col">Singular</TableHeadUI>
+              <TableHeadUI scope="col">ListKind</TableHeadUI>
+            </TableRowUI>
+          </TableHeaderUI>
+          <TableBodyUI>
+            <TableRowUI>
+              <TableCellUI>{n.kind}</TableCellUI>
+              <TableCellUI>{n.plural}</TableCellUI>
+              <TableCellUI>{n.singular ?? "—"}</TableCellUI>
+              <TableCellUI>{n.listKind ?? "—"}</TableCellUI>
+            </TableRowUI>
+          </TableBodyUI>
+        </TableUI>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/crds/detail/components/ScopeGroupConversionRow.tsx
+++ b/apps/client/src/modules/k8s/pages/crds/detail/components/ScopeGroupConversionRow.tsx
@@ -1,0 +1,23 @@
+import { HoverInfoLabel } from "@/core/components/HoverInfoLabel";
+import type { CRDObject } from "@my-project/shared";
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <div>
+        <HoverInfoLabel label={label} />
+      </div>
+      <div className="text-sm">{value}</div>
+    </div>
+  );
+}
+
+export function ScopeGroupConversionRow({ crd }: { crd: CRDObject }) {
+  return (
+    <div className="grid grid-cols-3 gap-6 py-2">
+      <Field label="Scope" value={crd.spec.scope} />
+      <Field label="Group" value={crd.spec.group} />
+      <Field label="Conversion" value={crd.spec.conversion?.strategy ?? "None"} />
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/crds/detail/components/VersionsCard.tsx
+++ b/apps/client/src/modules/k8s/pages/crds/detail/components/VersionsCard.tsx
@@ -1,0 +1,46 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/core/components/ui/card";
+import { Badge } from "@/core/components/ui/badge";
+import { TableUI, TableBodyUI, TableCellUI, TableHeadUI, TableHeaderUI, TableRowUI } from "@/core/components/ui/table";
+import type { CRDObject } from "@my-project/shared";
+
+export function VersionsCard({ crd }: { crd: CRDObject }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Versions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <TableUI>
+          <TableHeaderUI>
+            <TableRowUI>
+              <TableHeadUI scope="col">Name</TableHeadUI>
+              <TableHeadUI scope="col">Served</TableHeadUI>
+              <TableHeadUI scope="col">Storage</TableHeadUI>
+            </TableRowUI>
+          </TableHeaderUI>
+          <TableBodyUI>
+            {crd.spec.versions.length === 0 ? (
+              <TableRowUI>
+                <TableCellUI colSpan={3} className="text-muted-foreground text-center text-sm">
+                  No versions defined.
+                </TableCellUI>
+              </TableRowUI>
+            ) : (
+              crd.spec.versions.map((v) => (
+                <TableRowUI key={v.name} className={v.storage ? "font-semibold" : undefined}>
+                  <TableCellUI>{v.name}</TableCellUI>
+                  <TableCellUI>
+                    <Badge variant={v.served ? "success" : "secondary"}>{v.served ? "True" : "False"}</Badge>
+                  </TableCellUI>
+                  <TableCellUI>
+                    <Badge variant={v.storage ? "success" : "secondary"}>{v.storage ? "True" : "False"}</Badge>
+                  </TableCellUI>
+                </TableRowUI>
+              ))
+            )}
+          </TableBodyUI>
+        </TableUI>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/crds/detail/page.tsx
+++ b/apps/client/src/modules/k8s/pages/crds/detail/page.tsx
@@ -1,0 +1,134 @@
+import { Layers, Trash } from "lucide-react";
+import { useParams } from "@tanstack/react-router";
+import { ButtonWithPermission } from "@/core/components/ButtonWithPermission";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { useDialogOpener } from "@/core/providers/Dialog/hooks";
+import { DeleteKubeObjectDialog } from "@/core/components/DeleteKubeObject";
+import { ResourceYamlTab } from "@/modules/k8s/components/ResourceYamlTab";
+import { ResourceEventsTab } from "@/modules/k8s/components/ResourceEventsTab";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { usePermissions } from "@/k8s/api/hooks/usePermissions";
+import { CRDOverviewTab } from "./tabs/OverviewTab";
+import { useCRD } from "@/modules/k8s/hooks/useCRD";
+import { useDetailTabs, DEFAULT_DETAIL_TABS } from "@/modules/k8s/hooks/useDetailTabs";
+import { PATH_K8S_CRDS_FULL } from "@/modules/k8s/constants/paths";
+import { k8sCustomResourceDefinitionConfig, type CRDObject, type K8sResourceConfig } from "@my-project/shared";
+import type { RouteParams } from "@/core/router/types";
+
+export default function CRDDetailPage() {
+  const { clusterName, name } = useParams({ strict: false }) as { clusterName?: string; name?: string };
+  const openDelete = useDialogOpener(DeleteKubeObjectDialog);
+  const { activeTabIdx, setTab, onTabChange } = useDetailTabs(DEFAULT_DETAIL_TABS);
+
+  const result = useCRD(name ?? "");
+  const item = result.data as CRDObject | undefined;
+
+  const perms = usePermissions({
+    group: k8sCustomResourceDefinitionConfig.group,
+    version: k8sCustomResourceDefinitionConfig.version,
+    resourcePlural: k8sCustomResourceDefinitionConfig.pluralName,
+  });
+
+  const breadcrumbs = [
+    { label: "Cluster" },
+    {
+      label: "CRDs",
+      route: { to: PATH_K8S_CRDS_FULL, params: { clusterName: clusterName ?? "" } } as unknown as RouteParams,
+    },
+    { label: name ?? "" },
+  ];
+
+  if (result.isLoading) {
+    return (
+      <PageWrapper breadcrumbs={breadcrumbs}>
+        <PageContentWrapper icon={Layers} title={name ?? ""}>
+          <div className="text-muted-foreground p-6 text-sm">Loading…</div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+  if (result.query.isError) {
+    return (
+      <PageWrapper breadcrumbs={breadcrumbs}>
+        <PageContentWrapper icon={Layers} title={name ?? ""}>
+          <div className="p-6">
+            <ErrorContent error={result.query.error ?? null} />
+          </div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+  if (!item) {
+    return (
+      <PageWrapper breadcrumbs={breadcrumbs}>
+        <PageContentWrapper icon={Layers} title={name ?? ""}>
+          <div className="p-6">CRD not found.</div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  const handleDelete = () => {
+    const kind = item.spec.names.kind;
+    openDelete({
+      objectName: item.metadata.name,
+      resourceConfig: k8sCustomResourceDefinitionConfig as K8sResourceConfig,
+      resource: item,
+      description: (
+        <>
+          <div>
+            Delete CustomResourceDefinition &ldquo;<b>{kind}</b>&rdquo;.
+          </div>
+          <div className="text-destructive mt-2 text-sm">
+            Warning: deleting this CRD will remove all <b>{kind}</b> instances cluster-wide. This action cannot be
+            undone.
+          </div>
+        </>
+      ),
+    });
+  };
+
+  const tabs = [
+    {
+      id: "overview",
+      label: "Overview",
+      onClick: () => setTab("overview"),
+      component: <CRDOverviewTab item={item} />,
+    },
+    {
+      id: "yaml",
+      label: "YAML",
+      onClick: () => setTab("yaml"),
+      component: <ResourceYamlTab item={item} config={k8sCustomResourceDefinitionConfig as K8sResourceConfig} />,
+    },
+    {
+      id: "events",
+      label: "Events",
+      onClick: () => setTab("events"),
+      component: <ResourceEventsTab item={item} />,
+    },
+  ];
+
+  return (
+    <PageWrapper breadcrumbs={breadcrumbs}>
+      <PageContentWrapper
+        icon={Layers}
+        title={item.spec.names.kind}
+        description={`${item.spec.scope} · ${item.spec.group}`}
+        actions={
+          <ButtonWithPermission
+            allowed={perms.data.delete.allowed}
+            reason={perms.data.delete.reason ?? ""}
+            ButtonProps={{ variant: "outline", size: "sm", onClick: handleDelete }}
+          >
+            <Trash size={14} className="mr-1.5" /> Delete
+          </ButtonWithPermission>
+        }
+        tabs={tabs}
+        activeTab={activeTabIdx}
+        onTabChange={onTabChange}
+      />
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/crds/detail/route.lazy.ts
+++ b/apps/client/src/modules/k8s/pages/crds/detail/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_K8S_CRDS_DETAIL } from "./route";
+import CRDDetailPage from "./page";
+
+const K8sCRDsDetailRoute = createLazyRoute(ROUTE_ID_K8S_CRDS_DETAIL as never)({
+  component: CRDDetailPage,
+});
+
+export default K8sCRDsDetailRoute;

--- a/apps/client/src/modules/k8s/pages/crds/detail/route.lazy.ts
+++ b/apps/client/src/modules/k8s/pages/crds/detail/route.lazy.ts
@@ -2,7 +2,7 @@ import { createLazyRoute } from "@tanstack/react-router";
 import { ROUTE_ID_K8S_CRDS_DETAIL } from "./route";
 import CRDDetailPage from "./page";
 
-const K8sCRDsDetailRoute = createLazyRoute(ROUTE_ID_K8S_CRDS_DETAIL as never)({
+const K8sCRDsDetailRoute = createLazyRoute(ROUTE_ID_K8S_CRDS_DETAIL)({
   component: CRDDetailPage,
 });
 

--- a/apps/client/src/modules/k8s/pages/crds/detail/route.ts
+++ b/apps/client/src/modules/k8s/pages/crds/detail/route.ts
@@ -1,0 +1,15 @@
+import { createRoute } from "@tanstack/react-router";
+import { routeK8sMode } from "@/core/router/routes";
+import { baseDetailTabSchema } from "@/modules/k8s/constants/tabs";
+import { PATH_K8S_CRDS_DETAIL, PATH_K8S_CRDS_DETAIL_FULL } from "@/modules/k8s/constants/paths";
+
+export { PATH_K8S_CRDS_DETAIL_FULL };
+// Derived from the full path constant to avoid drift if the path ever changes.
+export const ROUTE_ID_K8S_CRDS_DETAIL = `/_layout${PATH_K8S_CRDS_DETAIL_FULL}` as const;
+
+export const routeK8sCRDsDetail = createRoute({
+  getParentRoute: () => routeK8sMode,
+  path: PATH_K8S_CRDS_DETAIL,
+  validateSearch: (search: Record<string, unknown>) => baseDetailTabSchema.parse(search),
+  head: () => ({ meta: [{ title: "CustomResourceDefinition | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/k8s/pages/crds/detail/tabs/OverviewTab.test.tsx
+++ b/apps/client/src/modules/k8s/pages/crds/detail/tabs/OverviewTab.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { CRDObject } from "@my-project/shared";
+import { CRDOverviewTab } from "./OverviewTab";
+
+const crd = {
+  apiVersion: "apiextensions.k8s.io/v1",
+  kind: "CustomResourceDefinition",
+  metadata: { name: "x.example.com", uid: "u", creationTimestamp: "" },
+  spec: {
+    group: "example.com",
+    scope: "Namespaced",
+    names: { kind: "X", plural: "xs", singular: "x", listKind: "XList" },
+    versions: [
+      { name: "v1", served: true, storage: true },
+      { name: "v1beta1", served: true, storage: false },
+    ],
+  },
+  status: { conditions: [{ type: "Established", status: "True", lastTransitionTime: "2026-05-15T10:00:00Z" }] },
+} as unknown as CRDObject;
+
+describe("CRDOverviewTab", () => {
+  it("renders Names, Versions, Scope row, and Conditions", () => {
+    render(<CRDOverviewTab item={crd} />);
+    expect(screen.getByText("Names")).toBeInTheDocument();
+    expect(screen.getByText("Versions")).toBeInTheDocument();
+    expect(screen.getByText("v1")).toBeInTheDocument();
+    expect(screen.getByText("example.com")).toBeInTheDocument(); // Group field
+    expect(screen.getByText("Established")).toBeInTheDocument(); // Conditions table row
+  });
+
+  it("renders an empty-state row when there are no versions defined", () => {
+    const empty = {
+      ...crd,
+      spec: { ...crd.spec, versions: [] },
+    } as unknown as CRDObject;
+    render(<CRDOverviewTab item={empty} />);
+    expect(screen.getByText(/No versions defined/i)).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/modules/k8s/pages/crds/detail/tabs/OverviewTab.tsx
+++ b/apps/client/src/modules/k8s/pages/crds/detail/tabs/OverviewTab.tsx
@@ -1,0 +1,16 @@
+import { ConditionsTable } from "@/modules/k8s/components/ConditionsTable";
+import { NamesCard } from "../components/NamesCard";
+import { ScopeGroupConversionRow } from "../components/ScopeGroupConversionRow";
+import { VersionsCard } from "../components/VersionsCard";
+import type { CRDObject } from "@my-project/shared";
+
+export function CRDOverviewTab({ item }: { item: CRDObject }) {
+  return (
+    <div className="space-y-6 p-4">
+      <NamesCard crd={item} />
+      <VersionsCard crd={item} />
+      <ScopeGroupConversionRow crd={item} />
+      <ConditionsTable conditions={item.status?.conditions ?? []} />
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/cr-parent/route.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/cr-parent/route.ts
@@ -1,0 +1,9 @@
+import { createRoute, Outlet } from "@tanstack/react-router";
+import { routeK8sMode } from "@/core/router/routes";
+import { PATH_K8S_CR } from "@/modules/k8s/constants/paths";
+
+export const routeK8sCRParent = createRoute({
+  getParentRoute: () => routeK8sMode,
+  path: PATH_K8S_CR,
+  component: Outlet,
+});

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail-cluster/page.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail-cluster/page.tsx
@@ -1,0 +1,5 @@
+import CRDetailView from "../detail/view";
+
+export default function CRDetailClusterPage() {
+  return <CRDetailView expectedVariant="cluster" />;
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail-cluster/route.lazy.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail-cluster/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_K8S_CR_DETAIL_CLUSTER } from "./route";
+import CRDetailClusterPage from "./page";
+
+const K8sCRDetailClusterRoute = createLazyRoute(ROUTE_ID_K8S_CR_DETAIL_CLUSTER as never)({
+  component: CRDetailClusterPage,
+});
+
+export default K8sCRDetailClusterRoute;

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail-cluster/route.lazy.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail-cluster/route.lazy.ts
@@ -2,8 +2,6 @@ import { createLazyRoute } from "@tanstack/react-router";
 import { ROUTE_ID_K8S_CR_DETAIL_CLUSTER } from "./route";
 import CRDetailClusterPage from "./page";
 
-const K8sCRDetailClusterRoute = createLazyRoute(ROUTE_ID_K8S_CR_DETAIL_CLUSTER as never)({
-  component: CRDetailClusterPage,
-});
+const K8sCRDetailClusterRoute = createLazyRoute(ROUTE_ID_K8S_CR_DETAIL_CLUSTER)({ component: CRDetailClusterPage });
 
 export default K8sCRDetailClusterRoute;

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail-cluster/route.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail-cluster/route.ts
@@ -1,0 +1,14 @@
+import { createRoute } from "@tanstack/react-router";
+import { routeK8sCRParent } from "../cr-parent/route";
+import { baseDetailTabSchema } from "@/modules/k8s/constants/tabs";
+import { PATH_K8S_CR_DETAIL_CLUSTER, PATH_K8S_CR_DETAIL_CLUSTER_FULL } from "@/modules/k8s/constants/paths";
+
+// Derived from the full path constant to avoid drift if the path ever changes.
+export const ROUTE_ID_K8S_CR_DETAIL_CLUSTER = `/_layout${PATH_K8S_CR_DETAIL_CLUSTER_FULL}` as const;
+
+export const routeK8sCRDetailCluster = createRoute({
+  getParentRoute: () => routeK8sCRParent,
+  path: PATH_K8S_CR_DETAIL_CLUSTER,
+  validateSearch: (search: Record<string, unknown>) => baseDetailTabSchema.parse(search),
+  head: () => ({ meta: [{ title: "Custom Resource | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail-namespaced/page.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail-namespaced/page.tsx
@@ -1,0 +1,5 @@
+import CRDetailView from "../detail/view";
+
+export default function CRDetailNsPage() {
+  return <CRDetailView expectedVariant="namespaced" />;
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail-namespaced/route.lazy.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail-namespaced/route.lazy.ts
@@ -2,6 +2,6 @@ import { createLazyRoute } from "@tanstack/react-router";
 import { ROUTE_ID_K8S_CR_DETAIL_NS } from "./route";
 import CRDetailNsPage from "./page";
 
-const K8sCRDetailNsRoute = createLazyRoute(ROUTE_ID_K8S_CR_DETAIL_NS as never)({ component: CRDetailNsPage });
+const K8sCRDetailNsRoute = createLazyRoute(ROUTE_ID_K8S_CR_DETAIL_NS)({ component: CRDetailNsPage });
 
 export default K8sCRDetailNsRoute;

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail-namespaced/route.lazy.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail-namespaced/route.lazy.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_K8S_CR_DETAIL_NS } from "./route";
+import CRDetailNsPage from "./page";
+
+const K8sCRDetailNsRoute = createLazyRoute(ROUTE_ID_K8S_CR_DETAIL_NS as never)({ component: CRDetailNsPage });
+
+export default K8sCRDetailNsRoute;

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail-namespaced/route.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail-namespaced/route.ts
@@ -1,0 +1,14 @@
+import { createRoute } from "@tanstack/react-router";
+import { routeK8sCRParent } from "../cr-parent/route";
+import { baseDetailTabSchema } from "@/modules/k8s/constants/tabs";
+import { PATH_K8S_CR_DETAIL_NS, PATH_K8S_CR_DETAIL_NS_FULL } from "@/modules/k8s/constants/paths";
+
+// Derived from the full path constant to avoid drift if the path ever changes.
+export const ROUTE_ID_K8S_CR_DETAIL_NS = `/_layout${PATH_K8S_CR_DETAIL_NS_FULL}` as const;
+
+export const routeK8sCRDetailNs = createRoute({
+  getParentRoute: () => routeK8sCRParent,
+  path: PATH_K8S_CR_DETAIL_NS,
+  validateSearch: (search: Record<string, unknown>) => baseDetailTabSchema.parse(search),
+  head: () => ({ meta: [{ title: "Custom Resource | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail/components/PrinterColumnsRows.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail/components/PrinterColumnsRows.tsx
@@ -1,0 +1,32 @@
+import { HoverInfoLabel } from "@/core/components/HoverInfoLabel";
+import { PrinterColumnValue } from "@/modules/k8s/components/PrinterColumnValue";
+import { resolveCRDVersion, CREATION_TIMESTAMP_PRINTER_COL_PATH } from "@/modules/k8s/registry/dynamic/crdUtils";
+import type { CRDObject, KubeObjectBase } from "@my-project/shared";
+
+export function PrinterColumnsRows({ crd, item, version }: { crd: CRDObject; item: KubeObjectBase; version: string }) {
+  const v = resolveCRDVersion(crd, version);
+  // Skip the creationTimestamp printer column — the detail page header already shows
+  // creation time, and it's also filtered out of the list view (consistency).
+  // Show ALL remaining printer columns (including priority > 0): detail surfaces are
+  // intended to give more information than the list summary.
+  const cols = (v?.additionalPrinterColumns ?? []).filter((c) => c.jsonPath !== CREATION_TIMESTAMP_PRINTER_COL_PATH);
+  if (cols.length === 0) {
+    return <p className="text-muted-foreground text-sm">No additional columns defined for this resource.</p>;
+  }
+  return (
+    <div className="grid grid-cols-[10rem_1fr] gap-x-6 gap-y-2">
+      {cols.map((c, idx) => (
+        // Suffix with idx so a malformed CRD with duplicate printer-column names doesn't
+        // produce duplicate React keys (which would mis-render the cell value).
+        <div className="contents" key={`${c.name}-${idx}`}>
+          <div>
+            <HoverInfoLabel label={c.name} tooltip={c.description} />
+          </div>
+          <div>
+            <PrinterColumnValue item={item} jsonPath={c.jsonPath} type={c.type} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail/tabs/CROverviewTab.test.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail/tabs/CROverviewTab.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CROverviewTab } from "./CROverviewTab";
+
+const crd = {
+  spec: {
+    group: "tekton.dev",
+    scope: "Namespaced",
+    names: { kind: "PipelineRun", plural: "pipelineruns" },
+    versions: [
+      {
+        name: "v1",
+        served: true,
+        storage: true,
+        additionalPrinterColumns: [
+          { name: "Status", type: "string", jsonPath: ".status.phase", description: "Current phase" },
+        ],
+      },
+    ],
+  },
+} as never;
+
+const item = {
+  metadata: { name: "pr-1", namespace: "dev" },
+  status: { phase: "Running", conditions: [{ type: "Succeeded", status: "Unknown" }] },
+} as never;
+
+describe("CROverviewTab", () => {
+  it("renders a row per printer column with the value extracted by JSONPath", () => {
+    render(<CROverviewTab crd={crd} item={item} version="v1" />);
+    expect(screen.getAllByText("Status").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("renders ConditionsTable when conditions are present", () => {
+    render(<CROverviewTab crd={crd} item={item} version="v1" />);
+    expect(screen.getByText("Succeeded")).toBeInTheDocument();
+  });
+
+  it("hides ConditionsTable when no conditions are present", () => {
+    const noCond = { ...(item as object), status: { phase: "Running" } } as never;
+    render(<CROverviewTab crd={crd} item={noCond} version="v1" />);
+    expect(screen.queryByRole("columnheader", { name: "Type" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail/tabs/CROverviewTab.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail/tabs/CROverviewTab.tsx
@@ -1,0 +1,13 @@
+import { ConditionsTable } from "@/modules/k8s/components/ConditionsTable";
+import { PrinterColumnsRows } from "../components/PrinterColumnsRows";
+import type { CRDObject, KubeCondition, KubeObjectBase } from "@my-project/shared";
+
+export function CROverviewTab({ crd, item, version }: { crd: CRDObject; item: KubeObjectBase; version: string }) {
+  const conditions = (item as { status?: { conditions?: KubeCondition[] } }).status?.conditions ?? [];
+  return (
+    <div className="space-y-6 p-4">
+      <PrinterColumnsRows crd={crd} item={item} version={version} />
+      {conditions.length > 0 && <ConditionsTable conditions={conditions} />}
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/detail/view.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/detail/view.tsx
@@ -1,0 +1,221 @@
+import { useMemo } from "react";
+import { Puzzle, Trash } from "lucide-react";
+import { useParams } from "@tanstack/react-router";
+import { ButtonWithPermission } from "@/core/components/ButtonWithPermission";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { useDialogOpener } from "@/core/providers/Dialog/hooks";
+import { DeleteKubeObjectDialog } from "@/core/components/DeleteKubeObject";
+import { ResourceYamlTab } from "@/modules/k8s/components/ResourceYamlTab";
+import { ResourceEventsTab } from "@/modules/k8s/components/ResourceEventsTab";
+import { ErrorContent } from "@/core/components/ErrorContent";
+import { usePermissions } from "@/k8s/api/hooks/usePermissions";
+import { CROverviewTab } from "./tabs/CROverviewTab";
+import { useCRDByGVR } from "@/modules/k8s/hooks/useCRDByGVR";
+import { useCR } from "@/modules/k8s/hooks/useCR";
+import { useDetailTabs, DEFAULT_DETAIL_TABS } from "@/modules/k8s/hooks/useDetailTabs";
+import { buildCRDescriptor } from "@/modules/k8s/registry/dynamic/buildCRDescriptor";
+import type { CRDObject } from "@my-project/shared";
+import type { DetailVariant } from "@/modules/k8s/registry/types";
+
+/**
+ * A minimal valid CRDObject placeholder used while the real CRD is still loading.
+ * Satisfies the CRDObject shape so buildCRDescriptor (called inside useCR) can run
+ * without crashing. The watch hook inside useCR will be disabled because `name` is
+ * empty until the CRD resolves.
+ */
+const PENDING_CRD: CRDObject = {
+  apiVersion: "apiextensions.k8s.io/v1",
+  kind: "CustomResourceDefinition",
+  metadata: {
+    name: "_pending",
+    uid: "_pending",
+    creationTimestamp: "",
+  },
+  spec: {
+    group: "",
+    scope: "Cluster",
+    names: {
+      kind: "_Pending",
+      plural: "_pending",
+      singular: "_pending",
+    },
+    versions: [{ name: "v1", served: true, storage: true }],
+  },
+};
+
+// Computed once: buildCRDescriptor(PENDING_CRD) is a constant, so reuse it during the
+// loading window instead of re-invoking the factory on every render.
+const PENDING_CONFIG = buildCRDescriptor(PENDING_CRD, "v1").config;
+
+export default function CRDetailView({ expectedVariant }: { expectedVariant: DetailVariant }) {
+  const params = useParams({ strict: false }) as {
+    group?: string;
+    version?: string;
+    plural?: string;
+    namespace?: string;
+    name?: string;
+  };
+  const openDelete = useDialogOpener(DeleteKubeObjectDialog);
+  const { activeTabIdx, setTab, onTabChange } = useDetailTabs(DEFAULT_DETAIL_TABS);
+
+  const { group = "", version = "", plural = "", namespace = "", name = "" } = params;
+
+  const crdResult = useCRDByGVR(group, version, plural);
+  const crd = crdResult.crd;
+
+  // Always call useCR unconditionally — use the real CRD once available, otherwise the
+  // placeholder so buildCRDescriptor doesn't blow up on a missing versions array.
+  // Gate the inner useWatchItem on `crd` being resolved: without this, the placeholder's
+  // (group "", plural "_pending") would be paired with the URL-derived name to issue a
+  // bogus GET against /api/v1/_pending/<name>, producing a 404 + a useless K8s audit log.
+  const result = useCR(crd ?? PENDING_CRD, namespace, name, version, { enabled: !!crd });
+
+  // Derive descriptor after both hooks are called. Memoize so identical (crd, version)
+  // inputs return a referentially stable descriptor, matching the cached config produced
+  // by useCR and avoiding redundant column-array allocations on every render.
+  const descriptor = useMemo(() => (crd ? buildCRDescriptor(crd, version) : null), [crd, version]);
+  // Fallback to PENDING_CRD's config during the loading window so downstream components
+  // (e.g. ResourceYamlTab, permission hook) receive a valid K8sResourceConfig shape.
+  const config = descriptor?.config ?? PENDING_CONFIG;
+
+  // Permission check uses the resolved CR's GVR. While the CRD is still loading,
+  // disable the query entirely (avoid a spurious SelfSubjectAccessReview against
+  // PENDING_CRD's placeholder pluralName); defaultPermissions keep Delete disabled.
+  const perms = usePermissions({
+    group: config.group,
+    version: config.version,
+    resourcePlural: config.pluralName,
+    enabled: !!crd,
+  });
+
+  const breadcrumbs = [
+    { label: "Cluster" },
+    { label: "Custom Resources" },
+    { label: descriptor?.label ?? "" },
+    { label: name },
+  ];
+
+  if (crdResult.isLoading) {
+    return (
+      <PageWrapper breadcrumbs={[{ label: "Cluster" }, { label: "Custom Resources" }]}>
+        <PageContentWrapper icon={Puzzle} title="Loading…">
+          <div className="text-muted-foreground p-6 text-sm">Loading…</div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  if (crdResult.error || !crd || !descriptor) {
+    return (
+      <PageWrapper breadcrumbs={[{ label: "Cluster" }, { label: "Custom Resources" }]}>
+        <PageContentWrapper icon={Puzzle} title="Unknown custom resource">
+          <div className="p-6">
+            Unknown: <code>{`${group}/${version}/${plural}`}</code>
+          </div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  if (descriptor.detailVariant !== expectedVariant) {
+    return (
+      <PageWrapper breadcrumbs={breadcrumbs.slice(0, 3)}>
+        <PageContentWrapper icon={Puzzle} title="Wrong route variant">
+          <div className="p-6">CRD is {descriptor.detailVariant}-scoped; use the correct detail route.</div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  if (result.isLoading) {
+    return (
+      <PageWrapper breadcrumbs={breadcrumbs}>
+        <PageContentWrapper icon={Puzzle} title={name}>
+          <div className="text-muted-foreground p-6 text-sm">Loading…</div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  if (result.query.isError) {
+    return (
+      <PageWrapper breadcrumbs={breadcrumbs}>
+        <PageContentWrapper icon={Puzzle} title={name}>
+          <div className="p-6">
+            <ErrorContent error={result.query.error ?? null} />
+          </div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  const item = result.data;
+
+  if (!item) {
+    return (
+      <PageWrapper breadcrumbs={breadcrumbs}>
+        <PageContentWrapper icon={Puzzle} title={name}>
+          <div className="p-6">Resource not found.</div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  const tabs = [
+    {
+      id: "overview",
+      label: "Overview",
+      onClick: () => setTab("overview"),
+      component: <CROverviewTab crd={crd} item={item} version={version} />,
+    },
+    {
+      id: "yaml",
+      label: "YAML",
+      onClick: () => setTab("yaml"),
+      component: <ResourceYamlTab item={item} config={config} />,
+    },
+    {
+      id: "events",
+      label: "Events",
+      onClick: () => setTab("events"),
+      component: <ResourceEventsTab item={item} />,
+    },
+  ];
+
+  return (
+    <PageWrapper breadcrumbs={breadcrumbs}>
+      <PageContentWrapper
+        icon={Puzzle}
+        title={item.metadata?.name ?? ""}
+        description={
+          expectedVariant === "namespaced"
+            ? `${descriptor.label} · ${item.metadata?.namespace ?? ""}`
+            : descriptor.label
+        }
+        actions={
+          <ButtonWithPermission
+            allowed={perms.data.delete.allowed}
+            reason={perms.data.delete.reason ?? ""}
+            ButtonProps={{
+              variant: "outline",
+              size: "sm",
+              onClick: () =>
+                openDelete({
+                  objectName: item.metadata?.name ?? "",
+                  resourceConfig: config,
+                  resource: item,
+                  description: `Delete ${descriptor.label} "${item.metadata?.name ?? ""}"`,
+                }),
+            }}
+          >
+            <Trash size={14} className="mr-1.5" /> Delete
+          </ButtonWithPermission>
+        }
+        tabs={tabs}
+        activeTab={activeTabIdx}
+        onTabChange={onTabChange}
+      />
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/components/CRListFilter/constants.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/components/CRListFilter/constants.ts
@@ -1,0 +1,38 @@
+import { createSearchMatchFunction, type MatchFunctions } from "@/core/providers/Filter";
+import { extractByJsonPath } from "@/modules/k8s/utils/extractByJsonPath";
+import type { CRDObject, KubeObjectBase } from "@my-project/shared";
+import { printerColumnFilterKey, type CRListFilterValues } from "./types";
+
+export const crListFilterControlNames = {
+  SEARCH: "search",
+} as const;
+
+export type PrinterColMeta = NonNullable<CRDObject["spec"]["versions"][number]["additionalPrinterColumns"]>[number];
+
+export const buildCRListDefaultValues = (printerCols: PrinterColMeta[], initialSearch = ""): CRListFilterValues => ({
+  [crListFilterControlNames.SEARCH]: initialSearch,
+  ...Object.fromEntries(printerCols.map((c) => [printerColumnFilterKey(c.name), [] as string[]])),
+});
+
+export const buildCRListMatchFunctions = (
+  printerCols: PrinterColMeta[]
+): MatchFunctions<KubeObjectBase, CRListFilterValues> => {
+  const search = createSearchMatchFunction<KubeObjectBase>();
+  // `CRListFilterValues` carries an index signature (so dynamic `pc:*` keys
+  // type-check inside `form.AppField`), which forces `MatchFunctions` to widen
+  // each value type to `unknown`. Narrow back at runtime when calling each fn —
+  // the FilterProvider only ever passes the value it stored for that field.
+  return {
+    [crListFilterControlNames.SEARCH]: (item: KubeObjectBase, v: unknown) => search(item, v as string),
+    ...Object.fromEntries(
+      printerCols.map((c) => [
+        printerColumnFilterKey(c.name),
+        (item: KubeObjectBase, v: unknown) => {
+          const arr = (v as string[] | undefined) ?? [];
+          if (!arr.length) return true;
+          return arr.includes(String(extractByJsonPath(item, c.jsonPath)));
+        },
+      ])
+    ),
+  };
+};

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/components/CRListFilter/hooks/useCRListFilter.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/components/CRListFilter/hooks/useCRListFilter.ts
@@ -1,0 +1,5 @@
+import { useFilterContext } from "@/core/providers/Filter";
+import type { KubeObjectBase } from "@my-project/shared";
+import type { CRListFilterValues } from "../types";
+
+export const useCRListFilter = () => useFilterContext<KubeObjectBase, CRListFilterValues>();

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/components/CRListFilter/index.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/components/CRListFilter/index.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/core/components/ui/button";
+import { Label } from "@/core/components/ui/label";
+import type { SelectOption } from "@/core/components/form";
+import { sortByName } from "@/core/utils/sortByName";
+import { extractByJsonPath } from "@/modules/k8s/utils/extractByJsonPath";
+import type { KubeObjectBase } from "@my-project/shared";
+import { crListFilterControlNames, type PrinterColMeta } from "./constants";
+import { printerColumnFilterKey } from "./types";
+import { useCRListFilter } from "./hooks/useCRListFilter";
+
+interface Props {
+  items: KubeObjectBase[];
+  printerCols: PrinterColMeta[];
+}
+
+export function CRListFilter({ items, printerCols }: Props) {
+  const { form, reset, isDefaultValue } = useCRListFilter();
+
+  // Build the option set for each multi-select from live items so newly arriving
+  // distinct values become selectable. The set of *columns* is frozen upstream
+  // (see frozenAutoColsRef in view.tsx), so the column layout stays stable while
+  // option lists grow as the watch streams in.
+  const optionsByCol = useMemo(() => {
+    const map = new Map<string, SelectOption[]>();
+    for (const col of printerCols) {
+      const distinct = new Set<string>();
+      for (const item of items) {
+        const v = extractByJsonPath(item, col.jsonPath);
+        if (v != null) distinct.add(String(v));
+      }
+      const opts: SelectOption[] = Array.from(distinct)
+        .sort(sortByName)
+        .map((value) => ({ label: value, value }));
+      map.set(col.name, opts);
+    }
+    return map;
+  }, [items, printerCols]);
+
+  return (
+    <>
+      <div className="col-span-3">
+        <form.AppField name={crListFilterControlNames.SEARCH}>
+          {(field) => <field.FormTextField label="Search" placeholder="Search resources" />}
+        </form.AppField>
+      </div>
+
+      {printerCols.map((col) => (
+        <div className="col-span-2" key={col.name}>
+          <form.AppField name={printerColumnFilterKey(col.name)}>
+            {(field) => (
+              <field.FormCombobox
+                label={col.name}
+                placeholder={`Select ${col.name.toLowerCase()}`}
+                options={optionsByCol.get(col.name) ?? []}
+                multiple
+              />
+            )}
+          </form.AppField>
+        </div>
+      ))}
+
+      {!isDefaultValue && (
+        <div className="col-span-1 flex flex-col gap-2">
+          <Label> </Label>
+          <Button variant="secondary" onClick={reset} size="sm" className="mt-0.5">
+            <X size={16} />
+            Clear
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/components/CRListFilter/types.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/components/CRListFilter/types.ts
@@ -1,0 +1,12 @@
+import type { FilterValueMap } from "@/core/providers/Filter";
+
+export interface CRListFilterValues extends FilterValueMap {
+  search: string;
+}
+
+/**
+ * Filter key for an auto-discovered printer column. Mirrors the original inline
+ * convention from the CR list view (`pc:<name>`) so existing bookmarked URLs
+ * continue to resolve after the refactor.
+ */
+export const printerColumnFilterKey = (name: string) => `pc:${name}` as const;

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/page.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/page.tsx
@@ -1,0 +1,5 @@
+import CRListView from "./view";
+
+export default function CRListPage() {
+  return <CRListView />;
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/route.lazy.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/route.lazy.ts
@@ -1,0 +1,7 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_K8S_CR_LIST } from "./route";
+import CRListPage from "./page";
+
+const K8sCRListRoute = createLazyRoute(ROUTE_ID_K8S_CR_LIST as never)({ component: CRListPage });
+
+export default K8sCRListRoute;

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/route.lazy.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/route.lazy.ts
@@ -2,6 +2,6 @@ import { createLazyRoute } from "@tanstack/react-router";
 import { ROUTE_ID_K8S_CR_LIST } from "./route";
 import CRListPage from "./page";
 
-const K8sCRListRoute = createLazyRoute(ROUTE_ID_K8S_CR_LIST as never)({ component: CRListPage });
+const K8sCRListRoute = createLazyRoute(ROUTE_ID_K8S_CR_LIST)({ component: CRListPage });
 
 export default K8sCRListRoute;

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/route.ts
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/route.ts
@@ -1,0 +1,25 @@
+import { createRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { routeK8sCRParent } from "../cr-parent/route";
+import { PATH_K8S_CR_LIST, PATH_K8S_CR_LIST_FULL } from "@/modules/k8s/constants/paths";
+
+// Derived from the full path constant to avoid drift if the path ever changes.
+export const ROUTE_ID_K8S_CR_LIST = `/_layout${PATH_K8S_CR_LIST_FULL}` as const;
+
+// `.passthrough()` is required so the dynamic `pc:${printerColumn.name}` keys
+// emitted by FilterProvider's syncWithUrl survive route validation. Without it,
+// Zod strips every key the schema doesn't explicitly declare, and the URL never
+// actually round-trips the filter values written by the UI.
+const searchSchema = z
+  .object({
+    namespace: z.string().optional(),
+    search: z.string().optional(),
+  })
+  .passthrough();
+
+export const routeK8sCRList = createRoute({
+  getParentRoute: () => routeK8sCRParent,
+  path: PATH_K8S_CR_LIST,
+  validateSearch: (search: Record<string, unknown>) => searchSchema.parse(search),
+  head: () => ({ meta: [{ title: "Custom Resources | KRCI" }] }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/view.test.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/view.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/modules/k8s/hooks/useCRDByGVR", () => ({
+  useCRDByGVR: vi.fn(),
+}));
+
+vi.mock("@/modules/k8s/hooks/useCRList", () => ({
+  useCRList: vi.fn(),
+}));
+
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: (selector: (s: { defaultNamespace: string }) => unknown) => selector({ defaultNamespace: "dev" }),
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    useParams: () => ({ clusterName: "c1", group: "tekton.dev", version: "v1", plural: "pipelineruns" }),
+    useSearch: () => ({}),
+    useNavigate: () => () => undefined,
+    Link: ({ children, ...rest }: { children: React.ReactNode; [k: string]: unknown }) => (
+      <a {...(rest as Record<string, string>)}>{children}</a>
+    ),
+  };
+});
+
+// Mock ResourceTable to avoid deep tree (DataTable, BatchDeleteAction, etc.)
+// but still render items and column labels so we can assert on them.
+vi.mock("@/modules/k8s/components/ResourceTable", () => ({
+  ResourceTable: ({
+    items,
+    descriptor,
+  }: {
+    items: { metadata?: { name?: string; namespace?: string; [k: string]: unknown }; [k: string]: unknown }[];
+    descriptor: {
+      columns: (renderName: (item: unknown) => React.ReactNode) => {
+        id: string;
+        label: string;
+        data: { render: (args: { data: unknown; meta: unknown }) => React.ReactNode };
+      }[];
+      config: { clusterScoped?: boolean };
+      label: string;
+    };
+  }) => {
+    const cols = descriptor.columns((item) => {
+      const obj = item as { metadata?: { name?: string } };
+      return <span>{obj.metadata?.name ?? ""}</span>;
+    });
+    return (
+      <table>
+        <thead>
+          <tr>
+            {cols.map((col) => (
+              <th key={col.id}>{col.label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((row, idx) => (
+            <tr key={idx}>
+              {cols.map((col) => (
+                <td key={col.id}>{col.data.render({ data: row, meta: { selectionLength: 0 } })}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  },
+}));
+
+import { useCRDByGVR } from "@/modules/k8s/hooks/useCRDByGVR";
+import { useCRList } from "@/modules/k8s/hooks/useCRList";
+import CRListView from "./view";
+
+const defaultCrd = {
+  metadata: { name: "pipelineruns.tekton.dev", uid: "u1", creationTimestamp: "2026-05-15T10:00:00Z" },
+  spec: {
+    group: "tekton.dev",
+    scope: "Namespaced",
+    names: { kind: "PipelineRun", plural: "pipelineruns", singular: "pipelinerun" },
+    versions: [
+      {
+        name: "v1",
+        served: true,
+        storage: true,
+        additionalPrinterColumns: [{ name: "Status", type: "string", jsonPath: ".status.phase" }],
+      },
+    ],
+  },
+};
+
+const baseWatchResult = (items: unknown[]) => ({
+  data: { array: items, map: new Map() },
+  query: { isSuccess: true, isPlaceholderData: false, error: null },
+  resourceVersion: "1",
+  isEmpty: items.length === 0,
+  isLoading: false,
+  isReady: true,
+  error: null,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useCRDByGVR).mockReturnValue({ crd: defaultCrd as never, isLoading: false, error: null });
+  vi.mocked(useCRList).mockReturnValue(
+    baseWatchResult([
+      { metadata: { name: "pr-1", namespace: "dev" }, status: { phase: "Running" } },
+      { metadata: { name: "pr-2", namespace: "dev" }, status: { phase: "Succeeded" } },
+    ]) as never
+  );
+});
+
+describe("CRListView", () => {
+  it("renders dynamic Status column from priority=0 printer columns", () => {
+    render(<CRListView />);
+    expect(screen.getByRole("columnheader", { name: "Status" })).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("shows the namespace column for namespaced CRDs", () => {
+    render(<CRListView />);
+    expect(screen.getByRole("columnheader", { name: /namespace/i })).toBeInTheDocument();
+  });
+
+  it("unknown GVR shows empty state", () => {
+    vi.mocked(useCRDByGVR).mockReturnValueOnce({ crd: undefined, isLoading: false, error: null });
+    render(<CRListView />);
+    // Both the page title and the body paragraph contain "Unknown custom resource",
+    // so use getAllByText and assert at least one element is present.
+    expect(screen.getAllByText(/unknown custom resource/i).length).toBeGreaterThan(0);
+  });
+
+  it("loading CRD shows Loading… state", () => {
+    vi.mocked(useCRDByGVR).mockReturnValueOnce({ crd: undefined, isLoading: true, error: null });
+    render(<CRListView />);
+    expect(screen.getByText(/Loading CRD/i)).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/view.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/view.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useMemo, useRef } from "react";
+import { Puzzle } from "lucide-react";
+import { useParams, useSearch } from "@tanstack/react-router";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { FilterProvider } from "@/core/providers/Filter";
+import { ResourceTable } from "@/modules/k8s/components/ResourceTable";
+import { useCRDByGVR } from "@/modules/k8s/hooks/useCRDByGVR";
+import { useCRList } from "@/modules/k8s/hooks/useCRList";
+import { buildCRDescriptor } from "@/modules/k8s/registry/dynamic/buildCRDescriptor";
+import { resolveCRDVersion, CREATION_TIMESTAMP_PRINTER_COL_PATH } from "@/modules/k8s/registry/dynamic/crdUtils";
+import { extractByJsonPath } from "@/modules/k8s/utils/extractByJsonPath";
+import { useClusterStore } from "@/k8s/store";
+import type { KubeObjectBase } from "@my-project/shared";
+import { CRListFilter } from "./components/CRListFilter";
+import {
+  buildCRListDefaultValues,
+  buildCRListMatchFunctions,
+  type PrinterColMeta,
+} from "./components/CRListFilter/constants";
+import { useCRListFilter } from "./components/CRListFilter/hooks/useCRListFilter";
+
+type Params = { clusterName: string; group: string; version: string; plural: string };
+type Search = { namespace?: string; search?: string };
+
+export default function CRListView() {
+  const { group, version, plural } = useParams({ strict: false }) as Partial<Params>;
+  const search = useSearch({ strict: false }) as Search;
+  const storedNs = useClusterStore((s) => s.defaultNamespace);
+
+  const { crd, isLoading, error } = useCRDByGVR(group ?? "", version ?? "", plural ?? "");
+
+  if (isLoading) {
+    return (
+      <PageWrapper breadcrumbs={[{ label: "Cluster" }, { label: "Custom Resources" }]}>
+        <PageContentWrapper icon={Puzzle} title="Loading…">
+          <div className="text-muted-foreground p-6 text-sm">Loading CRD…</div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  if (error || !crd) {
+    return (
+      <PageWrapper breadcrumbs={[{ label: "Cluster" }, { label: "Custom Resources" }]}>
+        <PageContentWrapper icon={Puzzle} title="Unknown custom resource">
+          <div className="p-6">
+            Unknown custom resource: <code>{`${group}/${version}/${plural}`}</code>.
+          </div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  // Key on the CRD's identity so navigating between two CR list pages (e.g.
+  // pipelineruns → applications) remounts CRListInner — otherwise the
+  // `frozenAutoColsRef` inside would survive the navigation and the new CRD
+  // would inherit the previous CRD's filter columns and match functions.
+  const innerKey = `${crd.spec.group}/${crd.spec.names.plural}`;
+  return <CRListInner key={innerKey} crd={crd} version={version ?? ""} storedNs={storedNs ?? ""} search={search} />;
+}
+
+function CRListInner({
+  crd,
+  version,
+  storedNs,
+  search,
+}: {
+  crd: NonNullable<ReturnType<typeof useCRDByGVR>["crd"]>;
+  version: string;
+  storedNs: string;
+  search: Search;
+}) {
+  const descriptor = useMemo(() => buildCRDescriptor(crd, version), [crd, version]);
+  const namespace = !descriptor.config.clusterScoped ? (search.namespace ?? storedNs ?? "") : "";
+
+  const watch = useCRList(crd, namespace, version);
+
+  // Auto multi-select discovery from the FIRST non-empty watch snapshot.
+  // Cache the result in a ref so later watch ticks (new items arriving via WebSocket)
+  // do not recompute the option set — recomputation would churn FilterProvider and
+  // could surface/hide columns as the distinct-value threshold (≤8) is crossed,
+  // creating a flickering filter UI. MVP trade-off; live-update would require
+  // lifting FilterProvider into a reactive recompute.
+  //
+  // The ref is only frozen once `items.length > 0`. If the first snapshot is empty
+  // (e.g. namespace not yet selected), `frozenAutoColsRef.current` stays null and the
+  // memo re-runs on the next tick once items arrive, avoiding permanently-empty filters.
+  const frozenAutoColsRef = useRef<PrinterColMeta[] | null>(null);
+
+  // Reset the frozen columns whenever the namespace changes so the new namespace's
+  // distinct values are used to build the filter dropdowns. Without this the ref
+  // would hold the previous namespace's frozen result until the component remounts.
+  useEffect(() => {
+    frozenAutoColsRef.current = null;
+  }, [namespace]);
+
+  // `watch.data` is intentionally a dep here: we need the memo to re-run when
+  // `data.array.length` transitions from 0 → nonzero so the filter columns are
+  // derived from actual item values rather than an empty set.
+  const watchDataLength = watch.isReady ? (watch.data.array as KubeObjectBase[]).length : 0;
+  const autoMultiSelectCols = useMemo<PrinterColMeta[]>(() => {
+    if (frozenAutoColsRef.current !== null) return frozenAutoColsRef.current;
+    if (!watch.isReady) return [];
+    const items = watch.data.array as KubeObjectBase[];
+    // Do not freeze yet when the snapshot is empty — wait for the first non-empty tick.
+    if (items.length === 0) return [];
+    const resolvedVersion = resolveCRDVersion(crd, version);
+    const printerCols = resolvedVersion?.additionalPrinterColumns ?? [];
+    const priorityZero = printerCols.filter(
+      (c) => (c.priority ?? 0) === 0 && c.jsonPath !== CREATION_TIMESTAMP_PRINTER_COL_PATH
+    );
+    const result = priorityZero.filter((c) => {
+      if (c.type !== "string") return false;
+      const distinct = new Set(items.map((it) => extractByJsonPath(it, c.jsonPath)).filter((v) => v != null));
+      return distinct.size > 0 && distinct.size <= 8;
+    });
+    frozenAutoColsRef.current = result;
+    return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watch.isReady, watchDataLength, crd, version]);
+
+  // Memoize so WebSocket watch ticks don't churn FilterProvider's internal memo/effect
+  // (otherwise URL-sync fires spuriously on every list update).
+  const defaultValues = useMemo(
+    () => buildCRListDefaultValues(autoMultiSelectCols, search.search ?? ""),
+    [autoMultiSelectCols, search.search]
+  );
+
+  const matchFunctions = useMemo(() => buildCRListMatchFunctions(autoMultiSelectCols), [autoMultiSelectCols]);
+
+  if (!watch.isReady) {
+    return (
+      <PageWrapper breadcrumbs={[{ label: "Cluster" }, { label: "Custom Resources" }, { label: descriptor.label }]}>
+        <PageContentWrapper icon={Puzzle} title={descriptor.label}>
+          <div className="text-muted-foreground p-6 text-sm">Loading…</div>
+        </PageContentWrapper>
+      </PageWrapper>
+    );
+  }
+
+  const items = watch.data.array as KubeObjectBase[];
+
+  return (
+    <FilterProvider defaultValues={defaultValues} matchFunctions={matchFunctions} syncWithUrl>
+      <CRListContent
+        descriptor={descriptor}
+        items={items}
+        printerCols={autoMultiSelectCols}
+        watchError={watch.error}
+        namespace={namespace}
+      />
+    </FilterProvider>
+  );
+}
+
+function CRListContent({
+  descriptor,
+  items,
+  printerCols,
+  watchError,
+  namespace,
+}: {
+  descriptor: ReturnType<typeof buildCRDescriptor>;
+  items: KubeObjectBase[];
+  printerCols: PrinterColMeta[];
+  watchError: unknown;
+  namespace: string;
+}) {
+  const { filterFunction } = useCRListFilter();
+
+  const tableSlots = useMemo(
+    () => ({
+      header: {
+        component: <CRListFilter items={items} printerCols={printerCols} />,
+      },
+    }),
+    [items, printerCols]
+  );
+
+  return (
+    <PageWrapper breadcrumbs={[{ label: "Cluster" }, { label: "Custom Resources" }, { label: descriptor.label }]}>
+      <PageContentWrapper icon={Puzzle} title={descriptor.label}>
+        <ResourceTable
+          items={items}
+          descriptor={descriptor}
+          isLoading={false}
+          error={(watchError as Error) ?? null}
+          namespace={namespace}
+          filterFunction={filterFunction}
+          slots={tableSlots}
+        />
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/detail/page.test.tsx
+++ b/apps/client/src/modules/k8s/pages/detail/page.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Tests for K8sDetailPage:
+ * (1) Delete button is disabled when perms.data.delete.allowed=false (placeholder default during loading)
+ * (2) Delete button is enabled and onClick fires when allowed=true
+ * (3) Delete button is disabled with tooltip when SSARS resolves allowed=false
+ * (4) actionsSlot component renders when descriptor.actionsSlot is set
+ * (5) no actionsSlot content when descriptor has no actionsSlot
+ * (6) ?tab=yaml URL param activates YAML tab index
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import React from "react";
+import { defaultPermissions } from "@my-project/shared";
+
+// ---- Router mock (must be hoisted before imports of the component) ----
+const searchParams: { tab?: string } = {};
+const navigateMock = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({ clusterName: "test-cluster", kind: "pods", namespace: "default", name: "my-pod" }),
+  useSearch: () => searchParams,
+  useNavigate: () => navigateMock,
+  Link: ({ children, to }: { children: React.ReactNode; to?: string }) => <a href={to ?? "#"}>{children}</a>,
+}));
+
+// ---- usePermissions mock — controlled per-test ----
+const permsMock = {
+  data: structuredClone(defaultPermissions),
+};
+vi.mock("@/k8s/api/hooks/usePermissions", () => ({
+  usePermissions: () => permsMock,
+}));
+
+// ---- useK8sResourceItem mock — returns a ready item ----
+const stubItem = {
+  kind: "Pod",
+  apiVersion: "v1",
+  metadata: { name: "my-pod", namespace: "default", uid: "u1", creationTimestamp: "" },
+};
+vi.mock("../../hooks/useK8sResourceItem", () => ({
+  useK8sResourceItem: () => ({
+    data: stubItem,
+    isLoading: false,
+    query: { isError: false, error: null },
+  }),
+}));
+
+// ---- Dialog opener mock ----
+const openDeleteMock = vi.fn();
+vi.mock("@/core/providers/Dialog/hooks", () => ({
+  useDialogOpener: () => openDeleteMock,
+}));
+
+// ---- DeleteKubeObjectDialog stub ----
+vi.mock("@/core/components/DeleteKubeObject", () => ({
+  DeleteKubeObjectDialog: () => null,
+}));
+
+// ---- Sidebar / PageWrapper: render children passthrough ----
+vi.mock("@/core/components/PageWrapper", () => ({
+  PageWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// ---- PageContentWrapper: render title + actions + tabs ----
+vi.mock("@/core/components/PageContentWrapper", () => ({
+  PageContentWrapper: ({
+    title,
+    actions,
+    tabs,
+    activeTab,
+  }: {
+    title?: string;
+    actions?: React.ReactNode;
+    tabs?: Array<{ id: string; label: string; component: React.ReactNode; onClick?: () => void }>;
+    activeTab?: number;
+  }) => (
+    <div>
+      {title && <h1>{title}</h1>}
+      <div data-testid="actions">{actions}</div>
+      {tabs?.map((tab, idx) => (
+        <div key={tab.id} data-testid={`tab-${tab.id}`} data-active={activeTab === idx ? "true" : "false"}>
+          {tab.label}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+// ---- ResourceOverviewTab / ResourceYamlTab / ResourceEventsTab stubs ----
+vi.mock("../../components/ResourceOverviewTab", () => ({
+  ResourceOverviewTab: () => <div data-testid="overview-tab-content">Overview</div>,
+}));
+vi.mock("../../components/ResourceYamlTab", () => ({
+  ResourceYamlTab: () => <div data-testid="yaml-tab-content">YAML</div>,
+}));
+vi.mock("../../components/ResourceEventsTab", () => ({
+  ResourceEventsTab: () => <div data-testid="events-tab-content">Events</div>,
+}));
+
+// ---- ErrorContent stub ----
+vi.mock("@/core/components/ErrorContent", () => ({
+  ErrorContent: ({ error }: { error: unknown }) => <div>Error: {String(error)}</div>,
+}));
+
+// ---- Import the component under test (after mocks are set up) ----
+import { K8sDetailPage } from "./page";
+
+// ---- Helpers ----
+function renderPage() {
+  return render(<K8sDetailPage expectedVariant="namespaced" />);
+}
+
+describe("K8sDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset to default (all denied — SSARS loading placeholder)
+    permsMock.data = structuredClone(defaultPermissions);
+    // Reset search params
+    delete searchParams.tab;
+  });
+
+  // (1) Delete button is disabled when perms.data.delete.allowed=false
+  it("renders Delete button as disabled when delete permission is denied (placeholder default)", () => {
+    // defaultPermissions has delete.allowed = false
+    renderPage();
+    const deleteBtn = screen.getByRole("button", { name: /delete/i });
+    expect(deleteBtn).toBeDisabled();
+  });
+
+  // (3) Delete button is disabled with tooltip wrapper when SSARS resolves denied
+  it("wraps disabled Delete button in a Tooltip when delete is denied", () => {
+    // defaultPermissions has delete.allowed = false, reason = ""
+    permsMock.data = {
+      ...defaultPermissions,
+      delete: { allowed: false, reason: "Forbidden: missing RBAC" },
+    };
+    renderPage();
+    const deleteBtn = screen.getByRole("button", { name: /delete/i });
+    expect(deleteBtn).toBeDisabled();
+    // ButtonWithPermission renders a Tooltip wrapper when !allowed
+    // Check the tooltip container is present
+    expect(deleteBtn.closest("[title], [aria-label]") ?? deleteBtn).toBeTruthy();
+  });
+
+  // (2) Delete button is enabled and onClick fires when allowed=true
+  it("renders Delete button as enabled and calls openDelete on click when permission is granted", async () => {
+    permsMock.data = {
+      create: { allowed: true, reason: "" },
+      update: { allowed: true, reason: "" },
+      patch: { allowed: true, reason: "" },
+      delete: { allowed: true, reason: "" },
+    };
+
+    renderPage();
+    const deleteBtn = screen.getByRole("button", { name: /delete/i });
+    expect(deleteBtn).not.toBeDisabled();
+
+    await userEvent.click(deleteBtn);
+    expect(openDeleteMock).toHaveBeenCalledTimes(1);
+    expect(openDeleteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectName: "my-pod",
+      })
+    );
+  });
+
+  // (5) No actionsSlot content when descriptor has no actionsSlot
+  it("renders no actionsSlot content when the descriptor has no actionsSlot", () => {
+    renderPage();
+    // Should NOT find a custom-action element
+    expect(screen.queryByTestId("actions-slot")).not.toBeInTheDocument();
+  });
+
+  // (4) actionsSlot component renders when descriptor.actionsSlot is set
+  it("renders actionsSlot when the registry descriptor defines one", () => {
+    // Override the registry mock to inject an actionsSlot
+    const ActionsSlotMock = () => <div data-testid="actions-slot">Custom Action</div>;
+
+    // We need to override the registry descriptor for "pods"
+    vi.doMock("../../registry/resolve", () => ({
+      resolveDescriptor: () => ({
+        config: {
+          apiVersion: "v1",
+          kind: "Pod",
+          group: "",
+          version: "v1",
+          singularName: "pod",
+          pluralName: "pods",
+        },
+        label: "Pods",
+        detailVariant: "namespaced",
+        sidebarGroup: "Workloads",
+        columns: () => [],
+        actionsSlot: ActionsSlotMock,
+      }),
+    }));
+
+    // Since vi.doMock is not hoisted, we test with the real registry below
+    // The actionsSlot renders as <descriptor.actionsSlot item={item} />
+    // For this test, we check the conditional rendering logic is correct:
+    // render the page and verify no actionsSlot div since pods has none by default
+    renderPage();
+    expect(screen.queryByTestId("actions-slot")).not.toBeInTheDocument();
+  });
+
+  // (6) ?tab=yaml URL param activates YAML tab index
+  it("sets the active tab to index 1 (yaml) when search.tab=yaml", () => {
+    searchParams.tab = "yaml";
+    renderPage();
+    // Our PageContentWrapper mock renders tabs with data-active attribute
+    const yamlTab = screen.getByTestId("tab-yaml");
+    expect(yamlTab).toHaveAttribute("data-active", "true");
+
+    const overviewTab = screen.getByTestId("tab-overview");
+    expect(overviewTab).toHaveAttribute("data-active", "false");
+  });
+
+  // Baseline: overview tab is active by default (no ?tab param)
+  it("defaults to overview tab (index 0) when no search.tab param is set", () => {
+    delete searchParams.tab;
+    renderPage();
+    const overviewTab = screen.getByTestId("tab-overview");
+    expect(overviewTab).toHaveAttribute("data-active", "true");
+
+    const yamlTab = screen.getByTestId("tab-yaml");
+    expect(yamlTab).toHaveAttribute("data-active", "false");
+  });
+});

--- a/apps/client/src/modules/k8s/pages/detail/page.test.tsx
+++ b/apps/client/src/modules/k8s/pages/detail/page.test.tsx
@@ -17,12 +17,34 @@ import { defaultPermissions } from "@my-project/shared";
 const searchParams: { tab?: string } = {};
 const navigateMock = vi.fn();
 
-vi.mock("@tanstack/react-router", () => ({
-  useParams: () => ({ clusterName: "test-cluster", kind: "pods", namespace: "default", name: "my-pod" }),
-  useSearch: () => searchParams,
-  useNavigate: () => navigateMock,
-  Link: ({ children, to }: { children: React.ReactNode; to?: string }) => <a href={to ?? "#"}>{children}</a>,
-}));
+vi.mock("@tanstack/react-router", () => {
+  const routeStub: Record<string, unknown> = {};
+  routeStub.lazy = () => routeStub;
+  routeStub.addChildren = () => routeStub;
+  routeStub.update = () => routeStub;
+  const createRootRouteWithContext = () => () => routeStub;
+  return {
+    useParams: () => ({ clusterName: "test-cluster", kind: "pods", namespace: "default", name: "my-pod" }),
+    useSearch: () => searchParams,
+    useNavigate: () => navigateMock,
+    Link: ({ children, to }: { children: React.ReactNode; to?: string }) => <a href={to ?? "#"}>{children}</a>,
+    createRoute: () => routeStub,
+    createRootRoute: () => routeStub,
+    createRootRouteWithContext,
+    createRouter: () => ({}),
+    createLazyRoute: () => routeStub,
+    Outlet: () => null,
+    RouterProvider: () => null,
+    redirect: () => {
+      throw new Error("redirect");
+    },
+    useRouterState: () => ({}),
+    useLocation: () => ({ pathname: "/" }),
+    useMatches: () => [],
+    HeadContent: () => null,
+    Scripts: () => null,
+  };
+});
 
 // ---- usePermissions mock — controlled per-test ----
 const permsMock = {

--- a/apps/client/src/modules/k8s/pages/detail/page.test.tsx
+++ b/apps/client/src/modules/k8s/pages/detail/page.test.tsx
@@ -125,6 +125,20 @@ vi.mock("@/core/components/ErrorContent", () => ({
   ErrorContent: ({ error }: { error: unknown }) => <div>Error: {String(error)}</div>,
 }));
 
+// ---- registry resolve: delegate to the REAL descriptor, but let a test graft an
+//      actionsSlot onto it (a hoisted vi.mock can't be re-configured per-test otherwise).
+let actionsSlotOverride: React.FC<{ item: unknown }> | undefined;
+vi.mock("../../registry/resolve", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../registry/resolve")>();
+  return {
+    ...actual,
+    resolveDescriptor: (...args: Parameters<typeof actual.resolveDescriptor>) => {
+      const descriptor = actual.resolveDescriptor(...args);
+      return descriptor && actionsSlotOverride ? { ...descriptor, actionsSlot: actionsSlotOverride } : descriptor;
+    },
+  };
+});
+
 // ---- Import the component under test (after mocks are set up) ----
 import { K8sDetailPage } from "./page";
 
@@ -140,6 +154,8 @@ describe("K8sDetailPage", () => {
     permsMock.data = structuredClone(defaultPermissions);
     // Reset search params
     delete searchParams.tab;
+    // Reset the per-test actionsSlot injection
+    actionsSlotOverride = undefined;
   });
 
   // (1) Delete button is disabled when perms.data.delete.allowed=false
@@ -160,9 +176,9 @@ describe("K8sDetailPage", () => {
     renderPage();
     const deleteBtn = screen.getByRole("button", { name: /delete/i });
     expect(deleteBtn).toBeDisabled();
-    // ButtonWithPermission renders a Tooltip wrapper when !allowed
-    // Check the tooltip container is present
-    expect(deleteBtn.closest("[title], [aria-label]") ?? deleteBtn).toBeTruthy();
+    // When denied, ButtonWithPermission wraps the button in a Tooltip trigger
+    // (carrying the reason). When allowed there is no such wrapper.
+    expect(deleteBtn.closest('[data-slot="tooltip-trigger"]')).toBeInTheDocument();
   });
 
   // (2) Delete button is enabled and onClick fires when allowed=true
@@ -196,34 +212,13 @@ describe("K8sDetailPage", () => {
 
   // (4) actionsSlot component renders when descriptor.actionsSlot is set
   it("renders actionsSlot when the registry descriptor defines one", () => {
-    // Override the registry mock to inject an actionsSlot
-    const ActionsSlotMock = () => <div data-testid="actions-slot">Custom Action</div>;
+    // Graft an actionsSlot onto the resolved descriptor for this test.
+    actionsSlotOverride = () => <div data-testid="actions-slot">Custom Action</div>;
 
-    // We need to override the registry descriptor for "pods"
-    vi.doMock("../../registry/resolve", () => ({
-      resolveDescriptor: () => ({
-        config: {
-          apiVersion: "v1",
-          kind: "Pod",
-          group: "",
-          version: "v1",
-          singularName: "pod",
-          pluralName: "pods",
-        },
-        label: "Pods",
-        detailVariant: "namespaced",
-        sidebarGroup: "Workloads",
-        columns: () => [],
-        actionsSlot: ActionsSlotMock,
-      }),
-    }));
-
-    // Since vi.doMock is not hoisted, we test with the real registry below
-    // The actionsSlot renders as <descriptor.actionsSlot item={item} />
-    // For this test, we check the conditional rendering logic is correct:
-    // render the page and verify no actionsSlot div since pods has none by default
     renderPage();
-    expect(screen.queryByTestId("actions-slot")).not.toBeInTheDocument();
+
+    // The page renders `descriptor.actionsSlot && <descriptor.actionsSlot item={item} />`.
+    expect(screen.getByTestId("actions-slot")).toBeInTheDocument();
   });
 
   // (6) ?tab=yaml URL param activates YAML tab index

--- a/apps/client/src/modules/k8s/pages/detail/page.tsx
+++ b/apps/client/src/modules/k8s/pages/detail/page.tsx
@@ -1,23 +1,22 @@
 import { Layers, Trash } from "lucide-react";
-import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { PATH_K8S_LIST_FULL } from "../../pages/list/route";
-import { Button } from "@/core/components/ui/button";
+import { useParams } from "@tanstack/react-router";
+import { PATH_K8S_LIST_FULL } from "@/modules/k8s/constants/paths";
+import { ButtonWithPermission } from "@/core/components/ButtonWithPermission";
 import { PageContentWrapper } from "@/core/components/PageContentWrapper";
 import { PageWrapper } from "@/core/components/PageWrapper";
 import { useDialogOpener } from "@/core/providers/Dialog/hooks";
 import { DeleteKubeObjectDialog } from "@/core/components/DeleteKubeObject";
+import { usePermissions } from "@/k8s/api/hooks/usePermissions";
 import { resolveDescriptor } from "../../registry/resolve";
 import { resourceRegistry } from "../../registry";
 import { useK8sResourceItem } from "../../hooks/useK8sResourceItem";
+import { useDetailTabs, DEFAULT_DETAIL_TABS } from "../../hooks/useDetailTabs";
 import { ResourceOverviewTab } from "../../components/ResourceOverviewTab";
 import { ResourceYamlTab } from "../../components/ResourceYamlTab";
 import { ResourceEventsTab } from "../../components/ResourceEventsTab";
 import { ErrorContent } from "@/core/components/ErrorContent";
 import type { DetailVariant } from "../../registry/types";
 import type { K8sResourceConfig, KubeObjectBase } from "@my-project/shared";
-
-const DETAIL_TABS = ["overview", "yaml", "events"] as const;
-type DetailTab = (typeof DETAIL_TABS)[number];
 
 const fallbackConfig: K8sResourceConfig = {
   apiVersion: "v1",
@@ -29,15 +28,14 @@ const fallbackConfig: K8sResourceConfig = {
 };
 
 export function K8sDetailPage({ expectedVariant }: { expectedVariant: DetailVariant }) {
-  const navigate = useNavigate();
   const params = useParams({ strict: false }) as {
     clusterName?: string;
     kind?: string;
     namespace?: string;
     name?: string;
   };
-  const search = useSearch({ strict: false }) as { tab?: string };
   const openDelete = useDialogOpener(DeleteKubeObjectDialog);
+  const { activeTabIdx, setTab, onTabChange } = useDetailTabs(DEFAULT_DETAIL_TABS);
 
   const { clusterName, kind, name } = params;
   const namespace = expectedVariant === "namespaced" ? (params.namespace ?? "") : "";
@@ -46,6 +44,16 @@ export function K8sDetailPage({ expectedVariant }: { expectedVariant: DetailVari
   const config = descriptor?.config ?? fallbackConfig;
   const result = useK8sResourceItem<KubeObjectBase>(config, namespace, name ?? "");
   const item = result.data;
+
+  // Permission check uses the resolved resource's GVR. For unknown kinds the
+  // hook is disabled to avoid a spurious SelfSubjectAccessReview against the
+  // "Unknown" fallback config; defaultPermissions keep Delete safely disabled.
+  const perms = usePermissions({
+    group: config.group,
+    version: config.version,
+    resourcePlural: config.pluralName,
+    enabled: !!descriptor,
+  });
 
   if (!descriptor) {
     return (
@@ -110,12 +118,7 @@ export function K8sDetailPage({ expectedVariant }: { expectedVariant: DetailVari
     );
   }
 
-  const activeTab: DetailTab = (DETAIL_TABS as readonly string[]).includes(search.tab ?? "")
-    ? (search.tab as DetailTab)
-    : "overview";
-  const activeTabIdx = DETAIL_TABS.indexOf(activeTab);
   const Overview = descriptor.overviewTab ?? ResourceOverviewTab;
-  const setTab = (t: DetailTab) => void navigate({ search: { ...search, tab: t } as never });
 
   const handleDelete = () => {
     openDelete({
@@ -151,25 +154,26 @@ export function K8sDetailPage({ expectedVariant }: { expectedVariant: DetailVari
   ];
 
   return (
-    <PageWrapper
-      breadcrumbs={[
-        { label: "Cluster" },
-        { label: descriptor.label, route: listRoute },
-        { label: item.metadata?.name ?? "" },
-      ]}
-    >
+    <PageWrapper breadcrumbs={breadcrumbs}>
       <PageContentWrapper
         icon={Layers}
         title={item.metadata?.name ?? ""}
         description={description}
         actions={
-          <Button variant="outline" size="sm" onClick={handleDelete}>
-            <Trash size={14} className="mr-1.5" /> Delete
-          </Button>
+          <>
+            {descriptor.actionsSlot && <descriptor.actionsSlot item={item} />}
+            <ButtonWithPermission
+              allowed={perms.data.delete.allowed}
+              reason={perms.data.delete.reason ?? ""}
+              ButtonProps={{ variant: "outline", size: "sm", onClick: handleDelete }}
+            >
+              <Trash size={14} className="mr-1.5" /> Delete
+            </ButtonWithPermission>
+          </>
         }
         tabs={tabs}
         activeTab={activeTabIdx}
-        onTabChange={(_, idx) => setTab(DETAIL_TABS[idx])}
+        onTabChange={onTabChange}
       />
     </PageWrapper>
   );

--- a/apps/client/src/modules/k8s/registry/descriptors/crds.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/crds.columns.tsx
@@ -1,0 +1,75 @@
+import { Badge } from "@/core/components/ui/badge";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import type { CRDObject, KubeObjectBase } from "@my-project/shared";
+import { ageColumn } from "./columnHelpers";
+import type { RenderName } from "./columnHelpers";
+import type { TableColumn } from "@/core/components/Table/types";
+
+export const crdsMvpColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => {
+  const name: TableColumn<KubeObjectBase> = {
+    id: "name",
+    label: "Name (Kind)",
+    data: {
+      render: ({ data }) => {
+        // Intentional UX trade-off: CRDs show spec.names.kind as the primary cell text
+        // (more meaningful than the dotted metadata.name like "argoprojects.argoproj.io")
+        // and route navigation happens via row click, not a name link. The shared
+        // renderName helper hardcodes metadata.name as the link text and offers no
+        // display-text override, so we render the kind here. The full CRD metadata
+        // name remains accessible via the line-clamp tooltip (and via the title
+        // attribute on the outer wrapper for assistive tech).
+        void renderName;
+        const kind = (data as CRDObject).spec.names.kind;
+        return (
+          <div className="w-full min-w-0" title={data.metadata?.name}>
+            <TextWithTooltip text={kind} />
+          </div>
+        );
+      },
+      columnSortableValuePath: "metadata.name",
+    },
+    cell: { baseWidth: 16 },
+  };
+
+  const group: TableColumn<KubeObjectBase> = {
+    id: "group",
+    label: "Group",
+    data: {
+      render: ({ data }) => (
+        <div className="w-full min-w-0">
+          <TextWithTooltip text={(data as CRDObject).spec.group} />
+        </div>
+      ),
+      columnSortableValuePath: "spec.group",
+    },
+    cell: { baseWidth: 14 },
+  };
+
+  const scope: TableColumn<KubeObjectBase> = {
+    id: "scope",
+    label: "Scope",
+    data: {
+      render: ({ data }) => {
+        const s = (data as CRDObject).spec.scope;
+        return <Badge variant={s === "Cluster" ? "secondary" : "outline"}>{s}</Badge>;
+      },
+    },
+    cell: { baseWidth: 8 },
+  };
+
+  const established: TableColumn<KubeObjectBase> = {
+    id: "established",
+    label: "Established",
+    data: {
+      render: ({ data }) => {
+        const c = (data as CRDObject).status?.conditions?.find((cc) => cc.type === "Established");
+        if (c?.status === "True") return <Badge variant="success">True</Badge>;
+        if (c?.status === "False") return <Badge variant="destructive">False</Badge>;
+        return <Badge variant="secondary">Unknown</Badge>;
+      },
+    },
+    cell: { baseWidth: 9 },
+  };
+
+  return [name, group, scope, established, ageColumn];
+};

--- a/apps/client/src/modules/k8s/registry/descriptors/crds.test.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/crds.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { crdsDescriptor } from "./crds";
+
+const crd = (conditions?: Array<{ type: string; status: string }>) =>
+  ({
+    metadata: { name: "x.example.com" },
+    status: { conditions },
+  }) as never;
+
+describe("crdsDescriptor.status", () => {
+  it("derives Established when condition is True", () => {
+    expect(crdsDescriptor.status!(crd([{ type: "Established", status: "True" }]))).toMatchObject({
+      phase: "Established",
+      severity: "success",
+    });
+  });
+  it("derives NotEstablished when condition is False", () => {
+    expect(crdsDescriptor.status!(crd([{ type: "Established", status: "False" }]))).toMatchObject({
+      phase: "NotEstablished",
+      severity: "destructive",
+    });
+  });
+  it("derives Unknown when condition is missing or Unknown", () => {
+    expect(crdsDescriptor.status!(crd())).toMatchObject({ phase: "Unknown", severity: "secondary" });
+    expect(crdsDescriptor.status!(crd([{ type: "Established", status: "Unknown" }]))).toMatchObject({
+      phase: "Unknown",
+      severity: "secondary",
+    });
+  });
+  it("derives NamesConflict (destructive) when NamesAccepted is False, even if Established is True", () => {
+    expect(
+      crdsDescriptor.status!(
+        crd([
+          { type: "Established", status: "True" },
+          { type: "NamesAccepted", status: "False" },
+        ])
+      )
+    ).toMatchObject({ phase: "NamesConflict", severity: "destructive" });
+  });
+});
+
+describe("crdsDescriptor.config", () => {
+  it("is cluster-scoped apiextensions.k8s.io/v1 customresourcedefinitions", () => {
+    expect(crdsDescriptor.config).toMatchObject({
+      apiVersion: "apiextensions.k8s.io/v1",
+      kind: "CustomResourceDefinition",
+      group: "apiextensions.k8s.io",
+      version: "v1",
+      pluralName: "customresourcedefinitions",
+      clusterScoped: true,
+    });
+  });
+});

--- a/apps/client/src/modules/k8s/registry/descriptors/crds.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/crds.ts
@@ -1,0 +1,29 @@
+import { Puzzle } from "lucide-react";
+import { k8sCustomResourceDefinitionConfig, type CRDObject } from "@my-project/shared";
+import { PATH_K8S_CRDS_FULL } from "../../constants/paths";
+import { crdsMvpColumns } from "./crds.columns";
+import type { ResourceDescriptor } from "../types";
+
+export const crdsDescriptor: ResourceDescriptor = {
+  config: k8sCustomResourceDefinitionConfig,
+  label: "CRDs",
+  sidebarGroup: "CustomResources",
+  // The "Custom Resources" group itself navigates to the CRDs list (see nav.ts),
+  // so the standalone "CRDs" leaf would just duplicate the parent header.
+  sidebarHidden: true,
+  sidebarIcon: Puzzle,
+  detailVariant: "cluster",
+  defaultSort: { sortBy: "name", order: "asc" },
+  columns: crdsMvpColumns,
+  status: (item) => {
+    const conditions = (item as CRDObject).status?.conditions ?? [];
+    const established = conditions.find((c) => c.type === "Established");
+    const namesAccepted = conditions.find((c) => c.type === "NamesAccepted");
+    // NamesAccepted=False blocks the CRD even if Established is True — surface it as destructive.
+    if (namesAccepted?.status === "False") return { phase: "NamesConflict", severity: "destructive" };
+    if (established?.status === "True") return { phase: "Established", severity: "success" };
+    if (established?.status === "False") return { phase: "NotEstablished", severity: "destructive" };
+    return { phase: "Unknown", severity: "secondary" };
+  },
+  listRoute: PATH_K8S_CRDS_FULL,
+};

--- a/apps/client/src/modules/k8s/registry/descriptors/daemonsets.actions.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/daemonsets.actions.tsx
@@ -1,0 +1,7 @@
+import type { KubeObjectBase } from "@my-project/shared";
+import { k8sDaemonSetConfig } from "@my-project/shared";
+import { RestartAction } from "@/modules/k8s/components/RestartAction";
+
+export function DaemonSetHeaderActions({ item }: { item: KubeObjectBase }) {
+  return <RestartAction item={item} config={k8sDaemonSetConfig} />;
+}

--- a/apps/client/src/modules/k8s/registry/descriptors/daemonsets.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/daemonsets.ts
@@ -1,6 +1,7 @@
 import { Workflow } from "lucide-react";
 import { k8sDaemonSetConfig } from "@my-project/shared";
 import { daemonSetColumns } from "./daemonsets.columns";
+import { DaemonSetHeaderActions } from "./daemonsets.actions";
 import type { ResourceDescriptor } from "../types";
 
 export const daemonSetsDescriptor: ResourceDescriptor = {
@@ -19,4 +20,5 @@ export const daemonSetsDescriptor: ResourceDescriptor = {
       ? { phase: "Available", severity: "success" }
       : { phase: "Progressing", severity: "warning" };
   },
+  actionsSlot: DaemonSetHeaderActions,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/deployments.actions.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/deployments.actions.tsx
@@ -1,0 +1,15 @@
+import type { KubeObjectBase } from "@my-project/shared";
+import { k8sDeploymentConfig } from "@my-project/shared";
+import { ScaleAction } from "@/modules/k8s/components/ScaleAction";
+import { RestartAction } from "@/modules/k8s/components/RestartAction";
+import { RollbackAction } from "@/modules/k8s/components/RollbackAction";
+
+export function DeploymentHeaderActions({ item }: { item: KubeObjectBase }) {
+  return (
+    <>
+      <ScaleAction item={item} config={k8sDeploymentConfig} />
+      <RestartAction item={item} config={k8sDeploymentConfig} />
+      <RollbackAction item={item} config={k8sDeploymentConfig} />
+    </>
+  );
+}

--- a/apps/client/src/modules/k8s/registry/descriptors/deployments.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/deployments.ts
@@ -1,6 +1,7 @@
 import { Rocket } from "lucide-react";
 import { k8sDeploymentConfig } from "@my-project/shared";
 import { deploymentColumns } from "./deployments.columns";
+import { DeploymentHeaderActions } from "./deployments.actions";
 import type { ResourceDescriptor } from "../types";
 
 export const deploymentsDescriptor: ResourceDescriptor = {
@@ -21,4 +22,5 @@ export const deploymentsDescriptor: ResourceDescriptor = {
       ? { phase: "Available", severity: "success" }
       : { phase: "Progressing", severity: "warning" };
   },
+  actionsSlot: DeploymentHeaderActions,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/statefulsets.actions.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/statefulsets.actions.tsx
@@ -1,0 +1,13 @@
+import type { KubeObjectBase } from "@my-project/shared";
+import { k8sStatefulSetConfig } from "@my-project/shared";
+import { ScaleAction } from "@/modules/k8s/components/ScaleAction";
+import { RestartAction } from "@/modules/k8s/components/RestartAction";
+
+export function StatefulSetHeaderActions({ item }: { item: KubeObjectBase }) {
+  return (
+    <>
+      <ScaleAction item={item} config={k8sStatefulSetConfig} />
+      <RestartAction item={item} config={k8sStatefulSetConfig} />
+    </>
+  );
+}

--- a/apps/client/src/modules/k8s/registry/descriptors/statefulsets.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/statefulsets.ts
@@ -1,6 +1,7 @@
 import { Layers2 } from "lucide-react";
 import { k8sStatefulSetConfig } from "@my-project/shared";
 import { statefulSetColumns } from "./statefulsets.columns";
+import { StatefulSetHeaderActions } from "./statefulsets.actions";
 import type { ResourceDescriptor } from "../types";
 
 export const statefulSetsDescriptor: ResourceDescriptor = {
@@ -12,7 +13,7 @@ export const statefulSetsDescriptor: ResourceDescriptor = {
   defaultSort: { sortBy: "name", order: "asc" },
   columns: statefulSetColumns,
   status: (item) => {
-    const status = (item as { status?: { readyReplicas?: number; updatedReplicas?: number } }).status;
+    const status = (item as { status?: { readyReplicas?: number } }).status;
     const spec = (item as { spec?: { replicas?: number } }).spec;
     const ready = status?.readyReplicas ?? 0;
     const desired = spec?.replicas ?? 0;
@@ -21,4 +22,5 @@ export const statefulSetsDescriptor: ResourceDescriptor = {
       ? { phase: "Available", severity: "success" }
       : { phase: "Progressing", severity: "warning" };
   },
+  actionsSlot: StatefulSetHeaderActions,
 };

--- a/apps/client/src/modules/k8s/registry/dynamic/buildCRDescriptor.test.ts
+++ b/apps/client/src/modules/k8s/registry/dynamic/buildCRDescriptor.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { buildCRDescriptor } from "./buildCRDescriptor";
+
+const baseCrd = (overrides: Record<string, unknown> = {}) =>
+  ({
+    metadata: { name: "pipelineruns.tekton.dev" },
+    spec: {
+      group: "tekton.dev",
+      scope: "Namespaced",
+      names: { kind: "PipelineRun", plural: "pipelineruns", singular: "pipelinerun" },
+      versions: [
+        {
+          name: "v1beta1",
+          served: true,
+          storage: false,
+          additionalPrinterColumns: [{ name: "Status", type: "string", jsonPath: ".status.phase" }],
+        },
+        {
+          name: "v1",
+          served: true,
+          storage: true,
+          additionalPrinterColumns: [
+            { name: "Status", type: "string", jsonPath: ".status.phase" },
+            { name: "Created", type: "date", jsonPath: ".metadata.creationTimestamp" },
+          ],
+        },
+      ],
+      ...overrides,
+    },
+  }) as never;
+
+describe("buildCRDescriptor — version resolution", () => {
+  it("uses preferredVersion when provided and present", () => {
+    const d = buildCRDescriptor(baseCrd(), "v1beta1");
+    expect(d.config.apiVersion).toBe("tekton.dev/v1beta1");
+    expect(d.config.version).toBe("v1beta1");
+  });
+  it("falls back to storage version when preferredVersion is missing", () => {
+    const d = buildCRDescriptor(baseCrd(), "v1alpha1");
+    expect(d.config.version).toBe("v1");
+  });
+  it("uses storage version when preferredVersion is omitted", () => {
+    const d = buildCRDescriptor(baseCrd());
+    expect(d.config.version).toBe("v1");
+  });
+  it("falls back to versions[0] when no version has storage:true", () => {
+    const d = buildCRDescriptor(baseCrd({ versions: [{ name: "v1beta1", served: true, storage: false }] }));
+    expect(d.config.version).toBe("v1beta1");
+  });
+  it("ignores a preferredVersion that has served:false (falls back to storage version)", () => {
+    const d = buildCRDescriptor(
+      baseCrd({
+        versions: [
+          { name: "v1beta1", served: false, storage: false },
+          { name: "v1", served: true, storage: true },
+        ],
+      }),
+      "v1beta1"
+    );
+    expect(d.config.version).toBe("v1");
+  });
+});
+
+describe("buildCRDescriptor — config", () => {
+  it("sets apiVersion=group/version for non-core groups", () => {
+    expect(buildCRDescriptor(baseCrd(), "v1").config.apiVersion).toBe("tekton.dev/v1");
+  });
+  it("sets apiVersion=version for core-group (empty group)", () => {
+    expect(buildCRDescriptor(baseCrd({ group: "" })).config.apiVersion).toBe("v1");
+  });
+  it("propagates clusterScoped from spec.scope", () => {
+    expect(buildCRDescriptor(baseCrd({ scope: "Cluster" })).config.clusterScoped).toBe(true);
+    expect(buildCRDescriptor(baseCrd()).config.clusterScoped).toBe(false);
+  });
+  it("sets defaultSort to name asc, consistent with the static CRD descriptor", () => {
+    expect(buildCRDescriptor(baseCrd()).defaultSort).toEqual({ sortBy: "name", order: "asc" });
+  });
+});
+
+describe("buildCRDescriptor — columns", () => {
+  it("filters .metadata.creationTimestamp JSONPath", () => {
+    const d = buildCRDescriptor(baseCrd(), "v1");
+    const cols = d.columns(((item: { metadata: { name: string } }) => item.metadata.name) as never);
+    expect(cols.find((c) => c.id === "Created")).toBeUndefined();
+  });
+  it("only includes priority=0 columns (MVP)", () => {
+    const d = buildCRDescriptor(
+      baseCrd({
+        versions: [
+          {
+            name: "v1",
+            served: true,
+            storage: true,
+            additionalPrinterColumns: [
+              { name: "A", type: "string", jsonPath: ".a" },
+              { name: "B", type: "string", jsonPath: ".b", priority: 1 },
+            ],
+          },
+        ],
+      })
+    );
+    const cols = d.columns(((item: { metadata: { name: string } }) => item.metadata.name) as never);
+    // Column id is `${name}-${idx}` so duplicate printer-column names don't collide.
+    expect(cols.some((c) => c.label === "A")).toBe(true);
+    expect(cols.some((c) => c.label === "B")).toBe(false);
+  });
+  it("appends a YAML quick-action column when no priority=0 printer columns remain", () => {
+    const d = buildCRDescriptor(
+      baseCrd({
+        versions: [{ name: "v1", served: true, storage: true, additionalPrinterColumns: [] }],
+      })
+    );
+    const cols = d.columns(((item: { metadata: { name: string } }) => item.metadata.name) as never);
+    expect(cols[cols.length - 1].id).toBe("yaml-action");
+  });
+});

--- a/apps/client/src/modules/k8s/registry/dynamic/buildCRDescriptor.tsx
+++ b/apps/client/src/modules/k8s/registry/dynamic/buildCRDescriptor.tsx
@@ -1,0 +1,115 @@
+import { Eye, Puzzle } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/core/components/ui/button";
+import type { CRDObject, KubeObjectBase } from "@my-project/shared";
+import type { ResourceDescriptor } from "../types";
+import type { RenderName } from "../descriptors/columnHelpers";
+import type { TableColumn } from "@/core/components/Table/types";
+import { PrinterColumnValue } from "@/modules/k8s/components/PrinterColumnValue";
+import { makeNameColumn, namespaceColumn, ageColumn } from "../descriptors/columnHelpers";
+import { resolveCRDVersion, CREATION_TIMESTAMP_PRINTER_COL_PATH } from "./crdUtils";
+import { PATH_K8S_CR_DETAIL_NS_FULL, PATH_K8S_CR_DETAIL_CLUSTER_FULL } from "@/modules/k8s/constants/paths";
+
+export function buildCRDescriptor(crd: CRDObject, preferredVersion?: string): ResourceDescriptor {
+  const group = crd.spec.group;
+  const plural = crd.spec.names.plural;
+  const resolved = resolveCRDVersion(crd, preferredVersion);
+
+  if (!resolved) {
+    // A CRD with zero versions is invalid per the K8s API contract, but guard
+    // defensively so a malformed cluster object does not throw here.
+    throw new Error(`CRD "${crd.metadata?.name ?? crd.spec.names.kind}" has no versions defined`);
+  }
+
+  const version = resolved.name;
+  const clusterScoped = crd.spec.scope === "Cluster";
+
+  return {
+    config: {
+      apiVersion: group ? `${group}/${version}` : version,
+      kind: crd.spec.names.kind,
+      group,
+      version,
+      singularName: crd.spec.names.singular ?? crd.spec.names.kind.toLowerCase(),
+      pluralName: plural,
+      clusterScoped,
+    },
+    label: crd.spec.names.kind,
+    sidebarGroup: "CustomResources",
+    sidebarIcon: Puzzle,
+    detailVariant: clusterScoped ? "cluster" : "namespaced",
+    customResource: true,
+    defaultSort: { sortBy: "name", order: "asc" },
+    columns: makeCRColumns(crd, resolved, version),
+  };
+}
+
+function makeCRColumns(crd: CRDObject, resolvedVersion: CRDObject["spec"]["versions"][number], version: string) {
+  return (renderName: RenderName): TableColumn<KubeObjectBase>[] => {
+    const base: TableColumn<KubeObjectBase>[] = [makeNameColumn(renderName)];
+    if (crd.spec.scope === "Namespaced") base.push(namespaceColumn);
+
+    const printerCols = (resolvedVersion.additionalPrinterColumns ?? []).filter(
+      (c) => c.jsonPath !== CREATION_TIMESTAMP_PRINTER_COL_PATH
+    );
+    const visible = printerCols.filter((c) => (c.priority ?? 0) === 0);
+
+    visible.forEach((col, idx) => {
+      base.push({
+        // A malformed CRD can declare two printer columns with the same `name`;
+        // suffix the index so the table never has two columns with the same id.
+        id: `${col.name}-${idx}`,
+        label: col.name,
+        data: {
+          render: ({ data }) => <PrinterColumnValue item={data} jsonPath={col.jsonPath} type={col.type} />,
+        },
+        cell: { baseWidth: 12 },
+      });
+    });
+    base.push(ageColumn);
+
+    if (visible.length === 0) base.push(yamlIconColumn(crd, version));
+    return base;
+  };
+}
+
+function yamlIconColumn(crd: CRDObject, version: string): TableColumn<KubeObjectBase> {
+  return {
+    id: "yaml-action",
+    label: "",
+    data: {
+      render: ({ data }) => {
+        const ns = data.metadata?.namespace;
+        const linkParams =
+          crd.spec.scope === "Cluster"
+            ? {
+                to: PATH_K8S_CR_DETAIL_CLUSTER_FULL,
+                params: {
+                  group: crd.spec.group,
+                  version,
+                  plural: crd.spec.names.plural,
+                  name: data.metadata?.name ?? "",
+                },
+              }
+            : {
+                to: PATH_K8S_CR_DETAIL_NS_FULL,
+                params: {
+                  group: crd.spec.group,
+                  version,
+                  plural: crd.spec.names.plural,
+                  namespace: ns ?? "",
+                  name: data.metadata?.name ?? "",
+                },
+              };
+        return (
+          <Button asChild variant="ghost" size="icon" title="View YAML">
+            <Link to={linkParams.to as never} params={linkParams.params as never} search={{ tab: "yaml" } as never}>
+              <Eye className="size-4" />
+            </Link>
+          </Button>
+        );
+      },
+    },
+    cell: { baseWidth: 4 },
+  };
+}

--- a/apps/client/src/modules/k8s/registry/dynamic/crdUtils.test.ts
+++ b/apps/client/src/modules/k8s/registry/dynamic/crdUtils.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { resolveCRDVersion, storageVersionName, escapeRe } from "./crdUtils";
+
+const crd = (versions: Array<{ name: string; storage?: boolean; served?: boolean }>) =>
+  ({
+    spec: { versions } as never,
+  }) as never;
+
+describe("resolveCRDVersion", () => {
+  it("returns preferredVersion when it exists and is served", () => {
+    const c = crd([
+      { name: "v1alpha1", served: true },
+      { name: "v1", storage: true, served: true },
+    ]);
+    expect(resolveCRDVersion(c, "v1alpha1")?.name).toBe("v1alpha1");
+  });
+
+  it("skips preferredVersion when it exists but is not served", () => {
+    const c = crd([
+      { name: "v1alpha1", served: false },
+      { name: "v1", storage: true, served: true },
+    ]);
+    expect(resolveCRDVersion(c, "v1alpha1")?.name).toBe("v1");
+  });
+
+  it("returns the storage version when storage:true and served", () => {
+    const c = crd([
+      { name: "v1alpha1", served: true },
+      { name: "v1", storage: true, served: true },
+    ]);
+    expect(resolveCRDVersion(c)?.name).toBe("v1");
+  });
+
+  it("skips the storage version when storage:true but served:false (migration state)", () => {
+    const c = crd([
+      { name: "v1alpha1", storage: true, served: false },
+      { name: "v1", served: true },
+    ]);
+    expect(resolveCRDVersion(c)?.name).toBe("v1");
+  });
+
+  it("returns the first served version when no storage version is served", () => {
+    const c = crd([
+      { name: "v1alpha1", served: false },
+      { name: "v1beta1", served: true },
+    ]);
+    expect(resolveCRDVersion(c)?.name).toBe("v1beta1");
+  });
+
+  it("falls back to versions[0] when every version is explicitly served:false", () => {
+    const c = crd([
+      { name: "v1alpha1", served: false },
+      { name: "v1beta1", served: false },
+    ]);
+    expect(resolveCRDVersion(c)?.name).toBe("v1alpha1");
+  });
+
+  it("returns undefined for an empty versions array", () => {
+    expect(resolveCRDVersion(crd([]))).toBeUndefined();
+  });
+});
+
+describe("storageVersionName", () => {
+  it("returns the storage version when one is marked and served", () => {
+    expect(
+      storageVersionName(
+        crd([
+          { name: "v1alpha1", served: true },
+          { name: "v1", storage: true, served: true },
+          { name: "v1beta1", served: true },
+        ])
+      )
+    ).toBe("v1");
+  });
+
+  it("falls back when no version has storage:true", () => {
+    expect(storageVersionName(crd([{ name: "v1alpha1", served: true }, { name: "v1beta1" }]))).toBe("v1alpha1");
+  });
+
+  it("does NOT return a storage version that is not served (migration state)", () => {
+    expect(
+      storageVersionName(
+        crd([
+          { name: "v1alpha1", storage: true, served: false },
+          { name: "v1", served: true },
+        ])
+      )
+    ).toBe("v1");
+  });
+});
+
+describe("escapeRe", () => {
+  it("escapes regex metacharacters", () => {
+    expect(escapeRe("foo.bar/baz")).toBe("foo\\.bar/baz");
+    expect(escapeRe("a+b*c?")).toBe("a\\+b\\*c\\?");
+  });
+});

--- a/apps/client/src/modules/k8s/registry/dynamic/crdUtils.ts
+++ b/apps/client/src/modules/k8s/registry/dynamic/crdUtils.ts
@@ -1,0 +1,58 @@
+import type { CRDObject } from "@my-project/shared";
+
+type CRDVersion = CRDObject["spec"]["versions"][number];
+
+/**
+ * jsonPath of the built-in "Age" printer column the Kubernetes API server implicitly
+ * adds to every CRD. The UI renders age via its own column, so all printer-column
+ * consumers skip this entry to avoid rendering it twice.
+ */
+export const CREATION_TIMESTAMP_PRINTER_COL_PATH = ".metadata.creationTimestamp";
+
+/**
+ * Pick the version a UI consumer should send to the API server. Precedence:
+ * 1. `preferredVersion` if it exists AND is served
+ * 2. The storage version if it is served (a deprecated storage version can have served:false during migration)
+ * 3. The first served version
+ * 4. `versions[0]` as a last-resort fallback so we never throw on a malformed CRD here
+ *
+ * Returns `undefined` only when the CRD has an empty versions array — every other
+ * path returns a real `CRDVersion`. Centralizes the version-resolution logic
+ * previously inlined in buildCRDescriptor, PrinterColumnsRows, and CR list view.
+ */
+export function resolveCRDVersion(crd: CRDObject, preferredVersion?: string): CRDVersion | undefined {
+  const versions = crd.spec.versions;
+  if (versions.length === 0) {
+    return undefined;
+  }
+  const isServed = (v: CRDVersion) => v.served !== false;
+
+  if (preferredVersion) {
+    const match = versions.find((v) => v.name === preferredVersion && isServed(v));
+    if (match) return match;
+  }
+  const storageServed = versions.find((v) => v.storage && isServed(v));
+  if (storageServed) return storageServed;
+  const firstServed = versions.find(isServed);
+  if (firstServed) return firstServed;
+  return versions[0];
+}
+
+/**
+ * Return the name of the version that the sidebar / direct deep-links should
+ * use. Mirrors {@link resolveCRDVersion} so a deprecated storage version
+ * (storage:true, served:false) does not get linked — clicking such a link
+ * would land on the "Unknown custom resource" error page because the served
+ * filter in `useCRDByGVR` would reject it.
+ */
+export function storageVersionName(crd: CRDObject): string {
+  const version = resolveCRDVersion(crd);
+  if (!version) {
+    throw new Error(`CRD "${crd.metadata?.name ?? crd.spec.names.kind}" has no versions defined`);
+  }
+  return version.name;
+}
+
+export function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/apps/client/src/modules/k8s/registry/index.ts
+++ b/apps/client/src/modules/k8s/registry/index.ts
@@ -19,6 +19,7 @@ import { rolesDescriptor } from "./descriptors/roles";
 import { roleBindingsDescriptor } from "./descriptors/role-bindings";
 import { clusterRolesDescriptor } from "./descriptors/cluster-roles";
 import { clusterRoleBindingsDescriptor } from "./descriptors/cluster-role-bindings";
+import { crdsDescriptor } from "./descriptors/crds";
 
 export const resourceRegistry: ResourceRegistry = {
   // Workloads — pods first to preserve sidebar order
@@ -47,6 +48,6 @@ export const resourceRegistry: ResourceRegistry = {
   rolebindings: roleBindingsDescriptor,
   clusterroles: clusterRolesDescriptor,
   clusterrolebindings: clusterRoleBindingsDescriptor,
+  // Custom Resources
+  customresourcedefinitions: crdsDescriptor,
 } as const;
-
-export type KindKey = keyof typeof resourceRegistry;

--- a/apps/client/src/modules/k8s/registry/resolve.test.ts
+++ b/apps/client/src/modules/k8s/registry/resolve.test.ts
@@ -1,9 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { resolveDescriptor } from "./resolve";
+import { listRouteSlug, resolveDescriptor } from "./resolve";
 import { resourceRegistry } from "./index";
+import type { ResourceRegistry } from "./types";
+
+describe("listRouteSlug", () => {
+  it("extracts the URL segment after /k8s/", () => {
+    expect(listRouteSlug("/c/$clusterName/k8s/crds")).toBe("crds");
+    expect(listRouteSlug("/c/$clusterName/k8s/pods")).toBe("pods");
+  });
+
+  it("returns null when listRoute is missing or has no /k8s/ segment", () => {
+    expect(listRouteSlug(undefined)).toBeNull();
+    expect(listRouteSlug("")).toBeNull();
+    expect(listRouteSlug("/c/$clusterName/other/crds")).toBeNull();
+  });
+});
 
 describe("resolveDescriptor", () => {
   it("returns null for unknown kind", () => {
     expect(resolveDescriptor(resourceRegistry, "totally-fake")).toBeNull();
+  });
+
+  it("resolves a descriptor whose URL slug differs from its registry key", () => {
+    // Verify the slug-based fallback: registry key "widgets" but listRoute slug "wdg".
+    const mockRegistry: ResourceRegistry = {
+      widgets: {
+        config: {
+          group: "example.io",
+          version: "v1",
+          apiVersion: "example.io/v1",
+          kind: "Widget",
+          singularName: "widget",
+          pluralName: "widgets",
+        },
+        label: "Widgets",
+        sidebarGroup: "Workloads",
+        detailVariant: "namespaced",
+        columns: () => [],
+        listRoute: "/c/$clusterName/k8s/wdg",
+      },
+    };
+    const descriptor = resolveDescriptor(mockRegistry, "wdg");
+    expect(descriptor).not.toBeNull();
+    expect(descriptor?.config.pluralName).toBe("widgets");
+  });
+
+  it("resolves directly by registry key when no listRoute override applies", () => {
+    expect(resolveDescriptor(resourceRegistry, "pods")?.config.pluralName).toBe("pods");
   });
 });

--- a/apps/client/src/modules/k8s/registry/resolve.test.ts
+++ b/apps/client/src/modules/k8s/registry/resolve.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { listRouteSlug, resolveDescriptor } from "./resolve";
 import { resourceRegistry } from "./index";
-import type { ResourceRegistry } from "./types";
 
 describe("listRouteSlug", () => {
   it("extracts the URL segment after /k8s/", () => {
@@ -22,27 +21,10 @@ describe("resolveDescriptor", () => {
   });
 
   it("resolves a descriptor whose URL slug differs from its registry key", () => {
-    // Verify the slug-based fallback: registry key "widgets" but listRoute slug "wdg".
-    const mockRegistry: ResourceRegistry = {
-      widgets: {
-        config: {
-          group: "example.io",
-          version: "v1",
-          apiVersion: "example.io/v1",
-          kind: "Widget",
-          singularName: "widget",
-          pluralName: "widgets",
-        },
-        label: "Widgets",
-        sidebarGroup: "Workloads",
-        detailVariant: "namespaced",
-        columns: () => [],
-        listRoute: "/c/$clusterName/k8s/wdg",
-      },
-    };
-    const descriptor = resolveDescriptor(mockRegistry, "wdg");
+    // CRDs are registered under key "customresourcedefinitions" but routed at /k8s/crds.
+    const descriptor = resolveDescriptor(resourceRegistry, "crds");
     expect(descriptor).not.toBeNull();
-    expect(descriptor?.config.pluralName).toBe("widgets");
+    expect(descriptor?.config.pluralName).toBe("customresourcedefinitions");
   });
 
   it("resolves directly by registry key when no listRoute override applies", () => {

--- a/apps/client/src/modules/k8s/registry/resolve.ts
+++ b/apps/client/src/modules/k8s/registry/resolve.ts
@@ -1,5 +1,19 @@
 import type { ResourceDescriptor, ResourceRegistry } from "./types";
 
+// Extracts the first path segment after `/k8s/` from a descriptor's listRoute,
+// e.g. "/c/$clusterName/k8s/crds" → "crds".
+export function listRouteSlug(listRoute: string | undefined): string | null {
+  if (!listRoute) return null;
+  const m = listRoute.match(/\/k8s\/([^/]+)/);
+  return m ? m[1] : null;
+}
+
 export function resolveDescriptor(registry: ResourceRegistry, kind: string): ResourceDescriptor | null {
-  return registry[kind] ?? null;
+  if (registry[kind]) return registry[kind];
+  // Fallback: a descriptor may declare a listRoute whose URL slug differs from
+  // its registry key (e.g. key "customresourcedefinitions" vs slug "crds").
+  for (const d of Object.values(registry)) {
+    if (listRouteSlug(d.listRoute) === kind) return d;
+  }
+  return null;
 }

--- a/apps/client/src/modules/k8s/registry/types.ts
+++ b/apps/client/src/modules/k8s/registry/types.ts
@@ -5,7 +5,7 @@ import type { TableColumn } from "@/core/components/Table/types";
 import type { BadgeProps } from "@/core/components/ui/badge";
 import type { RenderName } from "./descriptors/columnHelpers";
 
-export type SidebarGroup = "Workloads" | "Network" | "Storage" | "Config" | "Security" | "Cluster";
+export type SidebarGroup = "Workloads" | "Network" | "Storage" | "Config" | "Security" | "Cluster" | "CustomResources";
 export type DetailVariant = "namespaced" | "cluster";
 
 export interface ResourceStatus {
@@ -21,12 +21,20 @@ export interface ResourceDescriptor {
   sidebarGroup: SidebarGroup;
   sidebarIcon?: LucideIcon;
   detailVariant: DetailVariant;
+  /**
+   * When true, the name column links to the generic CR detail routes
+   * (PATH_K8S_CR_DETAIL_{CLUSTER,NS}_FULL) using group/version/pluralName
+   * instead of the built-in resource kind routes.
+   * Must be set together with non-empty config.group, config.version, and config.pluralName.
+   */
+  customResource?: boolean;
   status?: (item: KubeObjectBase) => ResourceStatus;
   overviewTab?: ComponentType<{ item: KubeObjectBase }>;
-  template?: (namespace: string) => string;
   sidebarHidden?: true;
   /** Overrides the default generic list route link in the sidebar. Full path with $clusterName param. */
   listRoute?: string;
+  /** Per-kind header actions rendered to the right of Delete in K8sDetailPage. */
+  actionsSlot?: ComponentType<{ item: KubeObjectBase }>;
 }
 
 export type ResourceRegistry = Record<string, ResourceDescriptor>;

--- a/apps/client/src/modules/k8s/utils/extractByJsonPath.test.ts
+++ b/apps/client/src/modules/k8s/utils/extractByJsonPath.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { extractByJsonPath } from "./extractByJsonPath";
+
+describe("extractByJsonPath", () => {
+  const sample = {
+    metadata: {
+      name: "pr-1",
+      labels: { app: "demo", "app.kubernetes.io/name": "kebab-case-label" },
+    },
+    spec: { replicas: 3, paused: false, containers: [{ image: "app:1" }, { image: "sidecar:2" }] },
+    status: {
+      phase: "Running",
+      details: { reason: "ok" },
+      conditions: [
+        { type: "Ready", status: "True" },
+        { type: "PodScheduled", status: "True" },
+      ],
+    },
+  };
+
+  it("returns the value at a simple dot path", () => {
+    expect(extractByJsonPath(sample, ".status.phase")).toBe("Running");
+    expect(extractByJsonPath(sample, ".spec.replicas")).toBe(3);
+    expect(extractByJsonPath(sample, ".spec.paused")).toBe(false);
+  });
+
+  it("traverses nested objects", () => {
+    expect(extractByJsonPath(sample, ".status.details.reason")).toBe("ok");
+  });
+
+  it("accepts paths without a leading dot", () => {
+    expect(extractByJsonPath(sample, "status.phase")).toBe("Running");
+  });
+
+  it("returns undefined for missing keys mid-path", () => {
+    expect(extractByJsonPath(sample, ".status.missing.deep")).toBeUndefined();
+  });
+
+  it("returns undefined for missing top-level keys", () => {
+    expect(extractByJsonPath(sample, ".nope.nada")).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined input", () => {
+    expect(extractByJsonPath(null, ".any")).toBeUndefined();
+    expect(extractByJsonPath(undefined, ".any")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty path string", () => {
+    expect(extractByJsonPath(sample, "")).toBeUndefined();
+  });
+
+  it("accepts a path that opens directly with a bracket key (no leading dot)", () => {
+    expect(extractByJsonPath({ foo: 1 }, '["foo"]')).toBe(1);
+  });
+
+  it("returns undefined when a path traverses through a non-object value", () => {
+    expect(extractByJsonPath(sample, ".spec.replicas.something")).toBeUndefined();
+  });
+
+  describe("array indexing", () => {
+    it("reads a value at a numeric bracket index", () => {
+      expect(extractByJsonPath(sample, ".spec.containers[0].image")).toBe("app:1");
+      expect(extractByJsonPath(sample, ".spec.containers[1].image")).toBe("sidecar:2");
+    });
+
+    it("returns undefined when the index is out of bounds", () => {
+      expect(extractByJsonPath(sample, ".spec.containers[99].image")).toBeUndefined();
+    });
+
+    it("reads through a nested array path", () => {
+      expect(extractByJsonPath(sample, ".status.conditions[0].type")).toBe("Ready");
+      expect(extractByJsonPath(sample, ".status.conditions[1].status")).toBe("True");
+    });
+  });
+
+  describe("string-key bracket access", () => {
+    it("reads a value with single-quoted bracket key", () => {
+      expect(extractByJsonPath(sample, ".metadata.labels['app']")).toBe("demo");
+    });
+
+    it("reads a value with double-quoted bracket key", () => {
+      expect(extractByJsonPath(sample, '.metadata.labels["app"]')).toBe("demo");
+    });
+
+    it("reads a key containing dots (e.g. label keys with prefixes)", () => {
+      expect(extractByJsonPath(sample, '.metadata.labels["app.kubernetes.io/name"]')).toBe("kebab-case-label");
+    });
+  });
+
+  describe("unsupported syntax (returns undefined + dev warning)", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    const originalEnv = process.env.NODE_ENV;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it("returns undefined for filter expressions", () => {
+      expect(extractByJsonPath(sample, '.status.conditions[?(@.type=="Ready")].status')).toBeUndefined();
+    });
+
+    it("returns undefined for wildcard expressions", () => {
+      expect(extractByJsonPath(sample, ".spec.containers[*].image")).toBeUndefined();
+    });
+
+    it("emits a console.warn in development mode for unsupported syntax", () => {
+      process.env.NODE_ENV = "development";
+      extractByJsonPath(sample, ".spec.containers[*].image");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/filter or wildcard/i);
+    });
+
+    it("does NOT emit a warning in production mode", () => {
+      process.env.NODE_ENV = "production";
+      extractByJsonPath(sample, ".spec.containers[*].image");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined for unparsable paths (e.g. trailing junk)", () => {
+      process.env.NODE_ENV = "development";
+      expect(extractByJsonPath(sample, ".status.phase!!!")).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/client/src/modules/k8s/utils/extractByJsonPath.ts
+++ b/apps/client/src/modules/k8s/utils/extractByJsonPath.ts
@@ -1,0 +1,72 @@
+/**
+ * Minimal JSONPath subset used by Custom Resource printer columns.
+ *
+ * Supported syntax:
+ *   - Dot-delimited paths:                    `.status.phase`, `.spec.replicas`
+ *   - Numeric array indexing:                 `.status.conditions[0].type`
+ *   - String-key bracket access (quoted):     `.metadata.labels["app.kubernetes.io/name"]`
+ *   - String-key bracket access (single):     `.metadata.labels['app']`
+ *
+ * NOT supported (returns undefined + dev warning):
+ *   - Filter expressions:                     `.status.conditions[?(@.type=="Ready")]`
+ *   - Wildcard:                               `.spec.containers[*].image`
+ *   - Recursive descent:                      `..type`
+ */
+
+// Match either a dot-segment ".foo", a bracket numeric "[0]", or a quoted string "['app']" / '["app"]'.
+const SEGMENT_RE = /\.([A-Za-z_$][A-Za-z0-9_$-]*)|\[(\d+)\]|\[(?:'([^']*)'|"([^"]*)")\]/g;
+// Detect bracket forms that this parser does NOT support so we can return early.
+const UNSUPPORTED_BRACKET_RE = /\[(?:\?|\*)/;
+
+function emitDevWarning(message: string) {
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(`[extractByJsonPath] ${message}`);
+  }
+}
+
+export function extractByJsonPath(item: unknown, path: string): unknown {
+  if (UNSUPPORTED_BRACKET_RE.test(path)) {
+    emitDevWarning(`unsupported syntax (filter or wildcard) — returning blank: ${path}`);
+    return undefined;
+  }
+
+  // Tolerate a missing leading dot: callers historically passed both "status.phase"
+  // and ".status.phase". Normalize to the spec form before scanning.
+  const normalizedPath = path.startsWith(".") || path.startsWith("[") ? path : `.${path}`;
+
+  const segments: string[] = [];
+  SEGMENT_RE.lastIndex = 0;
+  let consumedTo = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SEGMENT_RE.exec(normalizedPath)) !== null) {
+    if (match.index !== consumedTo) {
+      // A character outside the recognized grammar appeared between matches.
+      emitDevWarning(`unparsable path — returning blank: ${path}`);
+      return undefined;
+    }
+    consumedTo = match.index + match[0].length;
+    // match[1] = dot segment, match[2] = numeric index, match[3] = single-quoted, match[4] = double-quoted
+    segments.push(match[1] ?? match[2] ?? match[3] ?? match[4] ?? "");
+  }
+  if (consumedTo !== normalizedPath.length) {
+    // Trailing characters did not match any known segment form.
+    emitDevWarning(`unparsable path — returning blank: ${path}`);
+    return undefined;
+  }
+  if (segments.length === 0) return undefined;
+
+  let cur: unknown = item;
+  for (const seg of segments) {
+    if (cur == null) return undefined;
+    if (Array.isArray(cur)) {
+      const idx = Number(seg);
+      if (!Number.isInteger(idx)) return undefined;
+      cur = cur[idx];
+    } else if (typeof cur === "object") {
+      cur = (cur as Record<string, unknown>)[seg];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/__mocks__/index.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/__mocks__/index.ts
@@ -1,5 +1,12 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { gitProvider } from "@my-project/shared";
+import {
+  gitProvider,
+  k8sGitServerConfig,
+  k8sJiraServerConfig,
+  k8sTemplateConfig,
+  k8sConfigMapConfig,
+} from "@my-project/shared";
+import { getK8sWatchListQueryCacheKey, getK8sWatchItemQueryCacheKey } from "@/k8s/api/hooks/useWatch/query-keys";
 
 /**
  * Mock Git Servers for wizard testing
@@ -234,7 +241,15 @@ export const seedWizardMockData = (queryClient: QueryClient) => {
   // Mock Git Servers list (stored as Map)
   const gitServersMap = new Map(Object.values(mockGitServers).map((server) => [server.metadata.name, server]));
 
-  const gitServersQueryKey = ["k8s:watchList", clusterName, namespace, "gitservers"];
+  // Build keys via the same helpers the production hooks use so the seeded data
+  // always lands under the exact key the component reads (the key shape includes
+  // the resource `group`; hand-building it here would silently drift).
+  const gitServersQueryKey = getK8sWatchListQueryCacheKey(
+    clusterName,
+    namespace,
+    k8sGitServerConfig.group,
+    k8sGitServerConfig.pluralName
+  );
 
   queryClient.setQueryData(gitServersQueryKey, {
     apiVersion: "v2.krci.io/v1",
@@ -246,7 +261,13 @@ export const seedWizardMockData = (queryClient: QueryClient) => {
   // Mock individual Git Server watches
   Object.values(mockGitServers).forEach((gitServer) => {
     queryClient.setQueryData(
-      ["k8s:watchItem", clusterName, namespace, "gitservers", gitServer.metadata.name],
+      getK8sWatchItemQueryCacheKey(
+        clusterName,
+        namespace,
+        k8sGitServerConfig.group,
+        k8sGitServerConfig.pluralName,
+        gitServer.metadata.name
+      ),
       gitServer
     );
   });
@@ -254,7 +275,12 @@ export const seedWizardMockData = (queryClient: QueryClient) => {
   // Mock Jira Servers list (stored as Map)
   const jiraServersMap = new Map(Object.values(mockJiraServers).map((server) => [server.metadata.name, server]));
 
-  const jiraServersQueryKey = ["k8s:watchList", clusterName, namespace, "jiraservers"];
+  const jiraServersQueryKey = getK8sWatchListQueryCacheKey(
+    clusterName,
+    namespace,
+    k8sJiraServerConfig.group,
+    k8sJiraServerConfig.pluralName
+  );
 
   queryClient.setQueryData(jiraServersQueryKey, {
     apiVersion: "v2.krci.io/v1",
@@ -266,7 +292,13 @@ export const seedWizardMockData = (queryClient: QueryClient) => {
   // Mock individual Jira Server watches
   Object.values(mockJiraServers).forEach((jiraServer) => {
     queryClient.setQueryData(
-      ["k8s:watchItem", clusterName, namespace, "jiraservers", jiraServer.metadata.name],
+      getK8sWatchItemQueryCacheKey(
+        clusterName,
+        namespace,
+        k8sJiraServerConfig.group,
+        k8sJiraServerConfig.pluralName,
+        jiraServer.metadata.name
+      ),
       jiraServer
     );
   });
@@ -283,7 +315,12 @@ export const seedWizardMockData = (queryClient: QueryClient) => {
   // Mock Templates list (stored as Map)
   const templatesMap = new Map(Object.values(mockTemplates).map((template) => [template.metadata.name, template]));
 
-  const templatesQueryKey = ["k8s:watchList", clusterName, namespace, "templates"];
+  const templatesQueryKey = getK8sWatchListQueryCacheKey(
+    clusterName,
+    namespace,
+    k8sTemplateConfig.group,
+    k8sTemplateConfig.pluralName
+  );
 
   queryClient.setQueryData(templatesQueryKey, {
     apiVersion: "v2.krci.io/v1",
@@ -294,11 +331,29 @@ export const seedWizardMockData = (queryClient: QueryClient) => {
 
   // Mock individual Template watches
   Object.values(mockTemplates).forEach((template) => {
-    queryClient.setQueryData(["k8s:watchItem", clusterName, namespace, "templates", template.metadata.name], template);
+    queryClient.setQueryData(
+      getK8sWatchItemQueryCacheKey(
+        clusterName,
+        namespace,
+        k8sTemplateConfig.group,
+        k8sTemplateConfig.pluralName,
+        template.metadata.name
+      ),
+      template
+    );
   });
 
   // Mock KRCI Config
-  queryClient.setQueryData(["k8s:watchItem", clusterName, namespace, "configmaps", "krci-config"], mockKRCIConfig);
+  queryClient.setQueryData(
+    getK8sWatchItemQueryCacheKey(
+      clusterName,
+      namespace,
+      k8sConfigMapConfig.group,
+      k8sConfigMapConfig.pluralName,
+      "krci-config"
+    ),
+    mockKRCIConfig
+  );
 };
 
 /**

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/PipelineRunList.stories.tsx
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/PipelineRunList.stories.tsx
@@ -188,6 +188,7 @@ const pipelineRunListDecorator = withAppProviders({
     const permissionsCacheKey = getK8sItemPermissionsQueryCacheKey(
       STORYBOOK_CLUSTER_NAME,
       STORYBOOK_NAMESPACE,
+      k8sPipelineRunConfig.group,
       k8sPipelineRunConfig.pluralName
     );
     client.setQueryData(permissionsCacheKey, mockPermissions);

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -1,8 +1,9 @@
 import { defineProject } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import svgr from "vite-plugin-svgr";
 
 export default defineProject({
-  plugins: [tsconfigPaths({ root: "./" })],
+  plugins: [tsconfigPaths({ root: "./" }), svgr()],
   test: {
     name: "client",
     environment: "jsdom",

--- a/packages/shared/src/models/k8s/common/constants.ts
+++ b/packages/shared/src/models/k8s/common/constants.ts
@@ -12,6 +12,7 @@ export const k8sToRbacVerbMap: Record<K8sOperation, RBACOperation> = {
   [k8sOperation.create]: rbacOperation.create,
   [k8sOperation.delete]: rbacOperation.delete,
   [k8sOperation.update]: rbacOperation.update,
+  [k8sOperation.patch]: rbacOperation.patch,
   [k8sOperation.connect]: rbacOperation.connect,
   [k8sOperation.replace]: rbacOperation.update,
 };
@@ -28,7 +29,12 @@ export const rbacToK8sVerbMap: Record<RBACOperation, K8sOperation> = {
   [rbacOperation.connect]: k8sOperation.connect,
 };
 
-export const defaultPermissionsToCheck = [k8sOperation.create, k8sOperation.update, k8sOperation.delete] as const;
+export const defaultPermissionsToCheck = [
+  k8sOperation.create,
+  k8sOperation.update,
+  k8sOperation.patch,
+  k8sOperation.delete,
+] as const;
 
 export const defaultPermissions = {
   [k8sOperation.create]: {
@@ -38,6 +44,10 @@ export const defaultPermissions = {
   [k8sOperation.update]: {
     allowed: false,
     reason: `You cannot update resources of this kind. Permission check result has not been received yet.`,
+  },
+  [k8sOperation.patch]: {
+    allowed: false,
+    reason: `You cannot patch resources of this kind. Permission check result has not been received yet.`,
   },
   [k8sOperation.delete]: {
     allowed: false,

--- a/packages/shared/src/models/k8s/common/schema.ts
+++ b/packages/shared/src/models/k8s/common/schema.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 
-export const k8sOperationEnum = z.enum(["list", "read", "create", "delete", "update", "connect", "replace"]);
+export const k8sOperationEnum = z.enum(["list", "read", "create", "delete", "update", "patch", "connect", "replace"]);
 
 export const rbacOperationEnum = z.enum([
   "get",

--- a/packages/shared/src/models/k8s/common/types.ts
+++ b/packages/shared/src/models/k8s/common/types.ts
@@ -27,6 +27,23 @@ export type KubeObjectListBase<T extends KubeObjectBase> = z.infer<typeof KubeOb
 
 export type ResourceLabels = Record<string, string> | undefined;
 
+// Canonical K8s condition status values. Typed as `string` on KubeCondition
+// because runtime conditions extracted from arbitrary K8s resources may report
+// non-spec values, and a strict union would force casts at every consumer.
+export const KUBE_CONDITION_STATUS = {
+  True: "True",
+  False: "False",
+  Unknown: "Unknown",
+} as const;
+
+export interface KubeCondition {
+  type: string;
+  status: string;
+  lastTransitionTime?: string;
+  reason?: string;
+  message?: string;
+}
+
 export interface K8sResourceConfig<Labels extends ResourceLabels = ResourceLabels> extends z.infer<
   typeof k8sResourceConfigSchema
 > {

--- a/packages/shared/src/models/k8s/groups/ApiExtensions/CustomResourceDefinition/constants.test.ts
+++ b/packages/shared/src/models/k8s/groups/ApiExtensions/CustomResourceDefinition/constants.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { k8sCustomResourceDefinitionConfig } from "./constants.js";
+
+describe("k8sCustomResourceDefinitionConfig", () => {
+  it("has the correct K8sResourceConfig shape", () => {
+    expect(k8sCustomResourceDefinitionConfig).toMatchObject({
+      apiVersion: "apiextensions.k8s.io/v1",
+      kind: "CustomResourceDefinition",
+      group: "apiextensions.k8s.io",
+      version: "v1",
+      singularName: "customresourcedefinition",
+      pluralName: "customresourcedefinitions",
+      clusterScoped: true,
+    });
+  });
+
+  it("is cluster-scoped", () => {
+    expect(k8sCustomResourceDefinitionConfig.clusterScoped).toBe(true);
+  });
+});

--- a/packages/shared/src/models/k8s/groups/ApiExtensions/CustomResourceDefinition/constants.ts
+++ b/packages/shared/src/models/k8s/groups/ApiExtensions/CustomResourceDefinition/constants.ts
@@ -1,0 +1,11 @@
+import { K8sResourceConfig } from "../../../common/index.js";
+
+export const k8sCustomResourceDefinitionConfig = {
+  apiVersion: "apiextensions.k8s.io/v1",
+  kind: "CustomResourceDefinition",
+  group: "apiextensions.k8s.io",
+  version: "v1",
+  singularName: "customresourcedefinition",
+  pluralName: "customresourcedefinitions",
+  clusterScoped: true,
+} as const satisfies K8sResourceConfig;

--- a/packages/shared/src/models/k8s/groups/ApiExtensions/CustomResourceDefinition/index.ts
+++ b/packages/shared/src/models/k8s/groups/ApiExtensions/CustomResourceDefinition/index.ts
@@ -1,0 +1,2 @@
+export * from "./constants.js";
+export * from "./types.js";

--- a/packages/shared/src/models/k8s/groups/ApiExtensions/CustomResourceDefinition/types.ts
+++ b/packages/shared/src/models/k8s/groups/ApiExtensions/CustomResourceDefinition/types.ts
@@ -1,0 +1,55 @@
+import type { KubeCondition, KubeMetadata } from "../../../common/types.js";
+
+export interface CRDVersion {
+  name: string;
+  served: boolean;
+  storage: boolean;
+  additionalPrinterColumns?: Array<{
+    name: string;
+    type: "string" | "integer" | "number" | "boolean" | "date";
+    /** Optional format hint per CRD v1 spec (e.g. "byte", "date-time", "int32"). */
+    format?: string;
+    jsonPath: string;
+    description?: string;
+    priority?: number;
+  }>;
+  schema?: { openAPIV3Schema?: Record<string, unknown> };
+}
+
+export interface CRDObject {
+  apiVersion: "apiextensions.k8s.io/v1";
+  kind: "CustomResourceDefinition";
+  // Use the canonical KubeMetadata to inherit every field tracked by the
+  // central metadata schema (resourceVersion, deletionTimestamp, finalizers,
+  // generation, managedFields, ownerReferences, etc.) and avoid drift.
+  metadata: KubeMetadata;
+  spec: {
+    group: string;
+    scope: "Namespaced" | "Cluster";
+    names: {
+      kind: string;
+      plural: string;
+      singular?: string;
+      listKind?: string;
+      shortNames?: string[];
+      categories?: string[];
+    };
+    versions: CRDVersion[];
+    conversion?: {
+      strategy: "None" | "Webhook";
+      conversionReviewVersions?: string[];
+      webhook?: Record<string, unknown>;
+    };
+  };
+  status?: {
+    conditions?: KubeCondition[];
+    storedVersions?: string[];
+    acceptedNames?: {
+      kind: string;
+      plural: string;
+      singular?: string;
+      listKind?: string;
+      shortNames?: string[];
+    };
+  };
+}

--- a/packages/shared/src/models/k8s/groups/ApiExtensions/index.ts
+++ b/packages/shared/src/models/k8s/groups/ApiExtensions/index.ts
@@ -1,0 +1,1 @@
+export * from "./CustomResourceDefinition/index.js";

--- a/packages/shared/src/models/k8s/groups/apps/ReplicaSet/constants.test.ts
+++ b/packages/shared/src/models/k8s/groups/apps/ReplicaSet/constants.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { k8sReplicaSetConfig } from "./constants.js";
+
+describe("k8sReplicaSetConfig", () => {
+  it("has the correct K8sResourceConfig shape", () => {
+    expect(k8sReplicaSetConfig).toMatchObject({
+      group: "apps",
+      version: "v1",
+      apiVersion: "apps/v1",
+      kind: "ReplicaSet",
+      singularName: "replicaset",
+      pluralName: "replicasets",
+    });
+  });
+
+  it("is namespace-scoped (clusterScoped field omitted)", () => {
+    // ReplicaSet lives under /apis/apps/v1/namespaces/.../replicasets, never cluster-wide.
+    // Regression guard against an accidental flip to clusterScoped: true.
+    expect("clusterScoped" in k8sReplicaSetConfig).toBe(false);
+  });
+});

--- a/packages/shared/src/models/k8s/groups/apps/ReplicaSet/constants.ts
+++ b/packages/shared/src/models/k8s/groups/apps/ReplicaSet/constants.ts
@@ -1,0 +1,15 @@
+import { K8sResourceConfig } from "../../../common/index.js";
+
+export const k8sReplicaSetConfig = {
+  group: "apps",
+  version: "v1",
+  apiVersion: "apps/v1",
+  kind: "ReplicaSet",
+  singularName: "replicaset",
+  pluralName: "replicasets",
+} as const satisfies K8sResourceConfig;
+
+// Annotation written by the Deployment controller onto each owned ReplicaSet (and
+// onto the Deployment itself) to track the rollout revision number. Used by the
+// rollback + listRevisions procedures to identify the current revision.
+export const DEPLOYMENT_REVISION_ANNOTATION = "deployment.kubernetes.io/revision";

--- a/packages/shared/src/models/k8s/groups/apps/ReplicaSet/index.ts
+++ b/packages/shared/src/models/k8s/groups/apps/ReplicaSet/index.ts
@@ -1,0 +1,1 @@
+export * from "./constants.js";

--- a/packages/shared/src/models/k8s/groups/apps/index.ts
+++ b/packages/shared/src/models/k8s/groups/apps/index.ts
@@ -1,3 +1,4 @@
 export * from "./Deployment/index.js";
 export * from "./StatefulSet/index.js";
 export * from "./DaemonSet/index.js";
+export * from "./ReplicaSet/index.js";

--- a/packages/shared/src/models/k8s/index.ts
+++ b/packages/shared/src/models/k8s/index.ts
@@ -1,6 +1,5 @@
 export * from "./common/index.js";
 export * from "./groups/Core/index.js";
-export * from "./groups/Core/index.js";
 export * from "./groups/apps/index.js";
 export * from "./groups/autoscaling/index.js";
 export * from "./groups/batch/index.js";
@@ -10,5 +9,6 @@ export * from "./groups/Tekton/index.js";
 export * from "./groups/Trivy/index.js";
 export * from "./groups/Networking/index.js";
 export * from "./groups/Storage/index.js";
+export * from "./groups/ApiExtensions/index.js";
 export * from "./groups/RBAC/index.js";
 export * from "./integrations/index.js";

--- a/packages/trpc/src/clients/k8s/index.test.ts
+++ b/packages/trpc/src/clients/k8s/index.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
 import { KubeConfig } from "@kubernetes/client-node";
+import { K8sApiError } from "@my-project/shared";
+import fetchModule from "node-fetch";
 import { K8sClient } from "./index.js";
 import { CustomSession } from "../../context/types.js";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
 
 vi.mock("@kubernetes/client-node", () => {
   const mockKubeConfig: Partial<KubeConfig> = {
@@ -124,7 +128,9 @@ describe("K8sClient", () => {
     ]);
   });
 
-  it("throws error if no idToken is provided", () => {
+  it("leaves KubeConfig null when no idToken is provided (no throw)", () => {
+    // Mirrors the no-session branch so getInitializedK8sClient can raise a single
+    // typed UNAUTHORIZED error at the call site instead of a bare Error bubbling up.
     const sessionWithoutToken = {
       login: undefined,
       user: {
@@ -147,10 +153,14 @@ describe("K8sClient", () => {
       },
     } as CustomSession;
 
-    expect(() => new K8sClient(sessionWithoutToken)).toThrow("No access token provided in session");
+    const client = new K8sClient(sessionWithoutToken);
+    expect(client.KubeConfig).toBeNull();
   });
 
-  it("throws error if current cluster is not found", () => {
+  it("leaves KubeConfig null if current cluster is not found", () => {
+    // Mirrors the no-token branch: a misconfigured kubeconfig produces a null
+    // KubeConfig so getInitializedK8sClient can raise a typed UNAUTHORIZED
+    // TRPCError, instead of throwing a bare Error that handleK8sError maps to 500.
     vi.mocked(KubeConfig).mockImplementationOnce(
       () =>
         ({
@@ -166,7 +176,8 @@ describe("K8sClient", () => {
         }) as unknown as KubeConfig
     );
 
-    expect(() => new K8sClient(validSession)).toThrow("No cluster configuration found");
+    const client = new K8sClient(validSession);
+    expect(client.KubeConfig).toBeNull();
   });
 
   describe("discoverResource", () => {
@@ -219,7 +230,7 @@ describe("K8sClient", () => {
     });
   });
 
-  it("throws error if current context is not found", () => {
+  it("leaves KubeConfig null if current context is not found", () => {
     vi.mocked(KubeConfig).mockImplementationOnce(
       () =>
         ({
@@ -235,6 +246,272 @@ describe("K8sClient", () => {
         }) as unknown as KubeConfig
     );
 
-    expect(() => new K8sClient(validSession)).toThrow("No current context found in kubeConfig");
+    const client = new K8sClient(validSession);
+    expect(client.KubeConfig).toBeNull();
+  });
+
+  describe("patchResource — patchType + subresource", () => {
+    const deployConfig = {
+      group: "apps",
+      version: "v1",
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      singularName: "deployment",
+      pluralName: "deployments",
+    };
+
+    const makeKubeConfigWithServer = () =>
+      ({
+        loadFromDefault: vi.fn(),
+        loadFromCluster: vi.fn(),
+        getCurrentCluster: vi.fn().mockReturnValue({ name: "test-cluster", server: "https://k8s.example.com" }),
+        getCurrentContext: vi.fn().mockReturnValue("test-context"),
+        getCurrentUser: vi.fn().mockReturnValue({}),
+        setCurrentContext: vi.fn(),
+        applyToHTTPSOptions: vi.fn(),
+        users: [],
+        contexts: [],
+        clusters: [],
+        currentContext: "test-context",
+      }) as unknown as KubeConfig;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("default patchType sends Content-Type application/strategic-merge-patch+json", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      } as never);
+
+      const client = new K8sClient(validSession);
+      await client.patchResource(deployConfig, "foo", "ns", { spec: { replicas: 3 } });
+
+      const call0 = fetchMock.mock.calls[0]!;
+      expect(call0[1]!.method).toBe("PATCH");
+      expect((call0[1]!.headers as Record<string, string>)["Content-Type"]).toBe(
+        "application/strategic-merge-patch+json"
+      );
+    });
+
+    it('patchType "merge" sends Content-Type application/merge-patch+json', async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      } as never);
+
+      const client = new K8sClient(validSession);
+      await client.patchResource(deployConfig, "foo", "ns", {}, "merge");
+
+      const call0 = fetchMock.mock.calls[0]!;
+      expect((call0[1]!.headers as Record<string, string>)["Content-Type"]).toBe("application/merge-patch+json");
+    });
+
+    it('patchType "json" sends Content-Type application/json-patch+json', async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      } as never);
+
+      const client = new K8sClient(validSession);
+      await client.patchResource(deployConfig, "foo", "ns", [], "json");
+
+      const call0 = fetchMock.mock.calls[0]!;
+      expect((call0[1]!.headers as Record<string, string>)["Content-Type"]).toBe("application/json-patch+json");
+    });
+
+    it('subresource "scale" appends /scale to the URL', async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      } as never);
+
+      const client = new K8sClient(validSession);
+      await client.patchResource(deployConfig, "foo", "ns", { spec: { replicas: 5 } }, "strategic", "scale");
+
+      expect(fetchMock.mock.calls[0][0] as string).toMatch(
+        /\/apis\/apps\/v1\/namespaces\/ns\/deployments\/foo\/scale$/
+      );
+    });
+
+    it('subresource "status" appends /status to the URL', async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      } as never);
+
+      const client = new K8sClient(validSession);
+      await client.patchResource(deployConfig, "foo", "ns", { status: {} }, "merge", "status");
+
+      expect(fetchMock.mock.calls[0][0] as string).toMatch(
+        /\/apis\/apps\/v1\/namespaces\/ns\/deployments\/foo\/status$/
+      );
+    });
+
+    it("throws K8sApiError on non-2xx PATCH response", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+        text: async () => '{"message":"object has been modified"}',
+      } as never);
+
+      const client = new K8sClient(validSession);
+      await expect(
+        client.patchResource(deployConfig, "foo", "ns", { spec: { replicas: 2 } }, "strategic", "scale")
+      ).rejects.toMatchObject({
+        name: "K8sApiError",
+        statusCode: 409,
+        statusText: "Conflict",
+      });
+    });
+
+    it("throws K8sApiError instance (not a plain Error) on PATCH failure", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        text: async () => "{}",
+      } as never);
+
+      const client = new K8sClient(validSession);
+      await expect(client.patchResource(deployConfig, "foo", "ns", {})).rejects.toBeInstanceOf(K8sApiError);
+    });
+  });
+
+  describe("listAllResources — continue-token pagination", () => {
+    const rsConfig = {
+      group: "apps",
+      version: "v1",
+      apiVersion: "apps/v1",
+      kind: "ReplicaSet",
+      singularName: "replicaset",
+      pluralName: "replicasets",
+    };
+
+    const makeKubeConfigWithServer = () =>
+      ({
+        loadFromDefault: vi.fn(),
+        loadFromCluster: vi.fn(),
+        getCurrentCluster: vi.fn().mockReturnValue({ name: "test-cluster", server: "https://k8s.example.com" }),
+        getCurrentContext: vi.fn().mockReturnValue("test-context"),
+        getCurrentUser: vi.fn().mockReturnValue({}),
+        setCurrentContext: vi.fn(),
+        applyToHTTPSOptions: vi.fn(),
+        users: [],
+        contexts: [],
+        clusters: [],
+        currentContext: "test-context",
+      }) as unknown as KubeConfig;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("follows the continue token until the API server stops returning one", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ items: [{ name: "a" }, { name: "b" }], metadata: { continue: "tok-1" } }),
+        } as never)
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ items: [{ name: "c" }], metadata: { continue: "tok-2" } }),
+        } as never)
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ items: [{ name: "d" }], metadata: {} }),
+        } as never);
+
+      const client = new K8sClient(validSession);
+      const result = await client.listAllResources(rsConfig, "ns");
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(result.items).toHaveLength(4);
+      expect(result.items.map((it) => (it as unknown as { name: string }).name)).toEqual(["a", "b", "c", "d"]);
+      const secondCallUrl = fetchMock.mock.calls[1]![0] as string;
+      expect(secondCallUrl).toContain("continue=tok-1");
+      const thirdCallUrl = fetchMock.mock.calls[2]![0] as string;
+      expect(thirdCallUrl).toContain("continue=tok-2");
+    });
+
+    it("forwards labelSelector on every page", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ items: [], metadata: { continue: "tok" } }),
+        } as never)
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ items: [], metadata: {} }),
+        } as never);
+
+      const client = new K8sClient(validSession);
+      await client.listAllResources(rsConfig, "ns", "app=foo");
+
+      expect(fetchMock.mock.calls[0]![0] as string).toContain("labelSelector=app%3Dfoo");
+      expect(fetchMock.mock.calls[1]![0] as string).toContain("labelSelector=app%3Dfoo");
+    });
+
+    it("returns an empty list without throwing when the API server returns items: null", async () => {
+      // Some non-conformant API servers / alpha resources return null instead of [].
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ items: null, metadata: {} }),
+      } as never);
+
+      const client = new K8sClient(validSession);
+      const result = await client.listAllResources(rsConfig, "ns");
+
+      expect(result.items).toHaveLength(0);
+    });
+
+    it("caps at maxPages to prevent unbounded loops on a misbehaving server", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ items: [{ name: "x" }], metadata: { continue: "never-ends" } }),
+      } as never);
+
+      const client = new K8sClient(validSession);
+      const result = await client.listAllResources(rsConfig, "ns", undefined, { maxPages: 3 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(result.items).toHaveLength(3);
+    });
   });
 });

--- a/packages/trpc/src/clients/k8s/index.ts
+++ b/packages/trpc/src/clients/k8s/index.ts
@@ -12,12 +12,22 @@ export { isCoreKubernetesResource };
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
+export type PatchType = "strategic" | "merge" | "json";
+export type PatchSubresource = "scale" | "status";
+
 export class K8sClient {
   KubeConfig: KubeConfig | null;
+  // Captures the specific reason the KubeConfig could not be initialized so
+  // `getInitializedK8sClient` can surface it in the TRPCError message instead
+  // of a generic "client could not be initialized" string. Operators rely on
+  // this to distinguish "no session" from "missing cluster config" from
+  // "missing current context" when triaging KRCI integration-view failures.
+  kubeConfigInitError: string | null = null;
 
   constructor(session: CustomSession | undefined) {
     if (!session || !session.user) {
       this.KubeConfig = null;
+      this.kubeConfigInitError = "No active session for this request.";
       return;
     }
 
@@ -33,7 +43,9 @@ export class K8sClient {
     const userToken = session.user?.secret.idToken;
 
     if (!userToken) {
-      throw new Error("No access token provided in session");
+      this.KubeConfig = null;
+      this.kubeConfigInitError = "No access token provided in session.";
+      return;
     }
 
     this.KubeConfig.users = [
@@ -45,12 +57,16 @@ export class K8sClient {
 
     const cluster = this.KubeConfig.getCurrentCluster();
     if (!cluster) {
-      throw new Error("No cluster configuration found");
+      this.KubeConfig = null;
+      this.kubeConfigInitError = "No cluster configuration found in kubeconfig.";
+      return;
     }
 
     const currentContext = this.KubeConfig.getCurrentContext();
     if (!currentContext) {
-      throw new Error("No current context found in kubeConfig");
+      this.KubeConfig = null;
+      this.kubeConfigInitError = "No current context found in kubeconfig.";
+      return;
     }
 
     this.KubeConfig.contexts = [
@@ -82,12 +98,16 @@ export class K8sClient {
   }
 
   /**
-   * Unified method to list any Kubernetes resource (core or custom)
+   * Unified method to list any Kubernetes resource (core or custom). Returns the
+   * single page returned by the API server (subject to the API server's chunk
+   * limit, typically 500 items by default). Use {@link listAllResources} when the
+   * full set is required.
    */
   async listResource(
     resourceConfig: K8sResourceConfig,
     namespace?: string,
-    labelSelector?: string
+    labelSelector?: string,
+    options?: { limit?: number; continueToken?: string }
   ): Promise<KubeObjectListBase<KubeObjectBase>> {
     if (!this.KubeConfig) {
       throw new Error("KubeConfig is not initialized");
@@ -99,10 +119,62 @@ export class K8sClient {
     if (labelSelector) {
       queryParams.append("labelSelector", labelSelector);
     }
+    if (options?.limit && options.limit > 0) {
+      queryParams.append("limit", String(options.limit));
+    }
+    if (options?.continueToken) {
+      queryParams.append("continue", options.continueToken);
+    }
 
     const fullUrl = queryParams.toString() ? `${url}?${queryParams.toString()}` : url;
 
     return this.makeRequest("GET", fullUrl) as unknown as KubeObjectListBase<KubeObjectBase>;
+  }
+
+  /**
+   * List every page of a resource by following the API server's `continue` token.
+   * Use when a single-page response could miss items (e.g. ReplicaSet history of a
+   * long-lived Deployment exceeding the default 500-item chunk limit).
+   */
+  async listAllResources(
+    resourceConfig: K8sResourceConfig,
+    namespace?: string,
+    labelSelector?: string,
+    options?: { pageSize?: number; maxPages?: number }
+  ): Promise<KubeObjectListBase<KubeObjectBase>> {
+    const pageSize = options?.pageSize;
+    const maxPages = options?.maxPages ?? 20;
+
+    let continueToken: string | undefined;
+    let pages = 0;
+    const items: KubeObjectBase[] = [];
+    let lastPage: KubeObjectListBase<KubeObjectBase> | undefined;
+
+    do {
+      const page = await this.listResource(resourceConfig, namespace, labelSelector, {
+        limit: pageSize,
+        continueToken,
+      });
+      items.push(...(page.items ?? []));
+      lastPage = page;
+      continueToken = (page.metadata as { continue?: string } | undefined)?.continue;
+      pages += 1;
+    } while (continueToken && pages < maxPages);
+
+    if (continueToken) {
+      // Pagination cap hit with a non-empty continue token — callers receive a
+      // truncated result and have no other signal. Warn so the gap is at least
+      // diagnosable in server logs (e.g. rollback failing with NOT_FOUND for a
+      // valid RS that lives beyond the cap).
+      console.warn(
+        `listAllResources: maxPages cap of ${maxPages} reached for ${resourceConfig.kind}` +
+          `${namespace ? ` in namespace ${namespace}` : ""}; results are truncated.`
+      );
+    }
+
+    // Reuse the last page's envelope (kind/apiVersion/metadata.resourceVersion)
+    // and replace the items array with the accumulated set.
+    return { ...lastPage!, items };
   }
 
   /**
@@ -187,14 +259,16 @@ export class K8sClient {
     resourceConfig: K8sResourceConfig,
     name: string,
     namespace: string | undefined,
-    body: object
+    body: object,
+    patchType: PatchType = "strategic",
+    subresource?: PatchSubresource
   ): Promise<KubeObjectBase> {
     if (!this.KubeConfig) {
       throw new Error("KubeConfig is not initialized");
     }
 
-    const url = this.buildResourceUrl(resourceConfig, { namespace, name });
-    return this.makeRequest("PATCH", url, body);
+    const url = this.buildResourceUrl(resourceConfig, { namespace, name, subresource });
+    return this.makeRequest("PATCH", url, body, patchType);
   }
 
   /**
@@ -223,57 +297,47 @@ export class K8sClient {
   /**
    * Build the appropriate Kubernetes API URL for any resource
    */
-  private buildResourceUrl(resourceConfig: K8sResourceConfig, options: { namespace?: string; name?: string }): string {
+  private buildResourceUrl(
+    resourceConfig: K8sResourceConfig,
+    options: { namespace?: string; name?: string; subresource?: string }
+  ): string {
     const cluster = this.KubeConfig!.getCurrentCluster();
     if (!cluster) {
       throw new Error("No current cluster found");
     }
 
     const { server } = cluster;
-    const { namespace, name } = options;
+    const { namespace, name, subresource } = options;
 
     const isNamespaced =
       !resourceConfig.clusterScoped &&
       !CLUSTER_SCOPED_CORE_RESOURCES.has(resourceConfig.kind) &&
       resourceConfig.kind !== "Namespace";
 
-    let basePath: string;
-    let resourcePath: string;
-
     // Extract version from either version field or apiVersion field
     const version = resourceConfig.version || resourceConfig.apiVersion?.split("/").pop() || "v1";
 
-    if (isCoreKubernetesResource(resourceConfig)) {
-      basePath = `/api/${version}`;
+    const basePath = isCoreKubernetesResource(resourceConfig)
+      ? `/api/${version}`
+      : resourceConfig.group
+        ? `/apis/${resourceConfig.group}/${version}`
+        : `/apis/${version}`;
 
-      if (isNamespaced && namespace) {
-        resourcePath = `namespaces/${namespace}/${resourceConfig.pluralName}`;
-      } else {
-        resourcePath = resourceConfig.pluralName;
-      }
-    } else {
-      // Handle empty group case to avoid double slashes
-      if (resourceConfig.group) {
-        basePath = `/apis/${resourceConfig.group}/${version}`;
-      } else {
-        basePath = `/apis/${version}`;
-      }
+    const resourcePath =
+      isNamespaced && namespace ? `namespaces/${namespace}/${resourceConfig.pluralName}` : resourceConfig.pluralName;
 
-      if (isNamespaced && namespace) {
-        resourcePath = `namespaces/${namespace}/${resourceConfig.pluralName}`;
-      } else {
-        resourcePath = resourceConfig.pluralName;
-      }
-    }
-
-    // Ensure no double slashes by cleaning up the path construction
-    let url = `${server}${basePath}/${resourcePath}`.replace(/\/+/g, "/").replace(":/", "://");
+    let url = `${server}${basePath}/${resourcePath}`;
 
     if (name) {
       url += `/${name}`;
     }
 
-    return url;
+    if (subresource) {
+      url += `/${subresource}`;
+    }
+
+    // Ensure no double slashes anywhere in the path (applied after all segments are appended)
+    return url.replace(/([^:])\/{2,}/g, "$1/");
   }
 
   /**
@@ -282,7 +346,8 @@ export class K8sClient {
   private async makeRequest(
     method: HttpMethod,
     url: string,
-    body?: object
+    body?: object,
+    patchType?: PatchType
   ): Promise<KubeObjectBase | KubeObjectListBase<KubeObjectBase>> {
     if (!this.KubeConfig) {
       throw new Error("KubeConfig is not initialized");
@@ -308,10 +373,6 @@ export class K8sClient {
       Accept: "application/json",
     };
 
-    if (body && ["POST", "PUT", "PATCH"].includes(method)) {
-      requestHeaders["Content-Type"] = "application/json";
-    }
-
     const opts = {
       method,
       headers: requestHeaders,
@@ -320,6 +381,16 @@ export class K8sClient {
     };
 
     if (body && ["POST", "PUT", "PATCH"].includes(method)) {
+      if (method === "PATCH") {
+        requestHeaders["Content-Type"] =
+          patchType === "merge"
+            ? "application/merge-patch+json"
+            : patchType === "json"
+              ? "application/json-patch+json"
+              : "application/strategic-merge-patch+json";
+      } else {
+        requestHeaders["Content-Type"] = "application/json";
+      }
       opts.body = JSON.stringify(body);
     }
 

--- a/packages/trpc/src/routers/k8s/errors/index.ts
+++ b/packages/trpc/src/routers/k8s/errors/index.ts
@@ -1,7 +1,35 @@
 import { TRPCError } from "@trpc/server";
 
-export const ERROR_K8S_CLIENT_NOT_INITIALIZED: TRPCError = {
-  name: "TRPCError",
-  code: "INTERNAL_SERVER_ERROR",
-  message: "K8sClient is not initialized.",
-};
+type TRPCErrorOptions = ConstructorParameters<typeof TRPCError>[0];
+
+// `cause` must be an Error subclass for tRPC v11's defaultFormatter to attach
+// it to the wire payload (`data.source` is read off cause). Plain objects are
+// stripped during serialization, so the client-side guard that suppresses the
+// OIDC re-auth redirect would silently miss the `source: "k8s"` discriminator.
+class K8sClientNotInitializedCause extends Error {
+  readonly source = "k8s" as const;
+  constructor(reason: string) {
+    super(reason);
+    this.name = "K8sClientNotInitializedCause";
+  }
+}
+
+// A missing/uninitialized KubeConfig is a server-side configuration failure
+// (e.g. no in-cluster context, missing CA data), not a session expiry or an
+// RBAC denial. Using INTERNAL_SERVER_ERROR (HTTP 500) preserves that meaning
+// so integration views in KRCI mode do not misclassify the failure as a
+// `getForbiddenError`-style permission denial. The `source: "k8s"` marker on
+// the cause keeps the client's auth-error handler from triggering an OIDC
+// re-auth redirect, which is the same protection FORBIDDEN previously
+// provided but without the HTTP-403 side effect.
+export function errorK8sClientNotInitialized(reason: string): TRPCErrorOptions {
+  return {
+    code: "INTERNAL_SERVER_ERROR",
+    message: reason,
+    cause: new K8sClientNotInitializedCause(reason),
+  } satisfies TRPCErrorOptions;
+}
+
+export const ERROR_K8S_CLIENT_NOT_INITIALIZED = errorK8sClientNotInitialized(
+  "Kubernetes client could not be initialized for this session."
+);

--- a/packages/trpc/src/routers/k8s/index.ts
+++ b/packages/trpc/src/routers/k8s/index.ts
@@ -7,6 +7,10 @@ import { k8sGetKubeConfig } from "./procedures/kubeconfig/index.js";
 import { k8sListProcedure } from "./procedures/basic/list/index.js";
 import { k8sGetResourcePermissions } from "./procedures/permissions/index.js";
 import { k8sUpdateItemProcedure } from "./procedures/basic/update/index.js";
+import { k8sScaleWorkloadProcedure } from "./procedures/workloads/scale/index.js";
+import { k8sRestartWorkloadProcedure } from "./procedures/workloads/restart/index.js";
+import { k8sListDeploymentRevisionsProcedure } from "./procedures/workloads/listRevisions/index.js";
+import { k8sRollbackDeploymentProcedure } from "./procedures/workloads/rollback/index.js";
 import { k8sWatchItemProcedure } from "./procedures/basic/watchItem/index.js";
 import { k8sWatchListProcedure } from "./procedures/basic/watchList/index.js";
 import { k8sPodLogsProcedure, k8sWatchPodLogsProcedure } from "./procedures/basic/logs/index.js";
@@ -41,6 +45,10 @@ export const k8sRouter = t.router({
   applyYaml: k8sApplyYamlProcedure,
   update: k8sUpdateItemProcedure,
   delete: k8sDeleteItemProcedure,
+  scaleWorkload: k8sScaleWorkloadProcedure,
+  restartWorkload: k8sRestartWorkloadProcedure,
+  listDeploymentRevisions: k8sListDeploymentRevisionsProcedure,
+  rollbackDeployment: k8sRollbackDeploymentProcedure,
   apiVersions: k8sGetApiVersions,
   itemPermissions: k8sGetResourcePermissions,
   kubeconfig: k8sGetKubeConfig,

--- a/packages/trpc/src/routers/k8s/procedures/permissions/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/permissions/index.test.ts
@@ -50,7 +50,6 @@ describe("k8sGetResourcePermissions", () => {
   it("should call createSelfSubjectAccessReview for each verb and return correct result", async () => {
     const input = {
       clusterName: "test-cluster",
-      apiVersion: "v1",
       group: "test.group.io",
       version: "v1",
       namespace: "test-namespace",
@@ -85,8 +84,7 @@ describe("k8sGetResourcePermissions", () => {
 
   it("should throw validation error for missing input fields", async () => {
     const invalidInput = {
-      clusterName: "test-cluster",
-      // apiVersion missing
+      // clusterName missing
       group: "test.group.io",
       version: "v1",
       namespace: "test-namespace",
@@ -102,7 +100,6 @@ describe("k8sGetResourcePermissions", () => {
   it("should return default reason if status.reason is missing", async () => {
     const input = {
       clusterName: "test-cluster",
-      apiVersion: "v1",
       group: "test.group.io",
       version: "v1",
       namespace: "test-namespace",
@@ -133,10 +130,43 @@ describe("k8sGetResourcePermissions", () => {
     });
   });
 
+  it("preserves an explicit empty-string reason from the SSARS response", async () => {
+    // K8s SelfSubjectAccessReview can legitimately return `reason: ""` (for
+    // example on an unconditioned allow). Using `||` would replace it with
+    // the synthetic "You cannot {verb} {plural}" fallback and surface a wrong
+    // tooltip in ButtonWithPermission; `??` must preserve the empty string.
+    const input = {
+      clusterName: "test-cluster",
+      group: "test.group.io",
+      version: "v1",
+      namespace: "test-namespace",
+      resourcePlural: "testresources",
+    };
+
+    const mockResponses = defaultPermissionsToCheck.map(() => ({
+      status: {
+        allowed: true,
+        reason: "",
+      },
+    }));
+
+    mockAuthApi.createSelfSubjectAccessReview.mockImplementation(({ body }) => {
+      const verb = body.spec.resourceAttributes.verb;
+      const index = defaultPermissionsToCheck.indexOf(verb);
+      return Promise.resolve(mockResponses[index]);
+    });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.itemPermissions(input);
+
+    defaultPermissionsToCheck.forEach((verb) => {
+      expect(result[verb]).toEqual({ allowed: true, reason: "" });
+    });
+  });
+
   it("should throw error if Kubernetes API call fails", async () => {
     const input = {
       clusterName: "test-cluster",
-      apiVersion: "v1",
       group: "test.group.io",
       version: "v1",
       namespace: "test-namespace",

--- a/packages/trpc/src/routers/k8s/procedures/permissions/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/permissions/index.ts
@@ -1,7 +1,7 @@
 import { AuthorizationV1Api } from "@kubernetes/client-node";
 import { V1SelfSubjectAccessReview } from "@kubernetes/client-node";
 import { z } from "zod";
-import { handleK8sError } from "../../utils/handleK8sError/index.js";
+import { rethrowOrHandleK8sError } from "../../utils/handleK8sError/index.js";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 import {
   defaultPermissions,
@@ -9,15 +9,12 @@ import {
   DefaultPermissionListCheckResult,
   k8sToRbacVerbMap,
 } from "@my-project/shared";
-import { ERROR_K8S_CLIENT_NOT_INITIALIZED } from "../../errors/index.js";
-import { TRPCError } from "@trpc/server";
-import { K8sClient } from "../../../../clients/k8s/index.js";
+import { getInitializedK8sClient } from "../../utils/getInitializedK8sClient/index.js";
 
 export const k8sGetResourcePermissions = protectedProcedure
   .input(
     z.object({
       clusterName: z.string(),
-      apiVersion: z.string(),
       group: z.string(),
       version: z.string(),
       namespace: z.string(),
@@ -26,12 +23,8 @@ export const k8sGetResourcePermissions = protectedProcedure
   )
   .mutation(async ({ input, ctx }) => {
     try {
-      const { apiVersion, group, version, namespace, resourcePlural } = input;
-      const k8sClient = new K8sClient(ctx.session);
-
-      if (!k8sClient.KubeConfig) {
-        throw new TRPCError(ERROR_K8S_CLIENT_NOT_INITIALIZED);
-      }
+      const { group, version, namespace, resourcePlural } = input;
+      const k8sClient = getInitializedK8sClient(ctx);
 
       const authApi = k8sClient.KubeConfig.makeApiClient(AuthorizationV1Api);
 
@@ -41,7 +34,11 @@ export const k8sGetResourcePermissions = protectedProcedure
         acc.push(
           authApi.createSelfSubjectAccessReview({
             body: {
-              apiVersion: `authorization.k8s.io/${apiVersion}`,
+              // The SSARS object's own GVK is always authorization.k8s.io/v1 — it
+              // identifies the review request, not the target resource. The target
+              // GVR is conveyed via spec.resourceAttributes below.
+              apiVersion: "authorization.k8s.io/v1",
+              kind: "SelfSubjectAccessReview",
               spec: {
                 resourceAttributes: {
                   verb: rbacVerb,
@@ -63,13 +60,13 @@ export const k8sGetResourcePermissions = protectedProcedure
         const verb = defaultPermissionsToCheck[index];
         acc[verb] = {
           allowed: res.status?.allowed || false,
-          reason: res.status?.reason || `You cannot ${verb} ${resourcePlural}`,
+          reason: res.status?.reason ?? `You cannot ${verb} ${resourcePlural}`,
         };
         return acc;
-      }, defaultPermissions);
+      }, structuredClone(defaultPermissions));
 
       return result;
     } catch (error) {
-      throw handleK8sError(error);
+      throw rethrowOrHandleK8sError(error);
     }
   });

--- a/packages/trpc/src/routers/k8s/procedures/workloads/listRevisions/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/listRevisions/index.test.ts
@@ -1,0 +1,266 @@
+import { createMockedContext } from "../../../../../__mocks__/context.js";
+import { createCaller } from "../../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
+import { K8sClient } from "../../../../../clients/k8s/index.js";
+
+vi.mock("../../../../../clients/k8s/index.js", () => ({ K8sClient: vi.fn() }));
+
+const makeDeployment = (uid = "dep-uid", revision = "5") => ({
+  metadata: { name: "foo", namespace: "ns", uid, annotations: { "deployment.kubernetes.io/revision": revision } },
+  spec: { selector: { matchLabels: { app: "foo" } } },
+});
+
+const makeRS = (revision: string, ownerUid = "dep-uid", suffix = "") => ({
+  metadata: {
+    name: `foo-${revision}${suffix}`,
+    uid: `rs-${revision}${suffix}`,
+    creationTimestamp: `2026-05-${10 + Number(revision || 0)}T00:00:00Z`,
+    annotations: { "deployment.kubernetes.io/revision": revision },
+    ownerReferences: [{ kind: "Deployment", uid: ownerUid, name: "foo", controller: true }],
+  },
+  spec: {
+    template: {
+      spec: {
+        containers: [{ image: `app:${revision}` }],
+      },
+    },
+  },
+});
+
+describe("k8sListDeploymentRevisions", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+  let mockK8s: { KubeConfig: {}; getResource: Mock; listAllResources: Mock };
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+    mockK8s = { KubeConfig: {}, getResource: vi.fn(), listAllResources: vi.fn() };
+    (K8sClient as unknown as Mock).mockImplementation(() => mockK8s);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it("filters by ownerReferences.uid, sorts DESC, caps at 10, flags current", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(makeDeployment("dep-uid", "5"));
+    mockK8s.listAllResources.mockResolvedValueOnce({
+      items: [
+        makeRS("1"),
+        makeRS("2"),
+        makeRS("3"),
+        makeRS("4"),
+        makeRS("5"),
+        makeRS("6"),
+        makeRS("7"),
+        makeRS("8"),
+        makeRS("9"),
+        makeRS("10"),
+        makeRS("11"),
+        makeRS("12"),
+        makeRS("3", "OTHER", "-foreign"),
+      ],
+    });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.listDeploymentRevisions({
+      namespace: "ns",
+      name: "foo",
+    });
+
+    expect(result).toHaveLength(10);
+    expect(result[0].revision).toBe(12);
+    expect(result[9].revision).toBe(3);
+    expect(result.find((r) => r.replicaSetName.endsWith("-foreign"))).toBeUndefined();
+    const current = result.find((r) => r.isCurrent);
+    expect(current?.revision).toBe(5);
+  });
+
+  it("returns an empty array when no ReplicaSets are owned by the deployment", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(makeDeployment());
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [makeRS("1", "OTHER")] });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.listDeploymentRevisions({
+      namespace: "ns",
+      name: "foo",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes ReplicaSets with non-numeric revision annotation", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(makeDeployment());
+    mockK8s.listAllResources.mockResolvedValueOnce({
+      items: [
+        makeRS("1"),
+        {
+          ...makeRS("nope"),
+          metadata: { ...makeRS("nope").metadata, annotations: { "deployment.kubernetes.io/revision": "abc" } },
+        },
+      ],
+    });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.listDeploymentRevisions({
+      namespace: "ns",
+      name: "foo",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].revision).toBe(1);
+  });
+
+  it("includes container images and replicaSetUid on each row", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(makeDeployment());
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [makeRS("1")] });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.listDeploymentRevisions({
+      namespace: "ns",
+      name: "foo",
+    });
+
+    expect(result[0]).toMatchObject({
+      revision: 1,
+      replicaSetName: "foo-1",
+      replicaSetUid: "rs-1",
+      images: ["app:1"],
+    });
+    expect(result[0].creationTimestamp).toBe("2026-05-11T00:00:00Z");
+  });
+
+  it("excludes RSes where the Deployment is a non-controlling owner", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(makeDeployment());
+    const rs = makeRS("1");
+    rs.metadata.ownerReferences = [{ kind: "Deployment", uid: "dep-uid", name: "foo", controller: false }];
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [rs] });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.listDeploymentRevisions({
+      namespace: "ns",
+      name: "foo",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("filters out empty image strings", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(makeDeployment());
+    const rs = makeRS("1");
+    rs.spec.template.spec.containers = [{ image: "app:1" }, { image: "" }, { image: undefined }] as Array<{
+      image: string;
+    }>;
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [rs] });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.listDeploymentRevisions({
+      namespace: "ns",
+      name: "foo",
+    });
+
+    expect(result[0].images).toEqual(["app:1"]);
+  });
+
+  it("throws NOT_FOUND when the Deployment has no uid in metadata", async () => {
+    mockK8s.getResource.mockResolvedValueOnce({
+      metadata: { name: "foo", namespace: "ns", annotations: { "deployment.kubernetes.io/revision": "1" } },
+    });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.listDeploymentRevisions({
+        namespace: "ns",
+        name: "foo",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mockK8s.listAllResources).not.toHaveBeenCalled();
+  });
+
+  it("propagates errors from getResource via handleK8sError", async () => {
+    mockK8s.getResource.mockRejectedValueOnce(new Error("kube-apiserver unreachable"));
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.listDeploymentRevisions({
+        namespace: "ns",
+        name: "foo",
+      })
+    ).rejects.toThrow();
+    expect(mockK8s.listAllResources).not.toHaveBeenCalled();
+  });
+
+  it("forwards labelSelector derived from spec.selector.matchLabels to listResource", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(makeDeployment());
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [makeRS("1")] });
+
+    const caller = createCaller(mockContext);
+    await caller.k8s.listDeploymentRevisions({
+      namespace: "ns",
+      name: "foo",
+    });
+
+    expect(mockK8s.listAllResources).toHaveBeenCalledWith(expect.anything(), "ns", "app=foo");
+  });
+
+  it("falls back to no labelSelector when Deployment has no spec.selector", async () => {
+    mockK8s.getResource.mockResolvedValueOnce({
+      metadata: {
+        name: "foo",
+        namespace: "ns",
+        uid: "dep-uid",
+        annotations: { "deployment.kubernetes.io/revision": "1" },
+      },
+    });
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [makeRS("1")] });
+
+    const caller = createCaller(mockContext);
+    await caller.k8s.listDeploymentRevisions({
+      namespace: "ns",
+      name: "foo",
+    });
+
+    expect(mockK8s.listAllResources).toHaveBeenCalledWith(expect.anything(), "ns", undefined);
+  });
+
+  it("propagates errors from listResource via handleK8sError", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(makeDeployment());
+    mockK8s.listAllResources.mockRejectedValueOnce(new Error("rs list failed"));
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.listDeploymentRevisions({
+        namespace: "ns",
+        name: "foo",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("correctly identifies isCurrent when Deployment revision annotation has leading zero ('010' vs '10')", async () => {
+    // String equality '010' === '10' is false, but numeric equality Number('010') === Number('10') is true.
+    mockK8s.getResource.mockResolvedValueOnce({
+      metadata: {
+        name: "foo",
+        namespace: "ns",
+        uid: "dep-uid",
+        // Non-standard: leading zero in the deployment annotation
+        annotations: { "deployment.kubernetes.io/revision": "010" },
+      },
+      spec: { selector: { matchLabels: { app: "foo" } } },
+    });
+    const rs10 = {
+      metadata: {
+        name: "foo-10",
+        uid: "rs-10",
+        creationTimestamp: "2026-05-20T00:00:00Z",
+        annotations: { "deployment.kubernetes.io/revision": "10" },
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", name: "foo", controller: true }],
+      },
+      spec: { template: { spec: { containers: [{ image: "app:10" }] } } },
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [rs10] });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.listDeploymentRevisions({ namespace: "ns", name: "foo" });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isCurrent).toBe(true);
+  });
+});

--- a/packages/trpc/src/routers/k8s/procedures/workloads/listRevisions/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/listRevisions/index.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { DEPLOYMENT_REVISION_ANNOTATION } from "@my-project/shared";
+import { protectedProcedure } from "../../../../../procedures/protected/index.js";
+import { getInitializedK8sClient } from "../../../utils/getInitializedK8sClient/index.js";
+import { rethrowOrHandleK8sError } from "../../../utils/handleK8sError/index.js";
+import { getDeploymentOwnedReplicaSets } from "../../../utils/getDeploymentOwnedReplicaSets/index.js";
+import { isControlledBy } from "../../../utils/isControlledBy/index.js";
+import type { DeploymentRevision } from "./types.js";
+
+// UI display cap for the rollback dialog. Rollback itself is not bounded by this
+// constant: the server fetches the owned-RS set via listAllResources (paginated up to
+// the default maxPages=20 cap) and accepts any valid UID in that set, even one whose
+// revision is older than the 10 we return here.
+const MAX_REVISIONS = 10;
+
+export const k8sListDeploymentRevisionsProcedure = protectedProcedure
+  .input(
+    z.object({
+      namespace: z.string(),
+      name: z.string(),
+    })
+  )
+  .query(async ({ input, ctx }): Promise<DeploymentRevision[]> => {
+    try {
+      const k8sClient = getInitializedK8sClient(ctx);
+
+      const { namespace, name } = input;
+
+      // Fetch the Deployment and the ReplicaSets it owns (narrowed by matchLabels to
+      // avoid the namespace-wide scan + ~500-item page limit).
+      const { deploymentUid, currentRevision, items } = await getDeploymentOwnedReplicaSets(k8sClient, name, namespace);
+
+      // Match rollback's stricter predicate: only the controlling Deployment counts.
+      const owned = items.filter((rs) => isControlledBy(rs.metadata.ownerReferences, "Deployment", deploymentUid));
+
+      // When the Deployment's revision annotation is missing, fall back to treating
+      // the RS with the highest revision number as the current one. This covers the
+      // edge case where the Deployment was patched out-of-band and lost its annotation.
+      const revisions = owned
+        .map((rs): DeploymentRevision | null => {
+          const revisionStr = rs.metadata.annotations?.[DEPLOYMENT_REVISION_ANNOTATION];
+          if (!revisionStr) return null;
+          const revision = Number(revisionStr);
+          if (!Number.isFinite(revision)) return null;
+          // Compare numerically to avoid false inequality from non-standard formatting
+          // (e.g. '010' vs '10'). Both `revision` (already parsed) and `currentRevision`
+          // are guarded: revision is Number.isFinite-checked above; currentRevision is
+          // re-parsed here so non-numeric annotations cannot produce a false positive.
+          const currentRevisionNum = Number(currentRevision);
+          const isCurrentNumeric =
+            currentRevision !== undefined && Number.isFinite(currentRevisionNum) && revision === currentRevisionNum;
+          return {
+            revision,
+            replicaSetName: rs.metadata.name,
+            replicaSetUid: rs.metadata.uid,
+            creationTimestamp: rs.metadata.creationTimestamp,
+            images: (rs.spec?.template?.spec?.containers ?? []).flatMap((c) => (c.image ? [c.image] : [])),
+            isCurrent: isCurrentNumeric,
+          };
+        })
+        .filter((r): r is DeploymentRevision => r !== null)
+        .sort((a, b) => b.revision - a.revision);
+
+      if (currentRevision === undefined && revisions.length > 0) {
+        revisions[0].isCurrent = true;
+      }
+
+      // Always include the current revision in the returned slice, even if its
+      // revision number falls outside the top MAX_REVISIONS (e.g. Deployment
+      // rolled back to an old revision after many newer revisions accumulated).
+      // Without this guard the dialog would show a window of recent history
+      // with no indication that the workload is actually at a much older
+      // revision, and the rollback UI would let the user select what the server
+      // will reject as the current revision.
+      const sliced = revisions.slice(0, MAX_REVISIONS);
+      const currentInSlice = sliced.some((r) => r.isCurrent);
+      if (!currentInSlice) {
+        const currentRevisionEntry = revisions.find((r) => r.isCurrent);
+        if (currentRevisionEntry) {
+          // Drop the oldest entry from the slice to keep the size at MAX_REVISIONS
+          // and append the current revision so it always renders in the dialog.
+          sliced.pop();
+          sliced.push(currentRevisionEntry);
+        }
+      }
+
+      return sliced;
+    } catch (error) {
+      throw rethrowOrHandleK8sError(error);
+    }
+  });

--- a/packages/trpc/src/routers/k8s/procedures/workloads/listRevisions/types.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/listRevisions/types.ts
@@ -1,0 +1,8 @@
+export interface DeploymentRevision {
+  revision: number;
+  replicaSetName: string;
+  replicaSetUid: string;
+  creationTimestamp: string;
+  images: string[];
+  isCurrent: boolean;
+}

--- a/packages/trpc/src/routers/k8s/procedures/workloads/restart/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/restart/index.test.ts
@@ -1,0 +1,119 @@
+import { createMockedContext } from "../../../../../__mocks__/context.js";
+import { createCaller } from "../../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
+import { K8sClient } from "../../../../../clients/k8s/index.js";
+
+vi.mock("../../../../../clients/k8s/index.js", () => ({ K8sClient: vi.fn() }));
+
+describe("k8sRestartWorkload", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+  let mockK8s: { KubeConfig: {}; patchResource: Mock };
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+    mockK8s = { KubeConfig: {}, patchResource: vi.fn() };
+    (K8sClient as unknown as Mock).mockImplementation(() => mockK8s);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  const config = {
+    group: "apps",
+    version: "v1",
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    singularName: "deployment",
+    pluralName: "deployments",
+  } as const;
+
+  it("patches the parent resource (no subresource) with the restartedAt annotation", async () => {
+    mockK8s.patchResource.mockResolvedValueOnce({});
+    const caller = createCaller(mockContext);
+
+    await caller.k8s.restartWorkload({
+      namespace: "ns",
+      name: "foo",
+      resourceConfig: config,
+    });
+
+    expect(mockK8s.patchResource).toHaveBeenCalledTimes(1);
+    const [cfgArg, nameArg, nsArg, bodyArg, patchTypeArg, subArg] = mockK8s.patchResource.mock.calls[0];
+    expect(cfgArg).toEqual(config);
+    expect(nameArg).toBe("foo");
+    expect(nsArg).toBe("ns");
+    expect(patchTypeArg).toBe("strategic");
+    expect(subArg).toBeUndefined();
+
+    const annotation = bodyArg.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"];
+    expect(typeof annotation).toBe("string");
+    expect(() => new Date(annotation).toISOString()).not.toThrow();
+  });
+
+  it("rejects non-restartable kinds (e.g. Job)", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.restartWorkload({
+        namespace: "ns",
+        name: "foo",
+        // @ts-expect-error intentionally invalid kind to assert runtime rejection
+        resourceConfig: { ...config, kind: "Job" },
+      })
+    ).rejects.toThrow(/kind must be one of/i);
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("propagates K8s API errors via handleK8sError", async () => {
+    mockK8s.patchResource.mockRejectedValueOnce(new Error("kube-apiserver unreachable"));
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.restartWorkload({
+        namespace: "ns",
+        name: "foo",
+        resourceConfig: config,
+      })
+    ).rejects.toThrow();
+  });
+
+  it("throws when KubeConfig is not initialized", async () => {
+    mockK8s.KubeConfig = null as unknown as {};
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.restartWorkload({
+        namespace: "ns",
+        name: "foo",
+        resourceConfig: config,
+      })
+    ).rejects.toThrow(/initialized/i);
+  });
+
+  it("throws BAD_REQUEST when group does not match canonical config for the kind", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.restartWorkload({
+        namespace: "ns",
+        name: "foo",
+        // Deployment with a wrong group — should be "apps"
+        resourceConfig: {
+          ...config,
+          group: "rbac.authorization.k8s.io",
+          apiVersion: "rbac.authorization.k8s.io/v1",
+          pluralName: "clusterroles",
+        },
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("throws BAD_REQUEST when pluralName does not match canonical config for the kind", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.restartWorkload({
+        namespace: "ns",
+        name: "foo",
+        // Deployment kind but pluralName pointing to a different resource
+        resourceConfig: { ...config, pluralName: "daemonsets" },
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+});

--- a/packages/trpc/src/routers/k8s/procedures/workloads/restart/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/restart/index.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import {
+  k8sResourceConfigSchema,
+  k8sDeploymentConfig,
+  k8sStatefulSetConfig,
+  k8sDaemonSetConfig,
+} from "@my-project/shared";
+import { protectedProcedure } from "../../../../../procedures/protected/index.js";
+import { getInitializedK8sClient } from "../../../utils/getInitializedK8sClient/index.js";
+import { rethrowOrHandleK8sError } from "../../../utils/handleK8sError/index.js";
+import { kindEnumErrorMap } from "../../../utils/kindEnumErrorMap/index.js";
+import { assertCanonicalResourceConfig } from "../../../utils/assertCanonicalResourceConfig/index.js";
+
+// Kinds that own pods via spec.template and respond to the rolling-restart annotation.
+// ReplicaSet is intentionally excluded — restart its owning Deployment instead.
+const RESTARTABLE_KIND_ENUM = ["Deployment", "StatefulSet", "DaemonSet"] as const;
+
+// Allowlist mapping each restartable kind to its canonical {group, version, pluralName}.
+const RESTARTABLE_KIND_CANONICAL = {
+  Deployment: {
+    group: k8sDeploymentConfig.group,
+    version: k8sDeploymentConfig.version,
+    pluralName: k8sDeploymentConfig.pluralName,
+  },
+  StatefulSet: {
+    group: k8sStatefulSetConfig.group,
+    version: k8sStatefulSetConfig.version,
+    pluralName: k8sStatefulSetConfig.pluralName,
+  },
+  DaemonSet: {
+    group: k8sDaemonSetConfig.group,
+    version: k8sDaemonSetConfig.version,
+    pluralName: k8sDaemonSetConfig.pluralName,
+  },
+} as const satisfies Record<
+  (typeof RESTARTABLE_KIND_ENUM)[number],
+  { group: string; version: string; pluralName: string }
+>;
+
+export const k8sRestartWorkloadProcedure = protectedProcedure
+  .input(
+    z.object({
+      namespace: z.string(),
+      name: z.string(),
+      resourceConfig: k8sResourceConfigSchema.extend({
+        kind: z.enum(RESTARTABLE_KIND_ENUM, { errorMap: kindEnumErrorMap(RESTARTABLE_KIND_ENUM) }),
+      }),
+    })
+  )
+  .mutation(async ({ input, ctx }) => {
+    try {
+      const k8sClient = getInitializedK8sClient(ctx);
+
+      const { resourceConfig, name, namespace } = input;
+
+      // Reject a valid kind paired with mismatched group/version/pluralName so the
+      // PATCH cannot be routed to an arbitrary resource.
+      assertCanonicalResourceConfig(resourceConfig, RESTARTABLE_KIND_CANONICAL);
+
+      const body = {
+        spec: {
+          template: {
+            metadata: {
+              annotations: {
+                "kubectl.kubernetes.io/restartedAt": new Date().toISOString(),
+              },
+            },
+          },
+        },
+      };
+
+      return await k8sClient.patchResource(resourceConfig, name, namespace, body, "strategic");
+    } catch (error) {
+      throw rethrowOrHandleK8sError(error);
+    }
+  });

--- a/packages/trpc/src/routers/k8s/procedures/workloads/rollback/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/rollback/index.test.ts
@@ -1,0 +1,363 @@
+import { createMockedContext } from "../../../../../__mocks__/context.js";
+import { createCaller } from "../../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
+import { K8sClient } from "../../../../../clients/k8s/index.js";
+
+vi.mock("../../../../../clients/k8s/index.js", () => ({ K8sClient: vi.fn() }));
+
+describe("k8sRollbackDeployment", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+  let mockK8s: {
+    KubeConfig: {};
+    getResource: Mock;
+    listAllResources: Mock;
+    patchResource: Mock;
+  };
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+    mockK8s = {
+      KubeConfig: {},
+      getResource: vi.fn(),
+      listAllResources: vi.fn(),
+      patchResource: vi.fn(),
+    };
+    (K8sClient as unknown as Mock).mockImplementation(() => mockK8s);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  const deployment = {
+    metadata: { name: "foo", namespace: "ns", uid: "dep-uid" },
+    spec: { selector: { matchLabels: { app: "foo" } } },
+  };
+
+  const ownedRS = {
+    metadata: {
+      uid: "rs-uid",
+      name: "foo-rs",
+      ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+    },
+    spec: { template: { spec: { containers: [{ image: "app:1" }] } } },
+  };
+
+  it("throws BAD_REQUEST when the target RS is already the current revision", async () => {
+    mockK8s.getResource.mockResolvedValueOnce({
+      metadata: {
+        name: "foo",
+        namespace: "ns",
+        uid: "dep-uid",
+        annotations: { "deployment.kubernetes.io/revision": "5" },
+      },
+      spec: { selector: { matchLabels: { app: "foo" } } },
+    });
+    const currentRS = {
+      metadata: {
+        uid: "rs-current",
+        name: "foo-rs-5",
+        annotations: { "deployment.kubernetes.io/revision": "5" },
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+      },
+      spec: { template: { spec: { containers: [{ image: "app:5" }] } } },
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [currentRS] });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "rs-current",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("patches the deployment with the target RS's spec.template", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(deployment);
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [ownedRS] });
+    mockK8s.patchResource.mockResolvedValueOnce({});
+
+    const caller = createCaller(mockContext);
+    await caller.k8s.rollbackDeployment({
+      namespace: "ns",
+      name: "foo",
+      replicaSetUid: "rs-uid",
+    });
+
+    expect(mockK8s.patchResource).toHaveBeenCalledTimes(1);
+    const [, , , body, patchType] = mockK8s.patchResource.mock.calls[0];
+    expect(body).toEqual({ spec: { template: ownedRS.spec.template } });
+    expect(patchType).toBe("strategic");
+
+    // Verify the labelSelector derived from spec.selector.matchLabels was passed.
+    expect(mockK8s.listAllResources).toHaveBeenCalledWith(expect.anything(), "ns", "app=foo");
+  });
+
+  it("propagates K8s API errors from patchResource via handleK8sError", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(deployment);
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [ownedRS] });
+    mockK8s.patchResource.mockRejectedValueOnce(new Error("upstream"));
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "rs-uid",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("falls back to no labelSelector when the Deployment has no spec.selector", async () => {
+    const deploymentNoSelector = { metadata: { name: "foo", namespace: "ns", uid: "dep-uid" } };
+    mockK8s.getResource.mockResolvedValueOnce(deploymentNoSelector);
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [ownedRS] });
+    mockK8s.patchResource.mockResolvedValueOnce({});
+
+    const caller = createCaller(mockContext);
+    await caller.k8s.rollbackDeployment({
+      namespace: "ns",
+      name: "foo",
+      replicaSetUid: "rs-uid",
+    });
+
+    expect(mockK8s.listAllResources).toHaveBeenCalledWith(expect.anything(), "ns", undefined);
+  });
+
+  it("throws NOT_FOUND when the target RS uid is missing in the namespace", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(deployment);
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [] });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "missing",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws NOT_FOUND when the target RS is owned by a different deployment", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(deployment);
+    const foreign = {
+      metadata: {
+        uid: "rs-uid",
+        name: "foo-rs",
+        ownerReferences: [{ kind: "Deployment", uid: "OTHER", controller: true }],
+      },
+      spec: { template: { spec: { containers: [] } } },
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [foreign] });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "rs-uid",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws NOT_FOUND when the Deployment has no uid in metadata", async () => {
+    mockK8s.getResource.mockResolvedValueOnce({ metadata: { name: "foo", namespace: "ns" } });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "rs-uid",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND", message: expect.stringMatching(/missing UID/i) });
+    expect(mockK8s.listAllResources).not.toHaveBeenCalled();
+  });
+
+  it("throws NOT_FOUND when the target RS has no spec.template", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(deployment);
+    const rsWithoutTemplate = {
+      metadata: {
+        uid: "rs-uid",
+        name: "foo-rs",
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+      },
+      spec: {},
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [rsWithoutTemplate] });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "rs-uid",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("throws NOT_FOUND when the matching RS is a non-controlling owner", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(deployment);
+    const nonControlling = {
+      metadata: {
+        uid: "rs-uid",
+        name: "foo-rs",
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: false }],
+      },
+      spec: { template: { spec: { containers: [] } } },
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [nonControlling] });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "rs-uid",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("propagates K8s API errors via handleK8sError", async () => {
+    mockK8s.getResource.mockResolvedValueOnce(deployment);
+    mockK8s.listAllResources.mockRejectedValueOnce(new Error("kube-apiserver unreachable"));
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({
+        namespace: "ns",
+        name: "foo",
+        replicaSetUid: "rs-uid",
+      })
+    ).rejects.toThrow();
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("blocks rollback when Deployment annotation is '010' and RS annotation is '10' (numeric normalisation)", async () => {
+    // Deployment stores the revision as '010' (leading zero); RS stores it as '10'.
+    // String equality would consider them different and allow the rollback — numeric
+    // comparison must normalise both to 10 and block it.
+    mockK8s.getResource.mockResolvedValueOnce({
+      metadata: {
+        name: "foo",
+        namespace: "ns",
+        uid: "dep-uid",
+        annotations: { "deployment.kubernetes.io/revision": "010" },
+      },
+      spec: { selector: { matchLabels: { app: "foo" } } },
+    });
+    const currentRS = {
+      metadata: {
+        uid: "rs-current",
+        name: "foo-rs-10",
+        annotations: { "deployment.kubernetes.io/revision": "10" },
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+      },
+      spec: { template: { spec: { containers: [{ image: "app:10" }] } } },
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [currentRS] });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({ namespace: "ns", name: "foo", replicaSetUid: "rs-current" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("blocks rollback when RS annotation is '010' and Deployment annotation is '10' (numeric normalisation, reversed)", async () => {
+    // The reverse: RS has the leading zero. Both still represent revision 10.
+    mockK8s.getResource.mockResolvedValueOnce({
+      metadata: {
+        name: "foo",
+        namespace: "ns",
+        uid: "dep-uid",
+        annotations: { "deployment.kubernetes.io/revision": "10" },
+      },
+      spec: { selector: { matchLabels: { app: "foo" } } },
+    });
+    const currentRS = {
+      metadata: {
+        uid: "rs-current",
+        name: "foo-rs-10",
+        annotations: { "deployment.kubernetes.io/revision": "010" },
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+      },
+      spec: { template: { spec: { containers: [{ image: "app:10" }] } } },
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [currentRS] });
+
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.rollbackDeployment({ namespace: "ns", name: "foo", replicaSetUid: "rs-current" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("throws BAD_REQUEST when currentRevision is undefined and target is the highest-revision RS (fallback B)", async () => {
+    // Deployment has no revision annotation — the guard should fall back to highest-revision RS.
+    mockK8s.getResource.mockResolvedValueOnce({
+      metadata: { name: "foo", namespace: "ns", uid: "dep-uid" },
+      spec: { selector: { matchLabels: { app: "foo" } } },
+    });
+    const rs3 = {
+      metadata: {
+        uid: "rs-3",
+        name: "foo-rs-3",
+        annotations: { "deployment.kubernetes.io/revision": "3" },
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+      },
+      spec: { template: { spec: { containers: [{ image: "app:3" }] } } },
+    };
+    const rs2 = {
+      metadata: {
+        uid: "rs-2",
+        name: "foo-rs-2",
+        annotations: { "deployment.kubernetes.io/revision": "2" },
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+      },
+      spec: { template: { spec: { containers: [{ image: "app:2" }] } } },
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [rs3, rs2] });
+
+    const caller = createCaller(mockContext);
+    // rs-3 is the highest revision RS — rolling back to it is a no-op
+    await expect(
+      caller.k8s.rollbackDeployment({ namespace: "ns", name: "foo", replicaSetUid: "rs-3" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("allows rollback when currentRevision is undefined and target is NOT the highest-revision RS (fallback B)", async () => {
+    mockK8s.getResource.mockResolvedValueOnce({
+      metadata: { name: "foo", namespace: "ns", uid: "dep-uid" },
+      spec: { selector: { matchLabels: { app: "foo" } } },
+    });
+    const rs3 = {
+      metadata: {
+        uid: "rs-3",
+        name: "foo-rs-3",
+        annotations: { "deployment.kubernetes.io/revision": "3" },
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+      },
+      spec: { template: { spec: { containers: [{ image: "app:3" }] } } },
+    };
+    const rs2 = {
+      metadata: {
+        uid: "rs-2",
+        name: "foo-rs-2",
+        annotations: { "deployment.kubernetes.io/revision": "2" },
+        ownerReferences: [{ kind: "Deployment", uid: "dep-uid", controller: true }],
+      },
+      spec: { template: { spec: { containers: [{ image: "app:2" }] } } },
+    };
+    mockK8s.listAllResources.mockResolvedValueOnce({ items: [rs3, rs2] });
+    mockK8s.patchResource.mockResolvedValueOnce({});
+
+    const caller = createCaller(mockContext);
+    // rs-2 is an older revision — rolling back to it should be allowed
+    await caller.k8s.rollbackDeployment({ namespace: "ns", name: "foo", replicaSetUid: "rs-2" });
+    expect(mockK8s.patchResource).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/trpc/src/routers/k8s/procedures/workloads/rollback/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/rollback/index.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { DEPLOYMENT_REVISION_ANNOTATION, k8sDeploymentConfig } from "@my-project/shared";
+import { protectedProcedure } from "../../../../../procedures/protected/index.js";
+import { getInitializedK8sClient } from "../../../utils/getInitializedK8sClient/index.js";
+import { rethrowOrHandleK8sError } from "../../../utils/handleK8sError/index.js";
+import { getDeploymentOwnedReplicaSets } from "../../../utils/getDeploymentOwnedReplicaSets/index.js";
+import { isControlledBy } from "../../../utils/isControlledBy/index.js";
+
+export const k8sRollbackDeploymentProcedure = protectedProcedure
+  .input(
+    z.object({
+      namespace: z.string(),
+      name: z.string(),
+      replicaSetUid: z.string(),
+    })
+  )
+  .mutation(async ({ input, ctx }) => {
+    try {
+      const k8sClient = getInitializedK8sClient(ctx);
+
+      const { namespace, name, replicaSetUid } = input;
+
+      // Fetch the Deployment and the ReplicaSets it owns (narrowed by matchLabels,
+      // following the continue token so a long revision history is not truncated).
+      const { deploymentUid, currentRevision, items, listContinue } = await getDeploymentOwnedReplicaSets(
+        k8sClient,
+        name,
+        namespace
+      );
+
+      // Match the RS by uid AND require the Deployment to be its controlling owner.
+      const target = items.find(
+        (rs) =>
+          rs.metadata.uid === replicaSetUid && isControlledBy(rs.metadata.ownerReferences, "Deployment", deploymentUid)
+      );
+
+      if (!target || !target.spec?.template) {
+        // listAllResources caps pagination at maxPages (currently 20 × ~500 items).
+        // When the cap was hit, the continue token is non-empty —
+        // surface that to operators rather than mislead them with NOT_FOUND.
+        if (listContinue) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Deployment has more revision history than this UI can scan. Run `kubectl rollout undo` directly, or delete old ReplicaSets first.",
+          });
+        }
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Target revision no longer exists or is not owned by this deployment",
+        });
+      }
+
+      // Reject rollback to the active revision: PATCHing the Deployment with its own
+      // template wastes an API call, churns the controller, and gives no UX signal.
+      // The UI marks the current RS as isCurrent, so this guard only catches stale
+      // requests (cache replay, two open tabs racing).
+      //
+      // All revision comparisons use Number() to normalise annotation values like '010'
+      // and '10' to the same integer (10), mirroring the numeric comparison in
+      // listRevisions so both paths agree on which RS is current.
+      //
+      // Primary check: compare revision annotations when both are present.
+      // Fallback A: when currentRevision is known but targetRevision is absent, compare by UID.
+      // Fallback B: when currentRevision is absent from the Deployment (annotation stripped
+      //   out-of-band), identify the controller-owned RS with the highest revision number
+      //   as the de-facto active RS and block rollback to it, mirroring the same heuristic
+      //   used by listRevisions to flag isCurrent.
+
+      // Parse currentRevision once; NaN when undefined/non-numeric so isFinite guards below fail safely.
+      const currentRevisionNum = currentRevision !== undefined ? Number(currentRevision) : NaN;
+
+      const targetRevision = target.metadata.annotations?.[DEPLOYMENT_REVISION_ANNOTATION];
+      const targetRevisionNum = targetRevision !== undefined ? Number(targetRevision) : NaN;
+      const isCurrentByRevision =
+        Number.isFinite(targetRevisionNum) &&
+        Number.isFinite(currentRevisionNum) &&
+        targetRevisionNum === currentRevisionNum;
+
+      // Fallback A: when targetRevision annotation is missing but currentRevision is known,
+      // check by UID whether the target RS is the same object as the currently-active RS.
+      // Only do this when currentRevision is defined — otherwise the annotation lookup
+      // `annotation === undefined` would match every annotation-less RS.
+      const activeRsByUid = Number.isFinite(currentRevisionNum)
+        ? items.find(
+            (rs) =>
+              Number(rs.metadata.annotations?.[DEPLOYMENT_REVISION_ANNOTATION]) === currentRevisionNum &&
+              isControlledBy(rs.metadata.ownerReferences, "Deployment", deploymentUid)
+          )
+        : undefined;
+      const isCurrentByUid = activeRsByUid !== undefined && activeRsByUid.metadata.uid === replicaSetUid;
+
+      // Fallback B: when the Deployment has no revision annotation, use the RS with the
+      // highest numeric revision among controller-owned RSes as the active one.
+      let isCurrentByHighestRevision = false;
+      if (currentRevision === undefined) {
+        const ownedWithRevisions = items
+          .filter((rs) => isControlledBy(rs.metadata.ownerReferences, "Deployment", deploymentUid))
+          .map((rs) => ({
+            uid: rs.metadata.uid,
+            revision: Number(rs.metadata.annotations?.[DEPLOYMENT_REVISION_ANNOTATION] ?? NaN),
+          }))
+          .filter((r) => Number.isFinite(r.revision));
+        if (ownedWithRevisions.length > 0) {
+          const maxRevision = Math.max(...ownedWithRevisions.map((r) => r.revision));
+          const highestRevisionRS = ownedWithRevisions.find((r) => r.revision === maxRevision);
+          isCurrentByHighestRevision = highestRevisionRS?.uid === replicaSetUid;
+        }
+      }
+
+      if (isCurrentByRevision || isCurrentByUid || isCurrentByHighestRevision) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Target revision is already the current revision of this Deployment",
+        });
+      }
+
+      const template = structuredClone(target.spec.template) as {
+        metadata?: { labels?: Record<string, string> };
+      };
+      if (template.metadata?.labels) {
+        delete template.metadata.labels["pod-template-hash"];
+      }
+
+      return await k8sClient.patchResource(k8sDeploymentConfig, name, namespace, { spec: { template } }, "strategic");
+    } catch (error) {
+      throw rethrowOrHandleK8sError(error);
+    }
+  });

--- a/packages/trpc/src/routers/k8s/procedures/workloads/scale/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/scale/index.test.ts
@@ -1,0 +1,214 @@
+import { createMockedContext } from "../../../../../__mocks__/context.js";
+import { createCaller } from "../../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
+import { K8sClient } from "../../../../../clients/k8s/index.js";
+
+vi.mock("../../../../../clients/k8s/index.js", () => ({
+  K8sClient: vi.fn(),
+}));
+
+describe("k8sScaleWorkload", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+  let mockK8s: { KubeConfig: {}; patchResource: Mock };
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+    mockK8s = { KubeConfig: {}, patchResource: vi.fn() };
+    (K8sClient as unknown as Mock).mockImplementation(() => mockK8s);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const config = {
+    group: "apps",
+    version: "v1",
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    singularName: "deployment",
+    pluralName: "deployments",
+  } as const;
+
+  it("calls patchResource with /scale subresource and merge patch", async () => {
+    mockK8s.patchResource.mockResolvedValueOnce({ spec: { replicas: 5 } });
+    const caller = createCaller(mockContext);
+
+    await caller.k8s.scaleWorkload({
+      namespace: "ns",
+      name: "foo",
+      resourceConfig: config,
+      replicas: 5,
+    });
+
+    // K8s /scale subresource does not support strategic-merge-patch; use merge-patch.
+    expect(mockK8s.patchResource).toHaveBeenCalledWith(
+      config,
+      "foo",
+      "ns",
+      { spec: { replicas: 5 } },
+      "merge",
+      "scale"
+    );
+  });
+
+  it("rejects negative replicas", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.scaleWorkload({
+        namespace: "ns",
+        name: "foo",
+        resourceConfig: config,
+        replicas: -1,
+      })
+    ).rejects.toThrow(/greater than or equal to 0|too_small/i);
+  });
+
+  it("rejects fractional replicas (e.g. 3.5)", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.scaleWorkload({
+        namespace: "ns",
+        name: "foo",
+        resourceConfig: config,
+        replicas: 3.5,
+      })
+    ).rejects.toThrow(/integer|invalid_type/i);
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("rejects replicas above the upper bound (10001)", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.scaleWorkload({
+        namespace: "ns",
+        name: "foo",
+        resourceConfig: config,
+        replicas: 10001,
+      })
+    ).rejects.toThrow(/less than or equal to 10000|too_big/i);
+  });
+
+  it("accepts replicas = 0 (suspend) and forwards to patchResource", async () => {
+    mockK8s.patchResource.mockResolvedValueOnce({ spec: { replicas: 0 } });
+    const caller = createCaller(mockContext);
+
+    await caller.k8s.scaleWorkload({
+      namespace: "ns",
+      name: "foo",
+      resourceConfig: config,
+      replicas: 0,
+    });
+
+    expect(mockK8s.patchResource).toHaveBeenCalledWith(
+      config,
+      "foo",
+      "ns",
+      { spec: { replicas: 0 } },
+      "merge",
+      "scale"
+    );
+  });
+
+  it("accepts replicas = 10000 (upper bound) and forwards to patchResource", async () => {
+    mockK8s.patchResource.mockResolvedValueOnce({ spec: { replicas: 10000 } });
+    const caller = createCaller(mockContext);
+
+    await caller.k8s.scaleWorkload({
+      namespace: "ns",
+      name: "foo",
+      resourceConfig: config,
+      replicas: 10000,
+    });
+
+    expect(mockK8s.patchResource).toHaveBeenCalledWith(
+      config,
+      "foo",
+      "ns",
+      { spec: { replicas: 10000 } },
+      "merge",
+      "scale"
+    );
+  });
+
+  it("rejects non-scalable kinds (e.g. DaemonSet)", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.scaleWorkload({
+        namespace: "ns",
+        name: "foo",
+        // @ts-expect-error intentionally invalid kind to assert runtime rejection
+        resourceConfig: { ...config, kind: "DaemonSet" },
+        replicas: 3,
+      })
+    ).rejects.toThrow(/kind must be one of/i);
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("throws when KubeConfig is not initialized", async () => {
+    mockK8s.KubeConfig = null as unknown as {};
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.scaleWorkload({
+        namespace: "ns",
+        name: "foo",
+        resourceConfig: config,
+        replicas: 3,
+      })
+    ).rejects.toThrow(/initialized/i);
+  });
+
+  it("throws BAD_REQUEST when group does not match canonical config for the kind", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.scaleWorkload({
+        namespace: "ns",
+        name: "foo",
+        // Deployment with a wrong group — should be "apps"
+        resourceConfig: {
+          ...config,
+          group: "rbac.authorization.k8s.io",
+          apiVersion: "rbac.authorization.k8s.io/v1",
+          pluralName: "clusterroles",
+        },
+        replicas: 3,
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("throws BAD_REQUEST when pluralName does not match canonical config for the kind", async () => {
+    const caller = createCaller(mockContext);
+    await expect(
+      caller.k8s.scaleWorkload({
+        namespace: "ns",
+        name: "foo",
+        // Deployment kind but pluralName pointing to a different resource
+        resourceConfig: { ...config, pluralName: "statefulsets" },
+        replicas: 3,
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(mockK8s.patchResource).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid ReplicationController config (core group)", async () => {
+    mockK8s.patchResource.mockResolvedValueOnce({ spec: { replicas: 2 } });
+    const caller = createCaller(mockContext);
+
+    await caller.k8s.scaleWorkload({
+      namespace: "ns",
+      name: "foo",
+      resourceConfig: {
+        group: "",
+        version: "v1",
+        apiVersion: "v1",
+        kind: "ReplicationController",
+        singularName: "replicationcontroller",
+        pluralName: "replicationcontrollers",
+      },
+      replicas: 2,
+    });
+
+    expect(mockK8s.patchResource).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/trpc/src/routers/k8s/procedures/workloads/scale/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/workloads/scale/index.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import {
+  k8sResourceConfigSchema,
+  k8sDeploymentConfig,
+  k8sStatefulSetConfig,
+  k8sReplicaSetConfig,
+} from "@my-project/shared";
+import { protectedProcedure } from "../../../../../procedures/protected/index.js";
+import { getInitializedK8sClient } from "../../../utils/getInitializedK8sClient/index.js";
+import { rethrowOrHandleK8sError } from "../../../utils/handleK8sError/index.js";
+import { kindEnumErrorMap } from "../../../utils/kindEnumErrorMap/index.js";
+import { assertCanonicalResourceConfig } from "../../../utils/assertCanonicalResourceConfig/index.js";
+
+const MAX_REPLICAS = 10_000;
+
+// Kinds that expose the /scale subresource per the Kubernetes API.
+// Other kinds (DaemonSet, Job, etc.) will 404 against /scale.
+const SCALABLE_KIND_ENUM = ["Deployment", "StatefulSet", "ReplicaSet", "ReplicationController"] as const;
+
+// Allowlist mapping each scalable kind to its canonical {group, version, pluralName}.
+// ReplicationController lives in the core API group (empty group string).
+const SCALABLE_KIND_CANONICAL = {
+  Deployment: {
+    group: k8sDeploymentConfig.group,
+    version: k8sDeploymentConfig.version,
+    pluralName: k8sDeploymentConfig.pluralName,
+  },
+  StatefulSet: {
+    group: k8sStatefulSetConfig.group,
+    version: k8sStatefulSetConfig.version,
+    pluralName: k8sStatefulSetConfig.pluralName,
+  },
+  ReplicaSet: {
+    group: k8sReplicaSetConfig.group,
+    version: k8sReplicaSetConfig.version,
+    pluralName: k8sReplicaSetConfig.pluralName,
+  },
+  // Core API group: group is empty string, apiVersion is "v1"
+  ReplicationController: { group: "", version: "v1", pluralName: "replicationcontrollers" },
+} as const satisfies Record<
+  (typeof SCALABLE_KIND_ENUM)[number],
+  { group: string; version: string; pluralName: string }
+>;
+
+export const k8sScaleWorkloadProcedure = protectedProcedure
+  .input(
+    z.object({
+      namespace: z.string(),
+      name: z.string(),
+      resourceConfig: k8sResourceConfigSchema.extend({
+        kind: z.enum(SCALABLE_KIND_ENUM, { errorMap: kindEnumErrorMap(SCALABLE_KIND_ENUM) }),
+      }),
+      replicas: z.number().int().min(0).max(MAX_REPLICAS),
+    })
+  )
+  .mutation(async ({ input, ctx }) => {
+    try {
+      const k8sClient = getInitializedK8sClient(ctx);
+
+      const { resourceConfig, name, namespace, replicas } = input;
+
+      // Reject a valid kind paired with mismatched group/version/pluralName so the
+      // PATCH cannot be routed to an arbitrary resource.
+      assertCanonicalResourceConfig(resourceConfig, SCALABLE_KIND_CANONICAL);
+
+      // The /scale subresource accepts only merge-patch or json-patch —
+      // strategic merge patch is not supported on subresources (K8s returns 415).
+      return await k8sClient.patchResource(resourceConfig, name, namespace, { spec: { replicas } }, "merge", "scale");
+    } catch (error) {
+      throw rethrowOrHandleK8sError(error);
+    }
+  });

--- a/packages/trpc/src/routers/k8s/utils/assertCanonicalResourceConfig/index.test.ts
+++ b/packages/trpc/src/routers/k8s/utils/assertCanonicalResourceConfig/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { assertCanonicalResourceConfig } from "./index.js";
+
+const CANONICAL = {
+  Deployment: { group: "apps", version: "v1", pluralName: "deployments" },
+  ReplicationController: { group: "", version: "v1", pluralName: "replicationcontrollers" },
+} as const;
+
+describe("assertCanonicalResourceConfig", () => {
+  it("passes when group/version/pluralName match the canonical entry for the kind", () => {
+    expect(() =>
+      assertCanonicalResourceConfig(
+        { kind: "Deployment", group: "apps", version: "v1", pluralName: "deployments" },
+        CANONICAL
+      )
+    ).not.toThrow();
+  });
+
+  it("passes for a core-group kind whose canonical group is the empty string", () => {
+    expect(() =>
+      assertCanonicalResourceConfig(
+        { kind: "ReplicationController", group: "", version: "v1", pluralName: "replicationcontrollers" },
+        CANONICAL
+      )
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["group", { kind: "Deployment", group: "rbac.authorization.k8s.io", version: "v1", pluralName: "deployments" }],
+    ["version", { kind: "Deployment", group: "apps", version: "v1beta1", pluralName: "deployments" }],
+    ["pluralName", { kind: "Deployment", group: "apps", version: "v1", pluralName: "secrets" }],
+  ] as const)("throws BAD_REQUEST when %s does not match the canonical entry", (_field, resourceConfig) => {
+    expect(() => assertCanonicalResourceConfig(resourceConfig, CANONICAL)).toThrow(TRPCError);
+    expect(() => assertCanonicalResourceConfig(resourceConfig, CANONICAL)).toThrow(
+      /does not match the canonical values/
+    );
+  });
+});

--- a/packages/trpc/src/routers/k8s/utils/assertCanonicalResourceConfig/index.ts
+++ b/packages/trpc/src/routers/k8s/utils/assertCanonicalResourceConfig/index.ts
@@ -1,0 +1,31 @@
+import { TRPCError } from "@trpc/server";
+
+interface CanonicalIdentity {
+  group: string;
+  version: string;
+  pluralName: string;
+}
+
+/**
+ * Validates that a client-supplied resourceConfig's group/version/pluralName match
+ * the canonical values for its kind. Workload-action procedures (scale, restart)
+ * accept the kind via a Zod enum but still receive group/version/pluralName from the
+ * client; without this check a caller could pass a valid kind while pointing the PATCH
+ * at an arbitrary resource. Throws TRPCError BAD_REQUEST on any mismatch.
+ */
+export function assertCanonicalResourceConfig<Kind extends string>(
+  resourceConfig: CanonicalIdentity & { kind: Kind },
+  canonicalMap: Record<Kind, CanonicalIdentity>
+): void {
+  const canonical = canonicalMap[resourceConfig.kind];
+  if (
+    resourceConfig.group !== canonical.group ||
+    resourceConfig.version !== canonical.version ||
+    resourceConfig.pluralName !== canonical.pluralName
+  ) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `resourceConfig group/version/pluralName does not match the canonical values for kind "${resourceConfig.kind}"`,
+    });
+  }
+}

--- a/packages/trpc/src/routers/k8s/utils/getDeploymentOwnedReplicaSets/index.ts
+++ b/packages/trpc/src/routers/k8s/utils/getDeploymentOwnedReplicaSets/index.ts
@@ -1,0 +1,65 @@
+import { TRPCError } from "@trpc/server";
+import { DEPLOYMENT_REVISION_ANNOTATION, k8sDeploymentConfig, k8sReplicaSetConfig } from "@my-project/shared";
+import type { InitializedK8sClient } from "../getInitializedK8sClient/index.js";
+import { createLabelSelectorString } from "../createLabelSelectorString/index.js";
+
+export interface OwnedReplicaSet {
+  metadata: {
+    name: string;
+    uid: string;
+    creationTimestamp: string;
+    annotations?: Record<string, string>;
+    ownerReferences?: Array<{ kind?: string; uid?: string; controller?: boolean }>;
+  };
+  spec?: {
+    template?: {
+      metadata?: { labels?: Record<string, string> };
+      spec?: { containers?: Array<{ image?: string }> };
+    };
+  };
+}
+
+export interface DeploymentOwnedReplicaSets {
+  deploymentUid: string;
+  /** The Deployment's `deployment.kubernetes.io/revision` annotation, if present. */
+  currentRevision: string | undefined;
+  items: OwnedReplicaSet[];
+  /** Pagination continue token when `listAllResources` hit its maxPages cap. */
+  listContinue: string | undefined;
+}
+
+/**
+ * Fetches a Deployment and the ReplicaSets selected by its
+ * `spec.selector.matchLabels`, the shared first half of both `rollback` and
+ * `listRevisions`. Narrowing the RS list by the Deployment's matchLabels avoids a
+ * namespace-wide scan; callers still apply {@link isControlledBy} to confirm
+ * ownership before acting on a ReplicaSet. Throws TRPCError NOT_FOUND when the
+ * Deployment is missing or has no UID.
+ */
+export async function getDeploymentOwnedReplicaSets(
+  k8sClient: InitializedK8sClient,
+  name: string,
+  namespace: string
+): Promise<DeploymentOwnedReplicaSets> {
+  const deployment = (await k8sClient.getResource(k8sDeploymentConfig, name, namespace)) as {
+    metadata: { uid?: string; annotations?: Record<string, string> };
+    spec?: { selector?: { matchLabels?: Record<string, string> } };
+  };
+  const deploymentUid = deployment.metadata?.uid;
+  if (!deploymentUid) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Deployment not found or missing UID",
+    });
+  }
+
+  const currentRevision = deployment.metadata?.annotations?.[DEPLOYMENT_REVISION_ANNOTATION];
+  const labelSelector = createLabelSelectorString(deployment.spec?.selector?.matchLabels);
+
+  const list = (await k8sClient.listAllResources(k8sReplicaSetConfig, namespace, labelSelector)) as {
+    items: OwnedReplicaSet[];
+    metadata?: { continue?: string };
+  };
+
+  return { deploymentUid, currentRevision, items: list.items, listContinue: list.metadata?.continue };
+}

--- a/packages/trpc/src/routers/k8s/utils/getInitializedK8sClient/index.test.ts
+++ b/packages/trpc/src/routers/k8s/utils/getInitializedK8sClient/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { K8sClient } from "../../../../clients/k8s/index.js";
+import { getInitializedK8sClient } from "./index.js";
+import type { CustomSession } from "../../../../context/types.js";
+
+vi.mock("../../../../clients/k8s/index.js", () => ({
+  K8sClient: vi.fn(),
+}));
+
+describe("getInitializedK8sClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the K8sClient when KubeConfig is initialized", () => {
+    const instance = { KubeConfig: {} };
+    (K8sClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => instance);
+
+    const ctx = { session: {} as CustomSession };
+    expect(getInitializedK8sClient(ctx)).toBe(instance);
+  });
+
+  it("throws a TRPCError when KubeConfig is null", () => {
+    (K8sClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({ KubeConfig: null }));
+
+    const ctx = { session: {} as CustomSession };
+    expect(() => getInitializedK8sClient(ctx)).toThrow(TRPCError);
+  });
+
+  it("forwards the session through to the K8sClient constructor", () => {
+    const ctorSpy = vi.fn(() => ({ KubeConfig: {} }));
+    (K8sClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(ctorSpy);
+
+    const session = { foo: "bar" } as unknown as CustomSession;
+    getInitializedK8sClient({ session });
+    expect(ctorSpy).toHaveBeenCalledWith(session);
+  });
+});

--- a/packages/trpc/src/routers/k8s/utils/getInitializedK8sClient/index.ts
+++ b/packages/trpc/src/routers/k8s/utils/getInitializedK8sClient/index.ts
@@ -1,0 +1,31 @@
+import { KubeConfig } from "@kubernetes/client-node";
+import { TRPCError } from "@trpc/server";
+import { K8sClient } from "../../../../clients/k8s/index.js";
+import { ERROR_K8S_CLIENT_NOT_INITIALIZED, errorK8sClientNotInitialized } from "../../errors/index.js";
+import type { TRPCContext } from "../../../../context/types.js";
+
+// Narrowed view of K8sClient with a guaranteed non-null KubeConfig — the factory
+// throws if it's null, so consumers can drop the `!` assertion on every access.
+export type InitializedK8sClient = K8sClient & { KubeConfig: KubeConfig };
+
+/**
+ * Builds a K8sClient from the request's session and asserts that the underlying
+ * KubeConfig was loaded. Throws a TRPCError matching the standard
+ * ERROR_K8S_CLIENT_NOT_INITIALIZED shape when the user has no session/token.
+ *
+ * Use at the start of any tRPC procedure that needs a K8sClient. Replaces the
+ * repeating pattern:
+ *   const k8sClient = new K8sClient(ctx.session);
+ *   if (!k8sClient.KubeConfig) throw new TRPCError(ERROR_K8S_CLIENT_NOT_INITIALIZED);
+ */
+export function getInitializedK8sClient(ctx: Pick<TRPCContext, "session">): InitializedK8sClient {
+  const k8sClient = new K8sClient(ctx.session);
+  if (!k8sClient.KubeConfig) {
+    throw new TRPCError(
+      k8sClient.kubeConfigInitError
+        ? errorK8sClientNotInitialized(k8sClient.kubeConfigInitError)
+        : ERROR_K8S_CLIENT_NOT_INITIALIZED
+    );
+  }
+  return k8sClient as InitializedK8sClient;
+}

--- a/packages/trpc/src/routers/k8s/utils/handleK8sError/index.ts
+++ b/packages/trpc/src/routers/k8s/utils/handleK8sError/index.ts
@@ -108,3 +108,15 @@ export function handleK8sError(error: unknown): TRPCError {
     code: "INTERNAL_SERVER_ERROR",
   });
 }
+
+/**
+ * Re-throw a TRPCError untouched (so explicit NOT_FOUND/BAD_REQUEST from a procedure
+ * survives) or map any other unknown error through handleK8sError. Use in the catch
+ * block of procedures that throw their own TRPCErrors alongside calling the K8s API.
+ */
+export function rethrowOrHandleK8sError(error: unknown): never {
+  if (error instanceof TRPCError) {
+    throw error;
+  }
+  throw handleK8sError(error);
+}

--- a/packages/trpc/src/routers/k8s/utils/isControlledBy/index.ts
+++ b/packages/trpc/src/routers/k8s/utils/isControlledBy/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Predicate that returns true iff `ownerRefs` contains an ownerReference with
+ * controller:true matching the given kind and uid. Per the Kubernetes
+ * ownerReferences spec at most one entry has controller:true, and rollback /
+ * listRevisions both need to ensure the RS they touch is unambiguously owned
+ * by the Deployment under inspection (not by an unrelated RS that happens to
+ * share labels).
+ */
+export function isControlledBy(
+  ownerRefs: ReadonlyArray<{ kind?: string; uid?: string; controller?: boolean }> | undefined,
+  kind: string,
+  uid: string
+): boolean {
+  return ownerRefs?.some((o) => o.controller === true && o.kind === kind && o.uid === uid) ?? false;
+}

--- a/packages/trpc/src/routers/k8s/utils/kindEnumErrorMap/index.ts
+++ b/packages/trpc/src/routers/k8s/utils/kindEnumErrorMap/index.ts
@@ -1,0 +1,12 @@
+import type { z } from "zod";
+
+/**
+ * Builds a Zod errorMap that reports the allowed kind list when the provided
+ * kind is not in the workload-action allowlist. Use with `z.enum(KIND_TUPLE, { errorMap: kindEnumErrorMap(KIND_TUPLE) })`
+ * so the validation message points operators at the supported kinds.
+ */
+export function kindEnumErrorMap(allowedKinds: readonly string[]): z.ZodErrorMap {
+  return () => ({
+    message: `resourceConfig.kind must be one of: ${allowedKinds.join(", ")}`,
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
     dependencies:
       '@my-project/client':
         specifier: workspace:^
-        version: file:apps/client(@trpc/server@11.8.1(typescript@5.9.3))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(monaco-editor@0.55.1)(react-is@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        version: file:apps/client(@trpc/server@11.8.1(typescript@5.9.3))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(monaco-editor@0.55.1)(react-is@19.2.3)(solid-js@1.9.10)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@my-project/server':
         specifier: workspace:^
         version: link:apps/server
@@ -130,6 +130,9 @@ importers:
       '@radix-ui/react-separator':
         specifier: ^1.1.2
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slider':
+        specifier: ^1.3.6
+        version: 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
@@ -6195,7 +6198,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@my-project/client@file:apps/client(@trpc/server@11.8.1(typescript@5.9.3))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(monaco-editor@0.55.1)(react-is@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@my-project/client@file:apps/client(@trpc/server@11.8.1(typescript@5.9.3))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(monaco-editor@0.55.1)(react-is@19.2.3)(solid-js@1.9.10)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@melloware/react-logviewer': 6.3.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)
       '@monaco-editor/react': 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -7103,7 +7106,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -9897,7 +9900,7 @@ snapshots:
 
   recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.43.0


### PR DESCRIPTION
End-to-end UI for Custom Resource Definitions and their instances: shared CRDObject model, dynamic descriptor factory + YAML scaffold, generic CR list/detail (cluster + namespaced) driven by buildCRDescriptor, CRD detail page (NamesCard, VersionsCard, ScopeGroupConversionRow), and a "Custom Resources" sidebar group fed by useCRSidebarItems through a new collapsible-subgroup sidebar primitive.

Workload action controls (Scale, Restart, Rollback) wired into Deployment, StatefulSet, and DaemonSet detail pages via the descriptor actionsSlot. Server-side procedures (scaleWorkload, restartWorkload, rollbackDeployment, listDeploymentRevisions) use kind allowlists, targeted query-key invalidation, and controlling-owner + labelSelector predicates; K8sClient patchResource gains patchType + subresource params and getInitializedK8sClient factors out the init boilerplate.