### PR TITLE
EPMDEDP-16788: feat: enrich Kubernetes resource overview tabs and list descriptors

### DIFF
--- a/apps/client/src/k8s/api/groups/Core/Namespace/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/Core/Namespace/utils/getStatus/index.ts
@@ -1,0 +1,23 @@
+import { CircleCheck, LoaderCircle, ShieldQuestion } from "lucide-react";
+import type { Namespace } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+const isTerminating = (namespace: Namespace): boolean =>
+  namespace.status?.phase === "Terminating" || !!namespace.metadata?.deletionTimestamp;
+
+export const getNamespaceStatusIcon = (namespace: Namespace): K8sResourceStatusIcon => {
+  if (isTerminating(namespace)) {
+    return { component: LoaderCircle, color: STATUS_COLOR.MISSING, isSpinning: true };
+  }
+  if (namespace.status?.phase === "Active") {
+    return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+  }
+  return { component: ShieldQuestion, color: STATUS_COLOR.UNKNOWN };
+};
+
+export const getNamespaceStatusLabel = (namespace: Namespace): string => {
+  if (isTerminating(namespace)) return "Terminating";
+  if (namespace.status?.phase === "Active") return "Active";
+  return "Unknown";
+};

--- a/apps/client/src/k8s/api/groups/Core/PersistentVolume/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/Core/PersistentVolume/utils/getStatus/index.ts
@@ -1,0 +1,46 @@
+import { CircleCheck, CircleDot, CircleX, LoaderCircle, ShieldQuestion, TriangleAlert } from "lucide-react";
+import type { PersistentVolume } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+const readPhase = (pv: PersistentVolume): string | undefined => (pv.status as { phase?: string } | undefined)?.phase;
+
+export const getPVStatusIcon = (pv: PersistentVolume): K8sResourceStatusIcon => {
+  if (pv.metadata?.deletionTimestamp) return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+
+  const phase = readPhase(pv);
+  switch (phase) {
+    case "Bound":
+      return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+    case "Available":
+      return { component: CircleDot, color: STATUS_COLOR.IN_PROGRESS };
+    case "Released":
+      return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+    case "Failed":
+      return { component: CircleX, color: STATUS_COLOR.ERROR };
+    case "Pending":
+      return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+    default:
+      return { component: ShieldQuestion, color: STATUS_COLOR.UNKNOWN };
+  }
+};
+
+export const getPVStatusLabel = (pv: PersistentVolume): string => {
+  if (pv.metadata?.deletionTimestamp) return "Terminating";
+
+  const phase = readPhase(pv);
+  switch (phase) {
+    case "Bound":
+      return "Bound";
+    case "Available":
+      return "Available";
+    case "Released":
+      return "Released";
+    case "Failed":
+      return "Failed";
+    case "Pending":
+      return "Pending";
+    default:
+      return "Unknown";
+  }
+};

--- a/apps/client/src/k8s/api/groups/Core/PersistentVolumeClaim/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/Core/PersistentVolumeClaim/utils/getStatus/index.ts
@@ -1,0 +1,39 @@
+import { CircleCheck, CircleX, LoaderCircle, ShieldQuestion, TriangleAlert } from "lucide-react";
+import type { PersistentVolumeClaim } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+const readPhase = (pvc: PersistentVolumeClaim): string | undefined =>
+  (pvc.status as { phase?: string } | undefined)?.phase;
+
+export const getPVCStatusIcon = (pvc: PersistentVolumeClaim): K8sResourceStatusIcon => {
+  if (pvc.metadata?.deletionTimestamp) return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+
+  const phase = readPhase(pvc);
+  switch (phase) {
+    case "Bound":
+      return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+    case "Pending":
+      return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+    case "Lost":
+      return { component: CircleX, color: STATUS_COLOR.ERROR };
+    default:
+      return { component: ShieldQuestion, color: STATUS_COLOR.UNKNOWN };
+  }
+};
+
+export const getPVCStatusLabel = (pvc: PersistentVolumeClaim): string => {
+  if (pvc.metadata?.deletionTimestamp) return "Terminating";
+
+  const phase = readPhase(pvc);
+  switch (phase) {
+    case "Bound":
+      return "Bound";
+    case "Pending":
+      return "Pending";
+    case "Lost":
+      return "Lost";
+    default:
+      return "Unknown";
+  }
+};

--- a/apps/client/src/k8s/api/groups/apps/DaemonSet/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/apps/DaemonSet/utils/getStatus/index.ts
@@ -1,0 +1,39 @@
+import { CircleCheck, LoaderCircle, ShieldQuestion, TriangleAlert } from "lucide-react";
+import type { DaemonSet } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+interface DaemonSetStatusView {
+  desired: number;
+  ready: number;
+  available: number;
+  terminating: boolean;
+}
+
+const readStatus = (daemonSet: DaemonSet): DaemonSetStatusView => {
+  const status = daemonSet.status;
+  return {
+    desired: status?.desiredNumberScheduled ?? 0,
+    ready: status?.numberReady ?? 0,
+    available: status?.numberAvailable ?? 0,
+    terminating: !!daemonSet.metadata?.deletionTimestamp,
+  };
+};
+
+export const getDaemonSetStatusIcon = (daemonSet: DaemonSet): K8sResourceStatusIcon => {
+  const s = readStatus(daemonSet);
+  if (s.terminating) return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+  if (s.desired === 0) return { component: ShieldQuestion, color: STATUS_COLOR.UNKNOWN };
+  if (s.ready === s.desired && s.available === s.desired) {
+    return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+  }
+  return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+};
+
+export const getDaemonSetStatusLabel = (daemonSet: DaemonSet): string => {
+  const s = readStatus(daemonSet);
+  if (s.terminating) return "Terminating";
+  if (s.desired === 0) return "Not Scheduled";
+  if (s.ready === s.desired && s.available === s.desired) return "Available";
+  return "Progressing";
+};

--- a/apps/client/src/k8s/api/groups/apps/Deployment/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/apps/Deployment/utils/getStatus/index.ts
@@ -1,0 +1,47 @@
+import { CircleCheck, CircleX, LoaderCircle, Pause, TriangleAlert } from "lucide-react";
+import type { Deployment } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+interface DeploymentStatusView {
+  desired: number;
+  ready: number;
+  updated: number;
+  available: number;
+  replicaFailure: boolean;
+  terminating: boolean;
+}
+
+const readStatus = (deployment: Deployment): DeploymentStatusView => {
+  const spec = deployment.spec;
+  const status = deployment.status;
+  const conditions = status?.conditions as Array<{ type?: string; status?: string }> | undefined;
+  return {
+    desired: spec?.replicas ?? 0,
+    ready: status?.readyReplicas ?? 0,
+    updated: status?.updatedReplicas ?? 0,
+    available: status?.availableReplicas ?? 0,
+    replicaFailure: !!conditions?.find((c) => c.type === "ReplicaFailure" && c.status === "True"),
+    terminating: !!deployment.metadata?.deletionTimestamp,
+  };
+};
+
+export const getDeploymentStatusIcon = (deployment: Deployment): K8sResourceStatusIcon => {
+  const s = readStatus(deployment);
+  if (s.terminating) return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+  if (s.replicaFailure) return { component: CircleX, color: STATUS_COLOR.ERROR };
+  if (s.desired === 0) return { component: Pause, color: STATUS_COLOR.SUSPENDED };
+  if (s.ready === s.desired && s.updated === s.desired && s.available === s.desired) {
+    return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+  }
+  return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+};
+
+export const getDeploymentStatusLabel = (deployment: Deployment): string => {
+  const s = readStatus(deployment);
+  if (s.terminating) return "Terminating";
+  if (s.replicaFailure) return "ReplicaFailure";
+  if (s.desired === 0) return "Scaled Down";
+  if (s.ready === s.desired && s.updated === s.desired && s.available === s.desired) return "Available";
+  return "Progressing";
+};

--- a/apps/client/src/k8s/api/groups/apps/StatefulSet/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/apps/StatefulSet/utils/getStatus/index.ts
@@ -1,0 +1,42 @@
+import { CircleCheck, LoaderCircle, Pause, TriangleAlert } from "lucide-react";
+import type { StatefulSet } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+interface StatefulSetStatusView {
+  desired: number;
+  ready: number;
+  updated: number;
+  available: number;
+  terminating: boolean;
+}
+
+const readStatus = (statefulSet: StatefulSet): StatefulSetStatusView => {
+  const spec = statefulSet.spec;
+  const status = statefulSet.status;
+  return {
+    desired: spec?.replicas ?? 0,
+    ready: status?.readyReplicas ?? 0,
+    updated: status?.updatedReplicas ?? 0,
+    available: status?.availableReplicas ?? 0,
+    terminating: !!statefulSet.metadata?.deletionTimestamp,
+  };
+};
+
+export const getStatefulSetStatusIcon = (statefulSet: StatefulSet): K8sResourceStatusIcon => {
+  const s = readStatus(statefulSet);
+  if (s.terminating) return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+  if (s.desired === 0) return { component: Pause, color: STATUS_COLOR.SUSPENDED };
+  if (s.ready === s.desired && s.updated === s.desired && s.available === s.desired) {
+    return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+  }
+  return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+};
+
+export const getStatefulSetStatusLabel = (statefulSet: StatefulSet): string => {
+  const s = readStatus(statefulSet);
+  if (s.terminating) return "Terminating";
+  if (s.desired === 0) return "Scaled Down";
+  if (s.ready === s.desired && s.updated === s.desired && s.available === s.desired) return "Available";
+  return "Progressing";
+};

--- a/apps/client/src/k8s/api/groups/autoscaling/HorizontalPodAutoscaler/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/autoscaling/HorizontalPodAutoscaler/utils/getStatus/index.ts
@@ -1,0 +1,58 @@
+import { CircleCheck, LoaderCircle, ShieldQuestion, TriangleAlert } from "lucide-react";
+import type { HorizontalPodAutoscaler } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+interface HPAStatusView {
+  current: number;
+  desired: number;
+  max: number;
+  scalingActive?: string;
+  ableToScale?: string;
+  scalingLimited?: string;
+  terminating: boolean;
+}
+
+const readStatus = (hpa: HorizontalPodAutoscaler): HPAStatusView => {
+  const spec = hpa.spec as { maxReplicas?: number } | undefined;
+  const status = hpa.status as
+    | { currentReplicas?: number; desiredReplicas?: number; conditions?: Array<{ type?: string; status?: string }> }
+    | undefined;
+  const conditions = status?.conditions ?? [];
+  const conditionStatus = (type: string) => conditions.find((c) => c.type === type)?.status;
+  return {
+    current: status?.currentReplicas ?? 0,
+    desired: status?.desiredReplicas ?? 0,
+    max: spec?.maxReplicas ?? 0,
+    scalingActive: conditionStatus("ScalingActive"),
+    ableToScale: conditionStatus("AbleToScale"),
+    scalingLimited: conditionStatus("ScalingLimited"),
+    terminating: !!hpa.metadata?.deletionTimestamp,
+  };
+};
+
+export const getHPAStatusIcon = (hpa: HorizontalPodAutoscaler): K8sResourceStatusIcon => {
+  const s = readStatus(hpa);
+  if (s.terminating) return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+  if (s.scalingActive === "False") return { component: ShieldQuestion, color: STATUS_COLOR.UNKNOWN };
+  if ((s.scalingLimited === "True" || (s.max > 0 && s.current >= s.max)) && s.scalingActive !== "False") {
+    return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+  }
+  if (s.ableToScale === "True" && s.scalingActive === "True") {
+    return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+  }
+  if (s.current === s.desired) return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+  return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+};
+
+export const getHPAStatusLabel = (hpa: HorizontalPodAutoscaler): string => {
+  const s = readStatus(hpa);
+  if (s.terminating) return "Terminating";
+  if (s.scalingActive === "False") return "Inactive";
+  if ((s.scalingLimited === "True" || (s.max > 0 && s.current >= s.max)) && s.scalingActive !== "False") {
+    return "Limited";
+  }
+  if (s.ableToScale === "True" && s.scalingActive === "True") return "Active";
+  if (s.current === s.desired) return "Active";
+  return "Scaling";
+};

--- a/apps/client/src/k8s/api/groups/batch/CronJob/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/batch/CronJob/utils/getStatus/index.ts
@@ -1,0 +1,40 @@
+import { CircleCheck, Clock, LoaderCircle, Pause, TriangleAlert } from "lucide-react";
+import type { CronJob } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+interface CronJobStatusView {
+  terminating: boolean;
+  suspended: boolean;
+  active: number;
+  hasLastSchedule: boolean;
+}
+
+const readStatus = (cronJob: CronJob): CronJobStatusView => {
+  const spec = cronJob.spec as { suspend?: boolean } | undefined;
+  const status = cronJob.status as { active?: unknown[]; lastScheduleTime?: string } | undefined;
+  return {
+    terminating: !!cronJob.metadata?.deletionTimestamp,
+    suspended: spec?.suspend === true,
+    active: status?.active?.length ?? 0,
+    hasLastSchedule: !!status?.lastScheduleTime,
+  };
+};
+
+export const getCronJobStatusIcon = (cronJob: CronJob): K8sResourceStatusIcon => {
+  const s = readStatus(cronJob);
+  if (s.terminating) return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+  if (s.suspended) return { component: Pause, color: STATUS_COLOR.SUSPENDED };
+  if (s.active > 0) return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+  if (s.hasLastSchedule) return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+  return { component: Clock, color: STATUS_COLOR.UNKNOWN };
+};
+
+export const getCronJobStatusLabel = (cronJob: CronJob): string => {
+  const s = readStatus(cronJob);
+  if (s.terminating) return "Terminating";
+  if (s.suspended) return "Suspended";
+  if (s.active > 0) return "Active";
+  if (s.hasLastSchedule) return "Scheduled";
+  return "Pending";
+};

--- a/apps/client/src/k8s/api/groups/batch/Job/utils/getStatus/index.ts
+++ b/apps/client/src/k8s/api/groups/batch/Job/utils/getStatus/index.ts
@@ -1,0 +1,45 @@
+import { CircleCheck, CircleDot, CircleX, LoaderCircle, TriangleAlert } from "lucide-react";
+import type { Job } from "@my-project/shared";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+interface JobStatusView {
+  failed: boolean;
+  complete: boolean;
+  active: boolean;
+  terminating: boolean;
+}
+
+const readStatus = (job: Job): JobStatusView => {
+  const spec = job.spec as { completions?: number } | undefined;
+  const status = job.status;
+  const conditions = status?.conditions as Array<{ type?: string; status?: string }> | undefined;
+  const failed = !!conditions?.find((c) => c.type === "Failed" && c.status === "True");
+  const completeCondition = !!conditions?.find((c) => c.type === "Complete" && c.status === "True");
+  const completions = spec?.completions ?? 0;
+  const succeeded = status?.succeeded ?? 0;
+  return {
+    failed,
+    complete: completeCondition || (completions > 0 && succeeded >= completions),
+    active: (status?.active ?? 0) > 0,
+    terminating: !!job.metadata?.deletionTimestamp,
+  };
+};
+
+export const getJobStatusIcon = (job: Job): K8sResourceStatusIcon => {
+  const s = readStatus(job);
+  if (s.terminating) return { component: TriangleAlert, color: STATUS_COLOR.MISSING };
+  if (s.failed) return { component: CircleX, color: STATUS_COLOR.ERROR };
+  if (s.complete) return { component: CircleCheck, color: STATUS_COLOR.SUCCESS };
+  if (s.active) return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true };
+  return { component: CircleDot, color: STATUS_COLOR.UNKNOWN };
+};
+
+export const getJobStatusLabel = (job: Job): string => {
+  const s = readStatus(job);
+  if (s.terminating) return "Terminating";
+  if (s.failed) return "Failed";
+  if (s.complete) return "Complete";
+  if (s.active) return "Running";
+  return "Pending";
+};

--- a/apps/client/src/modules/k8s/components/overrides/ClusterRoleBindingOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/ClusterRoleBindingOverviewTab.tsx
@@ -1,0 +1,70 @@
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import type { ClusterRoleBinding, KubeObjectBase } from "@my-project/shared";
+import { SubjectsCard, type RbacSubject } from "@/modules/k8s/components/rbac";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+export function ClusterRoleBindingOverviewTab({ item }: { item: KubeObjectBase }) {
+  const crb = item as ClusterRoleBinding;
+  const subjects = (crb.subjects ?? []) as RbacSubject[];
+  const roleRef = crb.roleRef;
+  const created = crb.metadata?.creationTimestamp;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Role Ref"
+          value={
+            <span className="font-mono text-xs">
+              {roleRef.kind}/{roleRef.name}
+            </span>
+          }
+          sub="Bound role"
+        />
+        <WorkloadSummaryCard label="Subjects" value={subjects.length} sub="Bound to" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadInformationCard title="Role Reference">
+            <WorkloadInfoRow label="Kind">{roleRef.kind}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Name" mono>
+              {roleRef.name}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="API Group">{roleRef.apiGroup || "—"}</WorkloadInfoRow>
+          </WorkloadInformationCard>
+          <SubjectsCard subjects={subjects} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Subjects">{subjects.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {crb.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/ClusterRoleOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/ClusterRoleOverviewTab.tsx
@@ -1,0 +1,68 @@
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { PolicyRulesCard, type PolicyRule } from "@/modules/k8s/components/rbac";
+import type { ClusterRole, KubeObjectBase } from "@my-project/shared";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+export function ClusterRoleOverviewTab({ item }: { item: KubeObjectBase }) {
+  const clusterRole = item as ClusterRole;
+  const rules: PolicyRule[] = clusterRole.rules ?? [];
+  const created = clusterRole.metadata?.creationTimestamp;
+  const hasAggregationRule = Boolean((clusterRole as { aggregationRule?: unknown }).aggregationRule);
+
+  const apiGroups = new Set<string>();
+  const verbs = new Set<string>();
+  for (const rule of rules) {
+    for (const g of rule.apiGroups ?? []) {
+      apiGroups.add(g || "core");
+    }
+    for (const v of rule.verbs ?? []) {
+      verbs.add(v);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard label="Rules" value={rules.length} sub="Policy rules" />
+        <WorkloadSummaryCard label="API Groups" value={apiGroups.size} sub="Distinct" />
+        <WorkloadSummaryCard label="Verbs" value={verbs.size} sub="Distinct" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <PolicyRulesCard rules={rules} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Rules">{rules.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Aggregation Rule">{hasAggregationRule ? "Yes" : "No"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {clusterRole.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/ConfigMapOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/ConfigMapOverviewTab.tsx
@@ -1,41 +1,101 @@
 import { Editor } from "@monaco-editor/react";
-import { ResourceOverviewTab } from "../ResourceOverviewTab";
-import type { KubeObjectBase } from "@my-project/shared";
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import type { ConfigMap, KubeObjectBase } from "@my-project/shared";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
 
-interface ConfigMapLike extends KubeObjectBase {
+interface ConfigMapView {
   data?: Record<string, string>;
+  binaryData?: Record<string, string>;
+  immutable?: boolean;
 }
 
 export function ConfigMapOverviewTab({ item }: { item: KubeObjectBase }) {
-  const cm = item as ConfigMapLike;
+  const cm = item as ConfigMap & ConfigMapView;
+
   const data = cm.data ?? {};
+  const binaryData = (cm as ConfigMapView).binaryData ?? {};
+  const immutable = (cm as ConfigMapView).immutable ?? false;
+  const created = cm.metadata?.creationTimestamp;
+
+  const dataKeys = Object.keys(data).length;
+  const binaryKeys = Object.keys(binaryData).length;
+  const dataEntries = Object.entries(data);
 
   return (
-    <div className="grid gap-4">
-      <ResourceOverviewTab item={item} />
-      <section>
-        <h3 className="text-muted-foreground text-sm font-semibold tracking-wide uppercase">Data</h3>
-        {Object.entries(data).length === 0 ? (
-          <p className="text-muted-foreground mt-1 text-sm">—</p>
-        ) : (
-          <div className="mt-2 space-y-2">
-            {Object.entries(data).map(([k, v]) => (
-              <details key={k} className="bg-muted/30 rounded border">
-                <summary className="cursor-pointer px-3 py-2 font-mono text-sm">{k}</summary>
-                <div className="border-t">
-                  <Editor
-                    language="yaml"
-                    theme="vs-light"
-                    value={v}
-                    height="240px"
-                    options={{ readOnly: true, minimap: { enabled: false } }}
-                  />
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard label="Data Keys" value={dataKeys} sub="Entries" />
+        <WorkloadSummaryCard label="Binary Keys" value={binaryKeys} sub="Binary entries" />
+        <WorkloadSummaryCard label="Immutable" value={immutable ? "Yes" : "No"} sub="Mutability" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <Card>
+            <CardHeader className="p-4 pb-2">
+              <CardTitle className="flex items-baseline justify-between text-base font-semibold">
+                <span>Data</span>
+                <span className="text-muted-foreground text-xs">{dataKeys}</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-4 pt-2">
+              {dataEntries.length === 0 ? (
+                <p className="text-muted-foreground text-sm">No data entries.</p>
+              ) : (
+                <div className="space-y-2">
+                  {dataEntries.map(([k, v]) => (
+                    <details key={k} className="bg-muted/30 rounded border">
+                      <summary className="cursor-pointer px-3 py-2 font-mono text-sm">{k}</summary>
+                      <div className="border-t">
+                        <Editor
+                          language="yaml"
+                          theme="vs-light"
+                          value={v}
+                          height="240px"
+                          options={{ readOnly: true, minimap: { enabled: false } }}
+                        />
+                      </div>
+                    </details>
+                  ))}
                 </div>
-              </details>
-            ))}
-          </div>
-        )}
-      </section>
+              )}
+            </CardContent>
+          </Card>
+
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Data Keys">{dataKeys}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Binary Keys">{binaryKeys}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Immutable">{immutable ? "Yes" : "No"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {cm.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/client/src/modules/k8s/components/overrides/CronJobOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/CronJobOverviewTab.tsx
@@ -1,0 +1,239 @@
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { StatusIcon } from "@/core/components/StatusIcon";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { getCronJobStatusIcon, getCronJobStatusLabel } from "@/k8s/api/groups/batch/CronJob/utils/getStatus";
+import { getJobStatusIcon, getJobStatusLabel } from "@/k8s/api/groups/batch/Job/utils/getStatus";
+import { k8sJobConfig } from "@my-project/shared";
+import type { CronJob, Job, KubeObjectBase } from "@my-project/shared";
+import { useK8sResourceList } from "../../hooks/useK8sResourceList";
+import {
+  ContainerImagesList,
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface CronJobSpecView {
+  schedule?: string;
+  suspend?: boolean;
+  concurrencyPolicy?: string;
+  startingDeadlineSeconds?: number;
+  successfulJobsHistoryLimit?: number;
+  failedJobsHistoryLimit?: number;
+  jobTemplate?: {
+    spec?: {
+      template?: {
+        spec?: {
+          containers?: Array<{ name: string; image?: string; imagePullPolicy?: string }>;
+        };
+      };
+    };
+  };
+}
+
+interface CronJobStatusView {
+  active?: unknown[];
+  lastScheduleTime?: string;
+  lastSuccessfulTime?: string;
+}
+
+function CronJobJobsCard({ jobs, isLoading }: { jobs: Job[]; isLoading: boolean }) {
+  return (
+    <Card>
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="flex items-baseline justify-between text-base font-semibold">
+          <span>Jobs</span>
+          <span className="text-muted-foreground text-xs">{jobs.length}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {isLoading && jobs.length === 0 ? (
+          <div className="text-muted-foreground p-4 text-sm">Loading…</div>
+        ) : jobs.length === 0 ? (
+          <div className="text-muted-foreground p-4 text-sm">No jobs found for this CronJob.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground border-b text-left text-xs">
+                  <th className="px-4 py-2 font-medium">Name</th>
+                  <th className="px-4 py-2 font-medium">Status</th>
+                  <th className="px-4 py-2 font-medium">Completions</th>
+                  <th className="px-4 py-2 font-medium">Age</th>
+                </tr>
+              </thead>
+              <tbody>
+                {jobs.map((job) => {
+                  const icon = getJobStatusIcon(job);
+                  const created = job.metadata?.creationTimestamp;
+                  const succeeded = job.status?.succeeded ?? 0;
+                  const completions = job.spec?.completions ?? 1;
+                  return (
+                    <tr key={job.metadata?.uid ?? job.metadata?.name} className="border-b last:border-0">
+                      <td className="px-4 py-2 font-mono text-xs">{job.metadata?.name}</td>
+                      <td className="px-4 py-2">
+                        <div className="flex items-center gap-1.5">
+                          <StatusIcon
+                            Icon={icon.component}
+                            color={icon.color}
+                            isSpinning={icon.isSpinning}
+                            width={14}
+                          />
+                          <span className="text-xs">{getJobStatusLabel(job)}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-2 tabular-nums">
+                        {succeeded}/{completions}
+                      </td>
+                      <td className="text-muted-foreground px-4 py-2">
+                        {created ? (
+                          <Tooltip title={created}>
+                            <span>{formatRelativeTime(created)}</span>
+                          </Tooltip>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CronJobOverviewTab({ item }: { item: KubeObjectBase }) {
+  const cronJob = item as CronJob;
+
+  const spec = cronJob.spec as CronJobSpecView | undefined;
+  const status = cronJob.status as CronJobStatusView | undefined;
+  const namespace = cronJob.metadata?.namespace ?? "";
+  const name = cronJob.metadata?.name ?? "";
+
+  const jobsResult = useK8sResourceList<Job>(k8sJobConfig, namespace);
+  const allJobs = jobsResult.data.array;
+
+  const jobs = useMemo(() => {
+    return allJobs
+      .filter((job) => (job.metadata?.ownerReferences ?? []).some((ref) => ref.kind === "CronJob" && ref.name === name))
+      .sort((a, b) => {
+        const aTime = a.metadata?.creationTimestamp ? new Date(a.metadata.creationTimestamp).getTime() : 0;
+        const bTime = b.metadata?.creationTimestamp ? new Date(b.metadata.creationTimestamp).getTime() : 0;
+        return bTime - aTime;
+      })
+      .slice(0, 10);
+  }, [allJobs, name]);
+
+  const active = status?.active?.length ?? 0;
+  const lastScheduleTime = status?.lastScheduleTime;
+  const lastSuccessfulTime = status?.lastSuccessfulTime;
+  const created = cronJob.metadata?.creationTimestamp;
+
+  const containers = spec?.jobTemplate?.spec?.template?.spec?.containers ?? [];
+  const owner = cronJob.metadata?.ownerReferences?.[0];
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={<StatusBadge statusIcon={getCronJobStatusIcon(cronJob)} label={getCronJobStatusLabel(cronJob)} />}
+          sub="Health"
+        />
+        <WorkloadSummaryCard
+          label="Schedule"
+          value={<span className="font-mono text-sm">{spec?.schedule ?? "—"}</span>}
+          sub="Cron expression"
+        />
+        <WorkloadSummaryCard label="Active Jobs" value={active} sub="Running" />
+        <WorkloadSummaryCard
+          label="Last Schedule"
+          value={lastScheduleTime ? formatRelativeTime(lastScheduleTime) : "—"}
+          sub={
+            lastScheduleTime ? (
+              <Tooltip title={lastScheduleTime}>
+                <span>{formatTimestamp(lastScheduleTime)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+        <WorkloadSummaryCard
+          label="Last Successful"
+          value={lastSuccessfulTime ? formatRelativeTime(lastSuccessfulTime) : "—"}
+          sub={
+            lastSuccessfulTime ? (
+              <Tooltip title={lastSuccessfulTime}>
+                <span>{formatTimestamp(lastSuccessfulTime)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <CronJobJobsCard jobs={jobs} isLoading={jobsResult.isLoading} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Owner">
+              {owner ? (
+                <span className="font-mono text-xs">
+                  {owner.kind}/{owner.name}
+                </span>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Schedule" mono>
+              {spec?.schedule ?? "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Suspend">{spec?.suspend ? "Yes" : "No"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Concurrency Policy">{spec?.concurrencyPolicy ?? "Allow"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Starting Deadline">
+              {spec?.startingDeadlineSeconds !== undefined ? `${spec.startingDeadlineSeconds}s` : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Successful History Limit">
+              {spec?.successfulJobsHistoryLimit ?? "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Failed History Limit">{spec?.failedJobsHistoryLimit ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Containers">{containers.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Images" full>
+              <ContainerImagesList containers={containers} />
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {cronJob.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/DaemonSetOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/DaemonSetOverviewTab.tsx
@@ -1,0 +1,132 @@
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { getDaemonSetStatusIcon, getDaemonSetStatusLabel } from "@/k8s/api/groups/apps/DaemonSet/utils/getStatus";
+import type { DaemonSet, KubeObjectBase } from "@my-project/shared";
+import { useOwnedPods } from "../../hooks/useOwnedPods";
+import {
+  ContainerImagesList,
+  ReplicaProgress,
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadPodsCard,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+const DAEMONSET_REVISION_ANNOTATION = "daemonset.kubernetes.io/revision";
+
+interface DaemonSetSpecView {
+  selector?: { matchLabels?: Record<string, string> };
+  updateStrategy?: {
+    type?: string;
+    rollingUpdate?: { maxUnavailable?: string | number };
+  };
+  template?: {
+    spec?: {
+      serviceAccountName?: string;
+      serviceAccount?: string;
+      containers?: Array<{ name: string; image?: string; imagePullPolicy?: string }>;
+    };
+  };
+}
+
+interface DaemonSetStatusView {
+  updatedNumberScheduled?: number;
+}
+
+export function DaemonSetOverviewTab({ item }: { item: KubeObjectBase }) {
+  const daemonSet = item as DaemonSet;
+  const { pods, isLoading } = useOwnedPods(daemonSet);
+
+  const spec = daemonSet.spec as DaemonSetSpecView | undefined;
+  const status = daemonSet.status;
+  const statusView = daemonSet.status as DaemonSetStatusView | undefined;
+  const desired = status?.desiredNumberScheduled ?? 0;
+  const ready = status?.numberReady ?? 0;
+  const updated = statusView?.updatedNumberScheduled ?? 0;
+  const available = status?.numberAvailable ?? 0;
+  const created = daemonSet.metadata?.creationTimestamp;
+
+  const containers = spec?.template?.spec?.containers ?? [];
+  const podSpec = spec?.template?.spec;
+  const selector = spec?.selector?.matchLabels ?? {};
+  const owner = daemonSet.metadata?.ownerReferences?.[0];
+  const annotations = daemonSet.metadata?.annotations ?? {};
+  const revision = annotations[DAEMONSET_REVISION_ANNOTATION];
+  const updateStrategy = spec?.updateStrategy;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={
+            <StatusBadge statusIcon={getDaemonSetStatusIcon(daemonSet)} label={getDaemonSetStatusLabel(daemonSet)} />
+          }
+          sub="Health"
+        />
+        <WorkloadSummaryCard label="Desired" value={desired} sub="pods" />
+        <WorkloadSummaryCard label="Ready" value={<ReplicaProgress ready={ready} desired={desired} />} sub="pods" />
+        <WorkloadSummaryCard label="Up-to-date" value={updated} sub="pods" />
+        <WorkloadSummaryCard label="Available" value={available} sub="pods" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadPodsCard pods={pods} isLoading={isLoading} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Owner">
+              {owner ? (
+                <span className="font-mono text-xs">
+                  {owner.kind}/{owner.name}
+                </span>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Revision">{revision ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Update Strategy">{updateStrategy?.type ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Max Unavailable">
+              {updateStrategy?.rollingUpdate?.maxUnavailable ?? "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Service Account" mono>
+              {podSpec?.serviceAccountName ?? podSpec?.serviceAccount ?? "default"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Containers">{containers.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Selector" mono full>
+              {Object.keys(selector).length
+                ? Object.entries(selector)
+                    .map(([k, v]) => `${k}=${v}`)
+                    .join(", ")
+                : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Images" full>
+              <ContainerImagesList containers={containers} />
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {daemonSet.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/DeploymentOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/DeploymentOverviewTab.tsx
@@ -1,0 +1,152 @@
+import { Alert } from "@/core/components/ui/alert";
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { getDeploymentStatusIcon, getDeploymentStatusLabel } from "@/k8s/api/groups/apps/Deployment/utils/getStatus";
+import { DEPLOYMENT_REVISION_ANNOTATION } from "@my-project/shared";
+import type { Deployment, KubeObjectBase } from "@my-project/shared";
+import { useOwnedPods } from "../../hooks/useOwnedPods";
+import {
+  ContainerImagesList,
+  ReplicaProgress,
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadPodsCard,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface DeploymentSpecView {
+  replicas?: number;
+  selector?: { matchLabels?: Record<string, string> };
+  paused?: boolean;
+  minReadySeconds?: number;
+  progressDeadlineSeconds?: number;
+  strategy?: {
+    type?: string;
+    rollingUpdate?: { maxSurge?: string | number; maxUnavailable?: string | number };
+  };
+  template?: {
+    spec?: {
+      serviceAccountName?: string;
+      serviceAccount?: string;
+      containers?: Array<{ name: string; image?: string; imagePullPolicy?: string }>;
+    };
+  };
+}
+
+export function DeploymentOverviewTab({ item }: { item: KubeObjectBase }) {
+  const deployment = item as Deployment;
+  const { pods, isLoading } = useOwnedPods(deployment);
+
+  const spec = deployment.spec as DeploymentSpecView | undefined;
+  const status = deployment.status;
+  const desired = spec?.replicas ?? 0;
+  const ready = status?.readyReplicas ?? 0;
+  const updated = status?.updatedReplicas ?? 0;
+  const available = status?.availableReplicas ?? 0;
+  const created = deployment.metadata?.creationTimestamp;
+
+  const containers = spec?.template?.spec?.containers ?? [];
+  const podSpec = spec?.template?.spec;
+  const selector = spec?.selector?.matchLabels ?? {};
+  const owner = deployment.metadata?.ownerReferences?.[0];
+  const annotations = deployment.metadata?.annotations ?? {};
+  const revision = annotations[DEPLOYMENT_REVISION_ANNOTATION];
+  const strategy = spec?.strategy;
+
+  const conditions = status?.conditions as Array<{ type?: string; status?: string; message?: string }> | undefined;
+  const replicaFailure = conditions?.find((c) => c.type === "ReplicaFailure" && c.status === "True");
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={
+            <StatusBadge
+              statusIcon={getDeploymentStatusIcon(deployment)}
+              label={getDeploymentStatusLabel(deployment)}
+            />
+          }
+          sub="Health"
+        />
+        <WorkloadSummaryCard label="Desired" value={desired} sub="Replicas" />
+        <WorkloadSummaryCard
+          label="Ready"
+          value={<ReplicaProgress ready={ready} desired={desired} />}
+          sub="Available pods"
+        />
+        <WorkloadSummaryCard label="Up-to-date" value={updated} sub="Updated" />
+        <WorkloadSummaryCard label="Available" value={available} sub="Serving" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      {replicaFailure && (
+        <Alert variant="destructive" title="ReplicaFailure">
+          {replicaFailure.message ?? "One or more replicas failed to be created."}
+        </Alert>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadPodsCard pods={pods} isLoading={isLoading} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Owner">
+              {owner ? (
+                <span className="font-mono text-xs">
+                  {owner.kind}/{owner.name}
+                </span>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Revision">{revision ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Strategy">{strategy?.type ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Service Account" mono>
+              {podSpec?.serviceAccountName ?? podSpec?.serviceAccount ?? "default"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Max Surge">{strategy?.rollingUpdate?.maxSurge ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Max Unavailable">{strategy?.rollingUpdate?.maxUnavailable ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Min Ready">
+              {spec?.minReadySeconds !== undefined ? `${spec.minReadySeconds}s` : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Containers">{containers.length}</WorkloadInfoRow>
+            {spec?.paused !== undefined && (
+              <WorkloadInfoRow label="Paused">{spec.paused ? "Yes" : "No"}</WorkloadInfoRow>
+            )}
+            <WorkloadInfoRow label="Selector" mono full>
+              {Object.keys(selector).length
+                ? Object.entries(selector)
+                    .map(([k, v]) => `${k}=${v}`)
+                    .join(", ")
+                : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Images" full>
+              <ContainerImagesList containers={containers} />
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {deployment.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/HPAOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/HPAOverviewTab.tsx
@@ -1,0 +1,216 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import {
+  getHPAStatusIcon,
+  getHPAStatusLabel,
+} from "@/k8s/api/groups/autoscaling/HorizontalPodAutoscaler/utils/getStatus";
+import type { HorizontalPodAutoscaler, KubeCondition, KubeObjectBase } from "@my-project/shared";
+import { ConditionsTable } from "../ConditionsTable";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface HPAResourceMetricView {
+  name?: string;
+  current?: { averageUtilization?: number; averageValue?: string; value?: string };
+  target?: { averageUtilization?: number; averageValue?: string; value?: string; type?: string };
+}
+
+interface HPAMetricView {
+  type?: string;
+  resource?: HPAResourceMetricView;
+  pods?: HPAResourceMetricView;
+  object?: HPAResourceMetricView & { metric?: { name?: string } };
+  external?: HPAResourceMetricView & { metric?: { name?: string } };
+}
+
+interface HPASpecView {
+  scaleTargetRef?: { kind?: string; name?: string; apiVersion?: string };
+  minReplicas?: number;
+  maxReplicas?: number;
+  targetCPUUtilizationPercentage?: number;
+  metrics?: HPAMetricView[];
+}
+
+interface HPAStatusView {
+  currentReplicas?: number;
+  desiredReplicas?: number;
+  currentCPUUtilizationPercentage?: number;
+  lastScaleTime?: string;
+  currentMetrics?: HPAMetricView[];
+  conditions?: KubeCondition[];
+}
+
+interface MetricRow {
+  name: string;
+  current: string;
+  target: string;
+}
+
+const fmtPercent = (v?: number) => (v === undefined ? "—" : `${v}%`);
+
+const metricName = (m: HPAMetricView): string => {
+  if (m.resource?.name) return `Resource: ${m.resource.name}`;
+  if (m.pods?.name) return `Pods: ${m.pods.name}`;
+  if (m.object?.metric?.name) return `Object: ${m.object.metric.name}`;
+  if (m.external?.metric?.name) return `External: ${m.external.metric.name}`;
+  return m.type ?? "metric";
+};
+
+const metricCurrent = (m: HPAMetricView): string => {
+  const src = m.resource?.current ?? m.pods?.current ?? m.object?.current ?? m.external?.current;
+  if (!src) return "—";
+  if (src.averageUtilization !== undefined) return `${src.averageUtilization}%`;
+  return src.averageValue ?? src.value ?? "—";
+};
+
+const metricTarget = (m: HPAMetricView): string => {
+  const src = m.resource?.target ?? m.pods?.target ?? m.object?.target ?? m.external?.target;
+  if (!src) return "—";
+  if (src.averageUtilization !== undefined) return `${src.averageUtilization}%`;
+  return src.averageValue ?? src.value ?? "—";
+};
+
+const buildMetricRows = (spec: HPASpecView, status: HPAStatusView): MetricRow[] => {
+  // autoscaling/v2: pair spec.metrics with status.currentMetrics by index.
+  if (spec.metrics && spec.metrics.length > 0) {
+    return spec.metrics.map((m, idx) => {
+      const cur = status.currentMetrics?.[idx];
+      return {
+        name: metricName(m),
+        current: cur ? metricCurrent(cur) : "—",
+        target: metricTarget(m),
+      };
+    });
+  }
+  // autoscaling/v1: single CPU utilization row.
+  if (spec.targetCPUUtilizationPercentage !== undefined || status.currentCPUUtilizationPercentage !== undefined) {
+    return [
+      {
+        name: "Resource: cpu",
+        current: fmtPercent(status.currentCPUUtilizationPercentage),
+        target: fmtPercent(spec.targetCPUUtilizationPercentage),
+      },
+    ];
+  }
+  return [];
+};
+
+export function HPAOverviewTab({ item }: { item: KubeObjectBase }) {
+  const hpa = item as HorizontalPodAutoscaler;
+  const spec = (hpa.spec ?? {}) as HPASpecView;
+  const status = (hpa.status ?? {}) as HPAStatusView;
+
+  const created = hpa.metadata?.creationTimestamp;
+  const minReplicas = spec.minReplicas;
+  const maxReplicas = spec.maxReplicas;
+  const currentReplicas = status.currentReplicas ?? 0;
+  const desiredReplicas = status.desiredReplicas ?? 0;
+  const scaleTargetRef = spec.scaleTargetRef;
+  const lastScaleTime = status.lastScaleTime;
+  const conditions = (status.conditions ?? []) as KubeCondition[];
+  const metricRows = buildMetricRows(spec, status);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={<StatusBadge statusIcon={getHPAStatusIcon(hpa)} label={getHPAStatusLabel(hpa)} />}
+          sub="Health"
+        />
+        <WorkloadSummaryCard label="Min Replicas" value={minReplicas ?? "—"} sub="Lower bound" />
+        <WorkloadSummaryCard label="Max Replicas" value={maxReplicas ?? "—"} sub="Upper bound" />
+        <WorkloadSummaryCard label="Current" value={currentReplicas} sub="Replicas" />
+        <WorkloadSummaryCard label="Desired" value={desiredReplicas} sub="Replicas" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <Card>
+            <CardHeader className="p-4 pb-2">
+              <CardTitle className="text-base font-semibold">Metrics</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              {metricRows.length === 0 ? (
+                <div className="text-muted-foreground p-4 text-sm">No metrics configured.</div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-muted-foreground border-b text-left text-xs">
+                        <th className="px-4 py-2 font-medium">Metric</th>
+                        <th className="px-4 py-2 font-medium">Current</th>
+                        <th className="px-4 py-2 font-medium">Target</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {metricRows.map((row, idx) => (
+                        <tr key={`${row.name}-${idx}`} className="border-b last:border-0">
+                          <td className="px-4 py-2 font-mono text-xs">{row.name}</td>
+                          <td className="px-4 py-2 tabular-nums">{row.current}</td>
+                          <td className="px-4 py-2 tabular-nums">{row.target}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="p-4 pb-2">
+              <CardTitle className="text-base font-semibold">Conditions</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <ConditionsTable conditions={conditions} />
+            </CardContent>
+          </Card>
+
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Scale Target" mono>
+              {scaleTargetRef ? `${scaleTargetRef.kind ?? ""}/${scaleTargetRef.name ?? ""}` : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Min Replicas">{minReplicas ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Max Replicas">{maxReplicas ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Last Scale Time">
+              {lastScaleTime ? (
+                <Tooltip title={lastScaleTime}>
+                  <span>{formatRelativeTime(lastScaleTime)}</span>
+                </Tooltip>
+              ) : (
+                "—"
+              )}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {hpa.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/IngressOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/IngressOverviewTab.tsx
@@ -1,110 +1,198 @@
-import { ResourceOverviewTab } from "../ResourceOverviewTab";
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { Tooltip } from "@/core/components/ui/tooltip";
 import { TableUI, TableBodyUI, TableHeadUI, TableHeaderUI, TableRowUI, TableCellUI } from "@/core/components/ui/table";
-import type { KubeObjectBase } from "@my-project/shared";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import type { Ingress, KubeObjectBase } from "@my-project/shared";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
 
-interface IngressBackend {
+interface IngressBackendView {
   service?: { name?: string; port?: { number?: number; name?: string } };
+  resource?: { kind?: string; name?: string };
 }
 
-interface IngressPath {
+interface IngressPathView {
   path?: string;
   pathType?: string;
-  backend?: IngressBackend;
+  backend?: IngressBackendView;
 }
 
-interface IngressRule {
+interface IngressRuleView {
   host?: string;
-  http?: { paths?: IngressPath[] };
+  http?: { paths?: IngressPathView[] };
 }
 
-interface IngressLike extends KubeObjectBase {
-  spec?: {
-    ingressClassName?: string;
-    rules?: IngressRule[];
-    tls?: Array<{ hosts?: string[]; secretName?: string }>;
-  };
+interface IngressTLSView {
+  hosts?: string[];
+  secretName?: string;
+}
+
+interface IngressSpecView {
+  ingressClassName?: string;
+  defaultBackend?: IngressBackendView;
+  rules?: IngressRuleView[];
+  tls?: IngressTLSView[];
+}
+
+interface IngressStatusView {
+  loadBalancer?: { ingress?: Array<{ ip?: string; hostname?: string }> };
+}
+
+function describeBackend(backend?: IngressBackendView): string {
+  if (!backend) return "—";
+  if (backend.service?.name) {
+    const port = backend.service.port?.number ?? backend.service.port?.name;
+    return port !== undefined ? `${backend.service.name}:${port}` : backend.service.name;
+  }
+  if (backend.resource?.name) {
+    return `${backend.resource.kind ?? "Resource"}/${backend.resource.name}`;
+  }
+  return "—";
 }
 
 export function IngressOverviewTab({ item }: { item: KubeObjectBase }) {
-  const ing = item as IngressLike;
-  const rules = ing.spec?.rules ?? [];
-  const tls = ing.spec?.tls ?? [];
+  const ingress = item as Ingress;
+
+  const spec = ingress.spec as IngressSpecView | undefined;
+  const status = ingress.status as IngressStatusView | undefined;
+
+  const rules = spec?.rules ?? [];
+  const tls = spec?.tls ?? [];
+  const ingressClass = spec?.ingressClassName ?? "—";
+  const created = ingress.metadata?.creationTimestamp;
+
+  const hosts = Array.from(new Set(rules.map((r) => r.host).filter((h): h is string => Boolean(h))));
+  const tlsSecrets = tls.map((t) => t.secretName).filter((s): s is string => Boolean(s));
+
+  const lbIngress = status?.loadBalancer?.ingress?.[0];
+  const loadBalancer = lbIngress?.ip || lbIngress?.hostname || "—";
+
+  const defaultBackend = describeBackend(spec?.defaultBackend);
 
   return (
-    <div className="grid gap-4">
-      <ResourceOverviewTab item={item} />
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard label="Class" value={ingressClass} sub="Ingress class" />
+        <WorkloadSummaryCard label="Rules" value={rules.length} sub="Routing rules" />
+        <WorkloadSummaryCard label="Hosts" value={hosts.length} sub="Distinct hosts" />
+        <WorkloadSummaryCard label="TLS" value={tls.length} sub="TLS entries" />
+        <WorkloadSummaryCard label="Load Balancer" value={loadBalancer} sub="Address" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
 
-      {rules.length > 0 && (
-        <section>
-          <h3 className="text-muted-foreground mb-2 text-sm font-semibold tracking-wide uppercase">Rules</h3>
-          <div className="bg-card rounded-md border">
-            <TableUI>
-              <TableHeaderUI>
-                <TableRowUI>
-                  <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
-                    Host
-                  </TableHeadUI>
-                  <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
-                    Path
-                  </TableHeadUI>
-                  <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
-                    Backend
-                  </TableHeadUI>
-                  <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
-                    Port
-                  </TableHeadUI>
-                </TableRowUI>
-              </TableHeaderUI>
-              <TableBodyUI>
-                {rules.flatMap((rule, ri) =>
-                  (rule.http?.paths ?? [{ path: undefined, pathType: undefined, backend: undefined }]).map((p, pi) => (
-                    <TableRowUI key={`${ri}-${pi}`}>
-                      <TableCellUI className="px-4 py-2 font-mono text-sm">{rule.host ?? "*"}</TableCellUI>
-                      <TableCellUI className="px-4 py-2 font-mono text-sm">{p.path ?? "—"}</TableCellUI>
-                      <TableCellUI className="px-4 py-2 font-mono text-sm">
-                        {p.backend?.service?.name ?? "—"}
-                      </TableCellUI>
-                      <TableCellUI className="px-4 py-2 font-mono text-sm">
-                        {p.backend?.service?.port?.number ?? p.backend?.service?.port?.name ?? "—"}
-                      </TableCellUI>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          {rules.length > 0 && (
+            <Card>
+              <CardHeader className="p-4 pb-2">
+                <CardTitle className="text-base font-semibold">Rules</CardTitle>
+              </CardHeader>
+              <CardContent className="p-0">
+                <TableUI>
+                  <TableHeaderUI>
+                    <TableRowUI>
+                      <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
+                        Host
+                      </TableHeadUI>
+                      <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
+                        Path
+                      </TableHeadUI>
+                      <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
+                        Backend
+                      </TableHeadUI>
+                      <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
+                        Port
+                      </TableHeadUI>
                     </TableRowUI>
-                  ))
-                )}
-              </TableBodyUI>
-            </TableUI>
-          </div>
-        </section>
-      )}
+                  </TableHeaderUI>
+                  <TableBodyUI>
+                    {rules.flatMap((rule, ri) =>
+                      (rule.http?.paths ?? [{ path: undefined, pathType: undefined, backend: undefined }]).map(
+                        (p, pi) => (
+                          <TableRowUI key={`${ri}-${pi}`}>
+                            <TableCellUI className="px-4 py-2 font-mono text-sm">{rule.host ?? "*"}</TableCellUI>
+                            <TableCellUI className="px-4 py-2 font-mono text-sm">{p.path ?? "—"}</TableCellUI>
+                            <TableCellUI className="px-4 py-2 font-mono text-sm">
+                              {p.backend?.service?.name ?? "—"}
+                            </TableCellUI>
+                            <TableCellUI className="px-4 py-2 font-mono text-sm">
+                              {p.backend?.service?.port?.number ?? p.backend?.service?.port?.name ?? "—"}
+                            </TableCellUI>
+                          </TableRowUI>
+                        )
+                      )
+                    )}
+                  </TableBodyUI>
+                </TableUI>
+              </CardContent>
+            </Card>
+          )}
 
-      {tls.length > 0 && (
-        <section>
-          <h3 className="text-muted-foreground mb-2 text-sm font-semibold tracking-wide uppercase">TLS</h3>
-          <div className="bg-card rounded-md border">
-            <TableUI>
-              <TableHeaderUI>
-                <TableRowUI>
-                  <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
-                    Hosts
-                  </TableHeadUI>
-                  <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
-                    Secret
-                  </TableHeadUI>
-                </TableRowUI>
-              </TableHeaderUI>
-              <TableBodyUI>
-                {tls.map((t, i) => (
-                  <TableRowUI key={i}>
-                    <TableCellUI className="px-4 py-2 font-mono text-sm">
-                      {(t.hosts ?? []).join(", ") || "—"}
-                    </TableCellUI>
-                    <TableCellUI className="px-4 py-2 font-mono text-sm">{t.secretName ?? "—"}</TableCellUI>
-                  </TableRowUI>
-                ))}
-              </TableBodyUI>
-            </TableUI>
-          </div>
-        </section>
-      )}
+          {tls.length > 0 && (
+            <Card>
+              <CardHeader className="p-4 pb-2">
+                <CardTitle className="text-base font-semibold">TLS</CardTitle>
+              </CardHeader>
+              <CardContent className="p-0">
+                <TableUI>
+                  <TableHeaderUI>
+                    <TableRowUI>
+                      <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
+                        Hosts
+                      </TableHeadUI>
+                      <TableHeadUI className="bg-muted text-muted-foreground px-4 py-2 text-xs font-medium">
+                        Secret
+                      </TableHeadUI>
+                    </TableRowUI>
+                  </TableHeaderUI>
+                  <TableBodyUI>
+                    {tls.map((t, i) => (
+                      <TableRowUI key={i}>
+                        <TableCellUI className="px-4 py-2 font-mono text-sm">
+                          {(t.hosts ?? []).join(", ") || "—"}
+                        </TableCellUI>
+                        <TableCellUI className="px-4 py-2 font-mono text-sm">{t.secretName ?? "—"}</TableCellUI>
+                      </TableRowUI>
+                    ))}
+                  </TableBodyUI>
+                </TableUI>
+              </CardContent>
+            </Card>
+          )}
+
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Ingress Class">{ingressClass}</WorkloadInfoRow>
+            {spec?.defaultBackend && <WorkloadInfoRow label="Default Backend">{defaultBackend}</WorkloadInfoRow>}
+            <WorkloadInfoRow label="Rules">{rules.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="TLS Secrets" full>
+              {tlsSecrets.length ? tlsSecrets.join(", ") : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {ingress.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/client/src/modules/k8s/components/overrides/JobOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/JobOverviewTab.tsx
@@ -1,0 +1,141 @@
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { getJobStatusIcon, getJobStatusLabel } from "@/k8s/api/groups/batch/Job/utils/getStatus";
+import type { Job, KubeObjectBase } from "@my-project/shared";
+import { useOwnedPods } from "../../hooks/useOwnedPods";
+import {
+  ContainerImagesList,
+  ReplicaProgress,
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadPodsCard,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface JobSpecView {
+  parallelism?: number;
+  completions?: number;
+  backoffLimit?: number;
+  activeDeadlineSeconds?: number;
+  ttlSecondsAfterFinished?: number;
+  selector?: { matchLabels?: Record<string, string> };
+  template?: {
+    spec?: {
+      serviceAccountName?: string;
+      serviceAccount?: string;
+      containers?: Array<{ name: string; image?: string; imagePullPolicy?: string }>;
+    };
+  };
+}
+
+export function JobOverviewTab({ item }: { item: KubeObjectBase }) {
+  const job = item as Job;
+  const { pods, isLoading } = useOwnedPods(job, { fallbackLabels: { "job-name": job.metadata?.name ?? "" } });
+
+  const spec = job.spec as JobSpecView | undefined;
+  const status = job.status;
+  const succeeded = status?.succeeded ?? 0;
+  const failed = status?.failed ?? 0;
+  const active = status?.active ?? 0;
+  const completions = spec?.completions ?? 1;
+  const created = job.metadata?.creationTimestamp;
+  const startTime = status?.startTime;
+  const completionTime = status?.completionTime;
+
+  const containers = spec?.template?.spec?.containers ?? [];
+  const podSpec = spec?.template?.spec;
+  const owner = job.metadata?.ownerReferences?.[0];
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={<StatusBadge statusIcon={getJobStatusIcon(job)} label={getJobStatusLabel(job)} />}
+          sub="Health"
+        />
+        <WorkloadSummaryCard
+          label="Completions"
+          value={<ReplicaProgress ready={succeeded} desired={completions} />}
+          sub="Target"
+        />
+        <WorkloadSummaryCard label="Succeeded" value={succeeded} sub="Pods" />
+        <WorkloadSummaryCard label="Failed" value={failed} sub="Pods" />
+        <WorkloadSummaryCard label="Active" value={active} sub="Pods" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadPodsCard pods={pods} isLoading={isLoading} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Owner">
+              {owner ? (
+                <span className="font-mono text-xs">
+                  {owner.kind}/{owner.name}
+                </span>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Parallelism">{spec?.parallelism ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Completions">{spec?.completions ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Backoff Limit">{spec?.backoffLimit ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Active Deadline">
+              {spec?.activeDeadlineSeconds !== undefined ? `${spec.activeDeadlineSeconds}s` : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="TTL After Finished">
+              {spec?.ttlSecondsAfterFinished !== undefined ? `${spec.ttlSecondsAfterFinished}s` : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Start Time">
+              {startTime ? (
+                <Tooltip title={startTime}>
+                  <span>{formatTimestamp(startTime)}</span>
+                </Tooltip>
+              ) : (
+                "—"
+              )}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Completion Time">
+              {completionTime ? (
+                <Tooltip title={completionTime}>
+                  <span>{formatTimestamp(completionTime)}</span>
+                </Tooltip>
+              ) : (
+                "—"
+              )}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Service Account" mono>
+              {podSpec?.serviceAccountName ?? podSpec?.serviceAccount ?? "default"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Containers">{containers.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Images" full>
+              <ContainerImagesList containers={containers} />
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {job.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/NamespaceOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/NamespaceOverviewTab.tsx
@@ -1,0 +1,65 @@
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { getNamespaceStatusIcon, getNamespaceStatusLabel } from "@/k8s/api/groups/Core/Namespace/utils/getStatus";
+import type { KubeObjectBase, Namespace } from "@my-project/shared";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+export function NamespaceOverviewTab({ item }: { item: KubeObjectBase }) {
+  const namespace = item as Namespace;
+
+  const phase = namespace.status?.phase;
+  const created = namespace.metadata?.creationTimestamp;
+  const labels = namespace.metadata?.labels ?? {};
+  const annotations = namespace.metadata?.annotations ?? {};
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={
+            <StatusBadge statusIcon={getNamespaceStatusIcon(namespace)} label={getNamespaceStatusLabel(namespace)} />
+          }
+          sub="Health"
+        />
+        <WorkloadSummaryCard label="Phase" value={phase ?? "—"} sub="Lifecycle" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Phase">{phase ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Labels">{Object.keys(labels).length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Annotations">{Object.keys(annotations).length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {namespace.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/PVCOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/PVCOverviewTab.tsx
@@ -1,0 +1,117 @@
+import { useMemo } from "react";
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { getPVCStatusIcon, getPVCStatusLabel } from "@/k8s/api/groups/Core/PersistentVolumeClaim/utils/getStatus";
+import { k8sPodConfig } from "@my-project/shared";
+import type { KubeObjectBase, PersistentVolumeClaim, Pod } from "@my-project/shared";
+import { useK8sResourceList } from "../../hooks/useK8sResourceList";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadPodsCard,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface PVCSpecView {
+  accessModes?: string[];
+  storageClassName?: string;
+  volumeName?: string;
+  volumeMode?: string;
+  resources?: { requests?: { storage?: string } };
+}
+
+interface PVCStatusView {
+  phase?: string;
+  capacity?: { storage?: string };
+}
+
+export function PVCOverviewTab({ item }: { item: KubeObjectBase }) {
+  const pvc = item as PersistentVolumeClaim;
+
+  const spec = pvc.spec as PVCSpecView | undefined;
+  const status = pvc.status as PVCStatusView | undefined;
+  const created = pvc.metadata?.creationTimestamp;
+  const namespace = pvc.metadata?.namespace ?? "";
+  const pvcName = pvc.metadata?.name;
+
+  const accessModes = spec?.accessModes ?? [];
+  const accessModesText = accessModes.length ? accessModes.join(", ") : "—";
+  const capacity = status?.capacity?.storage ?? spec?.resources?.requests?.storage ?? "—";
+
+  const { data, isLoading } = useK8sResourceList<Pod>(k8sPodConfig, namespace);
+  const allPods = data.array;
+
+  const usedByPods = useMemo(() => {
+    if (!pvcName) return [];
+    return allPods.filter((pod) =>
+      (
+        (pod.spec as { volumes?: Array<{ persistentVolumeClaim?: { claimName?: string } }> } | undefined)?.volumes ?? []
+      ).some((v) => v.persistentVolumeClaim?.claimName === pvcName)
+    );
+  }, [allPods, pvcName]);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={<StatusBadge statusIcon={getPVCStatusIcon(pvc)} label={getPVCStatusLabel(pvc)} />}
+          sub="Phase"
+        />
+        <WorkloadSummaryCard label="Capacity" value={capacity} sub="Storage" />
+        <WorkloadSummaryCard label="Access Modes" value={accessModesText} sub="Modes" />
+        <WorkloadSummaryCard
+          label="Storage Class"
+          value={<span className="font-mono text-sm">{spec?.storageClassName ?? "—"}</span>}
+          sub="Class"
+        />
+        <WorkloadSummaryCard
+          label="Volume"
+          value={<span className="font-mono text-sm">{spec?.volumeName ?? "—"}</span>}
+          sub="Bound PV"
+        />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadPodsCard pods={usedByPods} isLoading={isLoading} emptyText="No pods are using this claim." />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Phase">{status?.phase ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Volume Mode">{spec?.volumeMode ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Access Modes">{accessModesText}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Storage Class" mono>
+              {spec?.storageClassName ?? "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Volume Name" mono>
+              {spec?.volumeName ?? "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Requested storage">{spec?.resources?.requests?.storage ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Capacity">{status?.capacity?.storage ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {pvc.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/PVOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/PVOverviewTab.tsx
@@ -1,0 +1,116 @@
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { getPVStatusIcon, getPVStatusLabel } from "@/k8s/api/groups/Core/PersistentVolume/utils/getStatus";
+import type { KubeObjectBase, PersistentVolume } from "@my-project/shared";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface PVSpecView {
+  capacity?: { storage?: string };
+  accessModes?: string[];
+  persistentVolumeReclaimPolicy?: string;
+  storageClassName?: string;
+  volumeMode?: string;
+  claimRef?: { namespace?: string; name?: string };
+}
+
+const KNOWN_SPEC_KEYS = new Set([
+  "capacity",
+  "accessModes",
+  "persistentVolumeReclaimPolicy",
+  "storageClassName",
+  "volumeMode",
+  "claimRef",
+  "mountOptions",
+  "nodeAffinity",
+  "volumeAttributesClassName",
+]);
+
+const detectVolumeSource = (spec: Record<string, unknown> | undefined): string | undefined => {
+  if (!spec) return undefined;
+  return Object.keys(spec).find((key) => !KNOWN_SPEC_KEYS.has(key));
+};
+
+export function PVOverviewTab({ item }: { item: KubeObjectBase }) {
+  const pv = item as PersistentVolume;
+
+  const spec = pv.spec as PVSpecView | undefined;
+  const status = pv.status as { phase?: string } | undefined;
+  const created = pv.metadata?.creationTimestamp;
+
+  const capacity = spec?.capacity?.storage;
+  const accessModes = spec?.accessModes ?? [];
+  const reclaimPolicy = spec?.persistentVolumeReclaimPolicy;
+  const storageClass = spec?.storageClassName;
+  const volumeMode = spec?.volumeMode;
+  const claimRef = spec?.claimRef;
+  const volumeSource = detectVolumeSource(pv.spec as Record<string, unknown> | undefined);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={<StatusBadge statusIcon={getPVStatusIcon(pv)} label={getPVStatusLabel(pv)} />}
+          sub="Phase"
+        />
+        <WorkloadSummaryCard label="Capacity" value={capacity ?? "—"} sub="Storage" />
+        <WorkloadSummaryCard
+          label="Access Modes"
+          value={accessModes.length ? accessModes.join(", ") : "—"}
+          sub="Modes"
+        />
+        <WorkloadSummaryCard label="Reclaim Policy" value={reclaimPolicy ?? "—"} sub="Policy" />
+        <WorkloadSummaryCard
+          label="Storage Class"
+          value={<span className="font-mono text-xs break-all">{storageClass ?? "—"}</span>}
+          sub="Class"
+        />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Phase">{status?.phase ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Capacity">{capacity ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Access Modes">{accessModes.length ? accessModes.join(", ") : "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Reclaim Policy">{reclaimPolicy ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Storage Class" mono>
+              {storageClass ?? "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Volume Mode">{volumeMode ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Claim" mono>
+              {claimRef ? `${claimRef.namespace}/${claimRef.name}` : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Volume Source">{volumeSource ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {pv.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/RoleBindingOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/RoleBindingOverviewTab.tsx
@@ -1,0 +1,73 @@
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import type { KubeObjectBase, RoleBinding } from "@my-project/shared";
+import { SubjectsCard, type RbacSubject } from "@/modules/k8s/components/rbac";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+export function RoleBindingOverviewTab({ item }: { item: KubeObjectBase }) {
+  const rb = item as RoleBinding;
+  const subjects = (rb.subjects ?? []) as RbacSubject[];
+  const roleRef = rb.roleRef;
+  const namespace = rb.metadata?.namespace;
+  const created = rb.metadata?.creationTimestamp;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Role Ref"
+          value={
+            <span className="font-mono text-xs">
+              {roleRef.kind}/{roleRef.name}
+            </span>
+          }
+          sub="Bound role"
+        />
+        <WorkloadSummaryCard label="Subjects" value={subjects.length} sub="Bound to" />
+        <WorkloadSummaryCard label="Namespace" value={namespace ?? "—"} sub="Scope" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadInformationCard title="Role Reference">
+            <WorkloadInfoRow label="Kind">{roleRef.kind}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Name" mono>
+              {roleRef.name}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="API Group">{roleRef.apiGroup || "—"}</WorkloadInfoRow>
+          </WorkloadInformationCard>
+          <SubjectsCard subjects={subjects} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Namespace">{namespace ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Subjects">{subjects.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {rb.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/RoleOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/RoleOverviewTab.tsx
@@ -1,0 +1,67 @@
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { PolicyRulesCard, type PolicyRule } from "@/modules/k8s/components/rbac";
+import type { Role, KubeObjectBase } from "@my-project/shared";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+export function RoleOverviewTab({ item }: { item: KubeObjectBase }) {
+  const role = item as Role;
+  const rules: PolicyRule[] = role.rules ?? [];
+  const created = role.metadata?.creationTimestamp;
+
+  const apiGroups = new Set<string>();
+  const verbs = new Set<string>();
+  for (const rule of rules) {
+    for (const g of rule.apiGroups ?? []) {
+      apiGroups.add(g || "core");
+    }
+    for (const v of rule.verbs ?? []) {
+      verbs.add(v);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard label="Rules" value={rules.length} sub="Policy rules" />
+        <WorkloadSummaryCard label="API Groups" value={apiGroups.size} sub="Distinct" />
+        <WorkloadSummaryCard label="Verbs" value={verbs.size} sub="Distinct" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <PolicyRulesCard rules={rules} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Namespace">{role.metadata?.namespace ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Rules">{rules.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {role.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/SecretOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/SecretOverviewTab.tsx
@@ -1,18 +1,34 @@
 import { useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { Button } from "@/core/components/ui/button";
-import { ResourceOverviewTab } from "../ResourceOverviewTab";
-import type { KubeObjectBase } from "@my-project/shared";
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import type { KubeObjectBase, Secret } from "@my-project/shared";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
 
-interface SecretLike extends KubeObjectBase {
+interface SecretView {
   type?: string;
   data?: Record<string, string>;
+  immutable?: boolean;
 }
 
 export function SecretOverviewTab({ item }: { item: KubeObjectBase }) {
   const [revealed, setRevealed] = useState<Record<string, boolean>>({});
-  const secret = item as SecretLike;
-  const data = secret.data ?? {};
+  const secret = item as Secret;
+  const view = secret as SecretView;
+
+  const data = view.data ?? {};
+  const dataEntries = Object.entries(data);
+  const dataKeyCount = dataEntries.length;
+  const immutable = view.immutable === true;
+  const created = secret.metadata?.creationTimestamp;
 
   const decode = (v: string) => {
     try {
@@ -23,35 +39,75 @@ export function SecretOverviewTab({ item }: { item: KubeObjectBase }) {
   };
 
   return (
-    <div className="grid gap-4">
-      <ResourceOverviewTab item={item} />
-      <section>
-        <h3 className="text-muted-foreground text-sm font-semibold tracking-wide uppercase">Type</h3>
-        <p className="mt-1 font-mono text-sm">{secret.type ?? "—"}</p>
-      </section>
-      <section>
-        <h3 className="text-muted-foreground text-sm font-semibold tracking-wide uppercase">Data</h3>
-        <ul className="mt-2 space-y-1 text-sm">
-          {Object.entries(data).length === 0 ? (
-            <li className="text-muted-foreground">—</li>
-          ) : (
-            Object.entries(data).map(([k, v]) => (
-              <li key={k} className="flex items-start gap-2">
-                <span className="text-muted-foreground min-w-[8rem] font-mono">{k}:</span>
-                <span className="flex-1 font-mono break-all">{revealed[k] ? decode(v) : "••••••••••••••••"}</span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setRevealed((p) => ({ ...p, [k]: !p[k] }))}
-                  aria-label={revealed[k] ? `Hide ${k}` : `Reveal ${k}`}
-                >
-                  {revealed[k] ? <EyeOff size={14} /> : <Eye size={14} />}
-                </Button>
-              </li>
-            ))
-          )}
-        </ul>
-      </section>
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Type"
+          value={<span className="font-mono text-xs break-all">{view.type ?? "—"}</span>}
+          sub="Secret type"
+        />
+        <WorkloadSummaryCard label="Data Keys" value={dataKeyCount} sub="Entries" />
+        <WorkloadSummaryCard label="Immutable" value={immutable ? "Yes" : "No"} sub="Mutability" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <Card>
+            <CardHeader className="p-4 pb-2">
+              <CardTitle className="text-base font-semibold">Data</CardTitle>
+            </CardHeader>
+            <CardContent className="p-4 pt-2">
+              <ul className="space-y-1 text-sm">
+                {dataEntries.length === 0 ? (
+                  <li className="text-muted-foreground">—</li>
+                ) : (
+                  dataEntries.map(([k, v]) => (
+                    <li key={k} className="flex items-start gap-2">
+                      <span className="text-muted-foreground min-w-[8rem] font-mono">{k}:</span>
+                      <span className="flex-1 font-mono break-all">{revealed[k] ? decode(v) : "••••••••••••••••"}</span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setRevealed((p) => ({ ...p, [k]: !p[k] }))}
+                        aria-label={revealed[k] ? `Hide ${k}` : `Reveal ${k}`}
+                      >
+                        {revealed[k] ? <EyeOff size={14} /> : <Eye size={14} />}
+                      </Button>
+                    </li>
+                  ))
+                )}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Type" mono>
+              {view.type ?? "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Data Keys">{dataKeyCount}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Immutable">{immutable ? "Yes" : "No"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {secret.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/client/src/modules/k8s/components/overrides/ServiceOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/ServiceOverviewTab.tsx
@@ -1,0 +1,175 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import type { KubeObjectBase, Service } from "@my-project/shared";
+import { useOwnedPods } from "../../hooks/useOwnedPods";
+import {
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadPodsCard,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface ServicePortView {
+  name?: string;
+  port: number;
+  targetPort?: string | number;
+  protocol?: string;
+  nodePort?: number;
+}
+
+interface ServiceSpecView {
+  type?: string;
+  clusterIP?: string;
+  clusterIPs?: string[];
+  ports?: ServicePortView[];
+  selector?: Record<string, string>;
+  sessionAffinity?: string;
+  externalTrafficPolicy?: string;
+  ipFamilies?: string[];
+}
+
+interface LoadBalancerIngressView {
+  ip?: string;
+  hostname?: string;
+}
+
+interface ServiceStatusView {
+  loadBalancer?: { ingress?: LoadBalancerIngressView[] };
+}
+
+function formatTargetPort(value?: string | number): string {
+  return value === undefined || value === "" ? "—" : String(value);
+}
+
+function getExternalEndpoint(status?: ServiceStatusView): string | undefined {
+  const ingress = status?.loadBalancer?.ingress ?? [];
+  const first = ingress.find((i) => i.ip || i.hostname);
+  return first?.ip ?? first?.hostname;
+}
+
+export function ServiceOverviewTab({ item }: { item: KubeObjectBase }) {
+  const service = item as Service;
+
+  const spec = service.spec as ServiceSpecView | undefined;
+  const status = (service as { status?: ServiceStatusView }).status;
+
+  const { pods, isLoading } = useOwnedPods(service, { fallbackLabels: spec?.selector ?? {} });
+
+  const created = service.metadata?.creationTimestamp;
+  const type = spec?.type ?? "ClusterIP";
+  const clusterIP = spec?.clusterIP ?? "—";
+  const clusterIPs = spec?.clusterIPs ?? [];
+  const ports = spec?.ports ?? [];
+  const selector = spec?.selector ?? {};
+  const selectorKeys = Object.keys(selector);
+  const externalEndpoint = getExternalEndpoint(status);
+  const ingress = status?.loadBalancer?.ingress ?? [];
+
+  const firstPort = ports[0];
+  const firstPortSub = firstPort ? `${firstPort.port} → ${formatTargetPort(firstPort.targetPort)}` : undefined;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard label="Type" value={type} sub="Service" />
+        <WorkloadSummaryCard label="Cluster IP" value={<span className="font-mono">{clusterIP}</span>} sub="Internal" />
+        <WorkloadSummaryCard label="Ports" value={ports.length} sub={firstPortSub ?? "—"} />
+        <WorkloadSummaryCard label="Selector" value={selectorKeys.length} sub="labels" />
+        <WorkloadSummaryCard label="External" value={externalEndpoint ?? "—"} sub="LoadBalancer" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <Card>
+            <CardHeader className="p-4 pb-2">
+              <CardTitle className="flex items-baseline justify-between text-base font-semibold">
+                <span>Ports</span>
+                <span className="text-muted-foreground text-xs">{ports.length}</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              {ports.length === 0 ? (
+                <div className="text-muted-foreground p-4 text-sm">No ports.</div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-muted-foreground border-b text-left text-xs">
+                        <th className="px-4 py-2 font-medium">Name</th>
+                        <th className="px-4 py-2 font-medium">Port</th>
+                        <th className="px-4 py-2 font-medium">Target</th>
+                        <th className="px-4 py-2 font-medium">Protocol</th>
+                        <th className="px-4 py-2 font-medium">NodePort</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {ports.map((port, index) => (
+                        <tr
+                          key={`${port.name ?? index}-${port.port}-${port.protocol ?? "TCP"}`}
+                          className="border-b last:border-0"
+                        >
+                          <td className="px-4 py-2 font-mono text-xs">{port.name ?? "—"}</td>
+                          <td className="px-4 py-2 tabular-nums">{port.port}</td>
+                          <td className="px-4 py-2 tabular-nums">{formatTargetPort(port.targetPort)}</td>
+                          <td className="px-4 py-2 text-xs">{port.protocol ?? "TCP"}</td>
+                          <td className="px-4 py-2 tabular-nums">{port.nodePort ?? "—"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <WorkloadPodsCard pods={pods} isLoading={isLoading} emptyText="No backing pods." />
+
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Type">{type}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Cluster IP(s)" mono>
+              {clusterIPs.length ? clusterIPs.join(", ") : clusterIP}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Session Affinity">{spec?.sessionAffinity ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="External Traffic Policy">{spec?.externalTrafficPolicy ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="IP Families">
+              {spec?.ipFamilies?.length ? spec.ipFamilies.join(", ") : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="LoadBalancer Ingress" mono>
+              {ingress.length
+                ? ingress
+                    .map((i) => i.ip ?? i.hostname)
+                    .filter(Boolean)
+                    .join(", ")
+                : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Selector" mono full>
+              {selectorKeys.length ? selectorKeys.map((k) => `${k}=${selector[k]}`).join(", ") : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {service.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/StatefulSetOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/StatefulSetOverviewTab.tsx
@@ -1,0 +1,139 @@
+import { StatusBadge } from "@/core/components/StatusBadge";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import { getStatefulSetStatusIcon, getStatefulSetStatusLabel } from "@/k8s/api/groups/apps/StatefulSet/utils/getStatus";
+import { DEPLOYMENT_REVISION_ANNOTATION } from "@my-project/shared";
+import type { KubeObjectBase, StatefulSet } from "@my-project/shared";
+import { useOwnedPods } from "../../hooks/useOwnedPods";
+import {
+  ContainerImagesList,
+  ReplicaProgress,
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadPodsCard,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface StatefulSetSpecView {
+  replicas?: number;
+  selector?: { matchLabels?: Record<string, string> };
+  serviceName?: string;
+  podManagementPolicy?: string;
+  updateStrategy?: { type?: string };
+  volumeClaimTemplates?: unknown[];
+  template?: {
+    spec?: {
+      serviceAccountName?: string;
+      serviceAccount?: string;
+      containers?: Array<{ name: string; image?: string; imagePullPolicy?: string }>;
+    };
+  };
+}
+
+interface StatefulSetStatusView {
+  currentReplicas?: number;
+}
+
+export function StatefulSetOverviewTab({ item }: { item: KubeObjectBase }) {
+  const statefulSet = item as StatefulSet;
+  const { pods, isLoading } = useOwnedPods(statefulSet);
+
+  const spec = statefulSet.spec as StatefulSetSpecView | undefined;
+  const status = statefulSet.status;
+  const statusView = status as StatefulSetStatusView | undefined;
+  const desired = spec?.replicas ?? 0;
+  const ready = status?.readyReplicas ?? 0;
+  const current = statusView?.currentReplicas ?? 0;
+  const updated = status?.updatedReplicas ?? 0;
+  const created = statefulSet.metadata?.creationTimestamp;
+
+  const containers = spec?.template?.spec?.containers ?? [];
+  const podSpec = spec?.template?.spec;
+  const selector = spec?.selector?.matchLabels ?? {};
+  const owner = statefulSet.metadata?.ownerReferences?.[0];
+  const annotations = statefulSet.metadata?.annotations ?? {};
+  const revision = annotations[DEPLOYMENT_REVISION_ANNOTATION];
+  const volumeClaimTemplatesCount = spec?.volumeClaimTemplates?.length ?? 0;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard
+          label="Status"
+          value={
+            <StatusBadge
+              statusIcon={getStatefulSetStatusIcon(statefulSet)}
+              label={getStatefulSetStatusLabel(statefulSet)}
+            />
+          }
+          sub="Health"
+        />
+        <WorkloadSummaryCard label="Desired" value={desired} sub="Replicas" />
+        <WorkloadSummaryCard
+          label="Ready"
+          value={<ReplicaProgress ready={ready} desired={desired} />}
+          sub="Available pods"
+        />
+        <WorkloadSummaryCard label="Current" value={current} sub="Replicas" />
+        <WorkloadSummaryCard label="Updated" value={updated} sub="Replicas" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadPodsCard pods={pods} isLoading={isLoading} />
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Owner">
+              {owner ? (
+                <span className="font-mono text-xs">
+                  {owner.kind}/{owner.name}
+                </span>
+              ) : (
+                <span className="text-muted-foreground">—</span>
+              )}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Revision">{revision ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Service Name">{spec?.serviceName ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Update Strategy">{spec?.updateStrategy?.type ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Pod Management Policy">{spec?.podManagementPolicy ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Volume Claim Templates">{volumeClaimTemplatesCount}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Service Account" mono>
+              {podSpec?.serviceAccountName ?? podSpec?.serviceAccount ?? "default"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Containers">{containers.length}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Selector" mono full>
+              {Object.keys(selector).length
+                ? Object.entries(selector)
+                    .map(([k, v]) => `${k}=${v}`)
+                    .join(", ")
+                : "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Images" full>
+              <ContainerImagesList containers={containers} />
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {statefulSet.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/overrides/StorageClassOverviewTab.tsx
+++ b/apps/client/src/modules/k8s/components/overrides/StorageClassOverviewTab.tsx
@@ -1,0 +1,77 @@
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime, formatTimestamp } from "@/core/utils/date-humanize/utils";
+import type { KubeObjectBase, StorageClass } from "@my-project/shared";
+import {
+  MetadataCard,
+  WorkloadInfoRow,
+  WorkloadInformationCard,
+  WorkloadOverviewSidebar,
+  WorkloadSummaryCard,
+  WorkloadSummaryGrid,
+} from "../workload";
+
+interface StorageClassView {
+  allowVolumeExpansion?: boolean;
+}
+
+const DEFAULT_CLASS_ANNOTATION = "storageclass.kubernetes.io/is-default-class";
+
+export function StorageClassOverviewTab({ item }: { item: KubeObjectBase }) {
+  const sc = item as StorageClass;
+  const view = item as StorageClassView;
+
+  const created = sc.metadata?.creationTimestamp;
+  const annotations = sc.metadata?.annotations ?? {};
+  const isDefault = annotations[DEFAULT_CLASS_ANNOTATION] === "true";
+  const allowVolumeExpansion = view.allowVolumeExpansion;
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <WorkloadSummaryGrid>
+        <WorkloadSummaryCard label="Default" value={isDefault ? "Yes" : "No"} sub="Default class" />
+        <WorkloadSummaryCard
+          label="Provisioner"
+          value={<span className="font-mono text-xs">{sc.provisioner ?? "—"}</span>}
+          sub="Driver"
+        />
+        <WorkloadSummaryCard label="Volume Binding Mode" value={sc.volumeBindingMode ?? "—"} sub="Binding" />
+        <WorkloadSummaryCard
+          label="Created"
+          value={formatRelativeTime(created)}
+          sub={
+            created ? (
+              <Tooltip title={created}>
+                <span>{formatTimestamp(created)}</span>
+              </Tooltip>
+            ) : (
+              "—"
+            )
+          }
+        />
+      </WorkloadSummaryGrid>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-4 lg:col-span-2">
+          <WorkloadInformationCard>
+            <WorkloadInfoRow label="Provisioner" mono>
+              {sc.provisioner ?? "—"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Reclaim Policy">{sc.reclaimPolicy ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Volume Binding Mode">{sc.volumeBindingMode ?? "—"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="Allow Volume Expansion">
+              {allowVolumeExpansion === undefined ? "—" : allowVolumeExpansion ? "Yes" : "No"}
+            </WorkloadInfoRow>
+            <WorkloadInfoRow label="Default">{isDefault ? "Yes" : "No"}</WorkloadInfoRow>
+            <WorkloadInfoRow label="UID" mono full>
+              {sc.metadata?.uid ?? "—"}
+            </WorkloadInfoRow>
+          </WorkloadInformationCard>
+          <MetadataCard title="Parameters" entries={sc.parameters ?? {}} />
+        </div>
+        <div className="lg:col-span-1">
+          <WorkloadOverviewSidebar item={item} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/rbac/PolicyRulesCard.tsx
+++ b/apps/client/src/modules/k8s/components/rbac/PolicyRulesCard.tsx
@@ -1,0 +1,64 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { Badge } from "@/core/components/ui/badge";
+
+export interface PolicyRule {
+  verbs: string[];
+  apiGroups?: string[];
+  resources?: string[];
+  resourceNames?: string[];
+  nonResourceURLs?: string[];
+}
+
+const list = (arr?: string[]) => (arr && arr.length ? arr.join(", ") : "—");
+
+/** Renders the policy rules of a Role / ClusterRole as a table. */
+export function PolicyRulesCard({ rules }: { rules: PolicyRule[] }) {
+  return (
+    <Card>
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="flex items-baseline justify-between text-base font-semibold">
+          <span>Policy Rules</span>
+          <span className="text-muted-foreground text-xs">{rules.length}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {rules.length === 0 ? (
+          <div className="text-muted-foreground p-4 text-sm">No rules.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground border-b text-left text-xs">
+                  <th className="px-4 py-2 font-medium">API Groups</th>
+                  <th className="px-4 py-2 font-medium">Resources</th>
+                  <th className="px-4 py-2 font-medium">Resource Names</th>
+                  <th className="px-4 py-2 font-medium">Verbs</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rules.map((rule, i) => (
+                  <tr key={i} className="border-b align-top last:border-0">
+                    <td className="px-4 py-2 font-mono text-xs">{list(rule.apiGroups?.map((g) => g || "core"))}</td>
+                    <td className="px-4 py-2 font-mono text-xs">
+                      {rule.nonResourceURLs?.length ? list(rule.nonResourceURLs) : list(rule.resources)}
+                    </td>
+                    <td className="px-4 py-2 font-mono text-xs">{list(rule.resourceNames)}</td>
+                    <td className="px-4 py-2">
+                      <div className="flex flex-wrap gap-1">
+                        {rule.verbs.map((v) => (
+                          <Badge key={v} variant="outline" className="text-[10px]">
+                            {v}
+                          </Badge>
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/components/rbac/SubjectsCard.tsx
+++ b/apps/client/src/modules/k8s/components/rbac/SubjectsCard.tsx
@@ -1,0 +1,48 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+
+export interface RbacSubject {
+  kind: string;
+  name: string;
+  namespace?: string;
+  apiGroup?: string;
+}
+
+/** Renders the subjects of a RoleBinding / ClusterRoleBinding as a table. */
+export function SubjectsCard({ subjects }: { subjects: RbacSubject[] }) {
+  return (
+    <Card>
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="flex items-baseline justify-between text-base font-semibold">
+          <span>Subjects</span>
+          <span className="text-muted-foreground text-xs">{subjects.length}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {subjects.length === 0 ? (
+          <div className="text-muted-foreground p-4 text-sm">No subjects.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground border-b text-left text-xs">
+                  <th className="px-4 py-2 font-medium">Kind</th>
+                  <th className="px-4 py-2 font-medium">Name</th>
+                  <th className="px-4 py-2 font-medium">Namespace</th>
+                </tr>
+              </thead>
+              <tbody>
+                {subjects.map((s, i) => (
+                  <tr key={i} className="border-b last:border-0">
+                    <td className="px-4 py-2 text-xs">{s.kind}</td>
+                    <td className="px-4 py-2 font-mono text-xs">{s.name}</td>
+                    <td className="text-muted-foreground px-4 py-2 font-mono text-xs">{s.namespace ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/components/rbac/index.ts
+++ b/apps/client/src/modules/k8s/components/rbac/index.ts
@@ -1,0 +1,2 @@
+export { PolicyRulesCard, type PolicyRule } from "./PolicyRulesCard";
+export { SubjectsCard, type RbacSubject } from "./SubjectsCard";

--- a/apps/client/src/modules/k8s/components/workload/CompactEventsCard.tsx
+++ b/apps/client/src/modules/k8s/components/workload/CompactEventsCard.tsx
@@ -1,0 +1,93 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime } from "@/core/utils/date-humanize/utils";
+import { k8sEventConfig } from "@my-project/shared";
+import type { KubeObjectBase } from "@my-project/shared";
+import { useK8sResourceList } from "../../hooks/useK8sResourceList";
+import { EVENT_TONE } from "../../constants/event";
+
+interface K8sEvent extends KubeObjectBase {
+  type?: string;
+  reason?: string;
+  message?: string;
+  count?: number;
+  lastTimestamp?: string;
+  eventTime?: string;
+  firstTimestamp?: string;
+  involvedObject?: {
+    kind?: string;
+    namespace?: string;
+    name?: string;
+    uid?: string;
+  };
+}
+
+/**
+ * Last-5 recent events for any namespaced object, matched by involvedObject
+ * uid (preferred) or kind+name+namespace. Generalized from the Pod detail
+ * sidebar's local `CompactEventsCard` so every workload overview can reuse it.
+ */
+export function CompactEventsCard({ item }: { item: KubeObjectBase }) {
+  const ns = item.metadata?.namespace ?? "";
+  const kind = (item as { kind?: string }).kind;
+  const result = useK8sResourceList<K8sEvent>(k8sEventConfig, ns);
+  const events = result.data.array;
+
+  const filtered = events
+    .filter(
+      (e) =>
+        e.involvedObject?.uid === item.metadata?.uid ||
+        (e.involvedObject?.kind === kind &&
+          e.involvedObject?.name === item.metadata?.name &&
+          e.involvedObject?.namespace === ns)
+    )
+    .sort((a, b) => {
+      const ta = new Date(a.lastTimestamp ?? a.eventTime ?? a.metadata?.creationTimestamp ?? 0).getTime();
+      const tb = new Date(b.lastTimestamp ?? b.eventTime ?? b.metadata?.creationTimestamp ?? 0).getTime();
+      return tb - ta;
+    })
+    .slice(0, 5);
+
+  return (
+    <Card>
+      <CardHeader className="p-3 pb-1">
+        <CardTitle className="flex items-baseline justify-between text-sm font-semibold">
+          <span>Events</span>
+          <span className="text-muted-foreground text-xs">recent</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 pt-1">
+        {filtered.length === 0 ? (
+          <div className="text-muted-foreground text-xs">No recent events for this resource.</div>
+        ) : (
+          <ul className="space-y-2">
+            {filtered.map((e, i) => {
+              const ts = e.lastTimestamp ?? e.eventTime ?? e.metadata?.creationTimestamp;
+              return (
+                <li key={i} className="flex items-start gap-2 text-xs">
+                  <span
+                    className={`mt-1 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full ${
+                      EVENT_TONE[e.type ?? ""] ?? "bg-muted-foreground"
+                    }`}
+                    aria-hidden
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="text-foreground truncate font-mono">{e.reason ?? "—"}</span>
+                      <span className="text-muted-foreground flex-shrink-0">{formatRelativeTime(ts)}</span>
+                    </div>
+                    {e.message && (
+                      <Tooltip title={e.message}>
+                        <span className="text-muted-foreground line-clamp-2 block">{e.message}</span>
+                      </Tooltip>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/components/workload/ContainerImagesList.tsx
+++ b/apps/client/src/modules/k8s/components/workload/ContainerImagesList.tsx
@@ -1,0 +1,33 @@
+import { Badge } from "@/core/components/ui/badge";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+
+export interface ContainerImageInfo {
+  name: string;
+  image?: string;
+  imagePullPolicy?: string;
+}
+
+/**
+ * Renders a workload's pod-template containers as `name | image | pullPolicy` rows.
+ */
+export function ContainerImagesList({ containers }: { containers: ContainerImageInfo[] }) {
+  if (!containers || containers.length === 0) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  return (
+    <ul className="space-y-1">
+      {containers.map((c, i) => (
+        <li key={`${c.name}-${i}`} className="flex min-w-0 items-center gap-2 text-xs">
+          <Badge variant="outline" className="shrink-0 font-mono">
+            {c.name}
+          </Badge>
+          <span className="text-muted-foreground min-w-0 flex-1 truncate font-mono">
+            <TextWithTooltip text={c.image ?? "—"} />
+          </span>
+          {c.imagePullPolicy && <span className="text-muted-foreground shrink-0">{c.imagePullPolicy}</span>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/client/src/modules/k8s/components/workload/MetadataCard.tsx
+++ b/apps/client/src/modules/k8s/components/workload/MetadataCard.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+
+/**
+ * Scrollable, count-badged `key: value` list for labels/annotations.
+ * Promoted from the Pod detail sidebar's local `MetadataListCard`.
+ */
+export function MetadataCard({ title, entries }: { title: string; entries: Record<string, string | undefined> }) {
+  const items = Object.entries(entries).filter((entry): entry is [string, string] => entry[1] !== undefined);
+
+  return (
+    <Card>
+      <CardHeader className="p-3 pb-1">
+        <CardTitle className="flex items-baseline justify-between text-sm font-semibold">
+          <span>{title}</span>
+          <span className="text-muted-foreground text-xs">{items.length}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 pt-1">
+        {items.length === 0 ? (
+          <div className="text-muted-foreground text-xs">—</div>
+        ) : (
+          <ul className="max-h-56 space-y-1 overflow-y-auto pr-1 font-mono text-xs">
+            {items.map(([k, v]) => (
+              <li key={k} className="break-all">
+                <span className="text-muted-foreground">{k}:</span> <span>{v}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/components/workload/ReplicaProgress.tsx
+++ b/apps/client/src/modules/k8s/components/workload/ReplicaProgress.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/core/utils/classname";
+
+interface ReplicaProgressProps {
+  ready: number;
+  desired: number;
+  className?: string;
+}
+
+/**
+ * A compact `ready / desired` count with a colored ratio bar.
+ * Green when fully satisfied, blue (in-progress) otherwise.
+ */
+export function ReplicaProgress({ ready, desired, className }: ReplicaProgressProps) {
+  const pct = desired > 0 ? Math.min(100, Math.round((ready / desired) * 100)) : ready > 0 ? 100 : 0;
+  const complete = desired > 0 && ready >= desired;
+
+  return (
+    <div className={cn("flex min-w-0 flex-col gap-1", className)}>
+      <span className="text-sm font-medium tabular-nums">
+        {ready} / {desired}
+      </span>
+      <div className="bg-border/40 h-1.5 w-full overflow-hidden rounded-full">
+        <div
+          className={cn("h-full rounded-full transition-all", complete ? "bg-status-success" : "bg-status-in-progress")}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/workload/WorkloadInfoCard.tsx
+++ b/apps/client/src/modules/k8s/components/workload/WorkloadInfoCard.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+
+interface WorkloadInfoRowProps {
+  label: string;
+  children: React.ReactNode;
+  mono?: boolean;
+  full?: boolean;
+}
+
+/**
+ * A fixed-label / value row inside {@link WorkloadInformationCard}.
+ * Promoted from the Pod detail page's local `InfoRow`.
+ */
+export function WorkloadInfoRow({ label, children, mono, full }: WorkloadInfoRowProps) {
+  return (
+    <div className={full ? "col-span-2" : ""}>
+      <div className="text-muted-foreground text-[11px] tracking-wide uppercase">{label}</div>
+      <div className={`mt-0.5 text-sm ${mono ? "font-mono text-xs break-all" : ""}`}>{children}</div>
+    </div>
+  );
+}
+
+/** Card wrapper that lays out {@link WorkloadInfoRow} children in a 2-column grid. */
+export function WorkloadInformationCard({
+  title = "Information",
+  children,
+}: {
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="text-base font-semibold">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 gap-x-6 gap-y-3 p-4 pt-2 sm:grid-cols-2">{children}</CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/components/workload/WorkloadOverviewSidebar.tsx
+++ b/apps/client/src/modules/k8s/components/workload/WorkloadOverviewSidebar.tsx
@@ -1,0 +1,17 @@
+import type { KubeObjectBase } from "@my-project/shared";
+import { CompactEventsCard } from "./CompactEventsCard";
+import { MetadataCard } from "./MetadataCard";
+
+/**
+ * Shared right-rail for workload overviews: recent events + labels + annotations.
+ * Mirrors the Pod detail page's `PodOverviewSidebar` minus the pod-only ports card.
+ */
+export function WorkloadOverviewSidebar({ item }: { item: KubeObjectBase }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <CompactEventsCard item={item} />
+      <MetadataCard title="Labels" entries={item.metadata?.labels ?? {}} />
+      <MetadataCard title="Annotations" entries={item.metadata?.annotations ?? {}} />
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/components/workload/WorkloadPodsCard.tsx
+++ b/apps/client/src/modules/k8s/components/workload/WorkloadPodsCard.tsx
@@ -1,0 +1,98 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { StatusIcon } from "@/core/components/StatusIcon";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime } from "@/core/utils/date-humanize/utils";
+import {
+  getPodReadyCounts,
+  getPodRestartCount,
+  getPodStatusIcon,
+  getPodStatusLabel,
+} from "@/k8s/api/groups/Core/Pod/utils/getStatusIcon";
+import type { Pod } from "@my-project/shared";
+
+interface WorkloadPodsCardProps {
+  pods: Pod[];
+  isLoading?: boolean;
+  emptyText?: string;
+}
+
+/**
+ * Lists the pods owned by a workload: name + IP, status, ready, restarts, node, age.
+ * Pair with the `useOwnedPods` hook.
+ */
+export function WorkloadPodsCard({ pods, isLoading, emptyText = "No pods." }: WorkloadPodsCardProps) {
+  return (
+    <Card>
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="flex items-baseline justify-between text-base font-semibold">
+          <span>Pods</span>
+          <span className="text-muted-foreground text-xs">{pods.length}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {isLoading && pods.length === 0 ? (
+          <div className="text-muted-foreground p-4 text-sm">Loading…</div>
+        ) : pods.length === 0 ? (
+          <div className="text-muted-foreground p-4 text-sm">{emptyText}</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground border-b text-left text-xs">
+                  <th className="px-4 py-2 font-medium">Name</th>
+                  <th className="px-4 py-2 font-medium">Status</th>
+                  <th className="px-4 py-2 font-medium">Ready</th>
+                  <th className="px-4 py-2 font-medium">Restarts</th>
+                  <th className="px-4 py-2 font-medium">Node</th>
+                  <th className="px-4 py-2 font-medium">Age</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pods.map((pod) => {
+                  const icon = getPodStatusIcon(pod);
+                  const { ready, total } = getPodReadyCounts(pod);
+                  const created = pod.metadata?.creationTimestamp;
+                  return (
+                    <tr key={pod.metadata?.uid ?? pod.metadata?.name} className="border-b last:border-0">
+                      <td className="px-4 py-2">
+                        <div className="font-mono text-xs">{pod.metadata?.name}</div>
+                        {pod.status?.podIP && (
+                          <div className="text-muted-foreground font-mono text-[11px]">{pod.status.podIP}</div>
+                        )}
+                      </td>
+                      <td className="px-4 py-2">
+                        <div className="flex items-center gap-1.5">
+                          <StatusIcon
+                            Icon={icon.component}
+                            color={icon.color}
+                            isSpinning={icon.isSpinning}
+                            width={14}
+                          />
+                          <span className="text-xs">{getPodStatusLabel(pod)}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-2 tabular-nums">
+                        {ready}/{total}
+                      </td>
+                      <td className="px-4 py-2 tabular-nums">{getPodRestartCount(pod)}</td>
+                      <td className="px-4 py-2 font-mono text-xs">{pod.spec?.nodeName ?? "—"}</td>
+                      <td className="text-muted-foreground px-4 py-2">
+                        {created ? (
+                          <Tooltip title={created}>
+                            <span>{formatRelativeTime(created)}</span>
+                          </Tooltip>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/components/workload/WorkloadSummaryCard.tsx
+++ b/apps/client/src/modules/k8s/components/workload/WorkloadSummaryCard.tsx
@@ -1,0 +1,27 @@
+import { Card } from "@/core/components/ui/card";
+
+interface WorkloadSummaryCardProps {
+  label: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+}
+
+/**
+ * A single stat tile used in the workload overview summary grid.
+ * Promoted from the Pod detail page's local `SummaryCard` so every workload
+ * (Deployment, StatefulSet, DaemonSet, Job, CronJob, …) renders identical tiles.
+ */
+export function WorkloadSummaryCard({ label, value, sub }: WorkloadSummaryCardProps) {
+  return (
+    <Card className="flex min-w-0 flex-col gap-1 p-3">
+      <div className="text-muted-foreground text-[11px] tracking-wide uppercase">{label}</div>
+      <div className="text-foreground min-w-0 truncate text-sm font-medium">{value}</div>
+      {sub !== undefined && <div className="text-muted-foreground truncate text-xs">{sub}</div>}
+    </Card>
+  );
+}
+
+/** Responsive 2/3/6-column grid wrapper for {@link WorkloadSummaryCard} tiles. */
+export function WorkloadSummaryGrid({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6">{children}</div>;
+}

--- a/apps/client/src/modules/k8s/components/workload/index.ts
+++ b/apps/client/src/modules/k8s/components/workload/index.ts
@@ -1,0 +1,8 @@
+export { WorkloadSummaryCard, WorkloadSummaryGrid } from "./WorkloadSummaryCard";
+export { WorkloadInfoRow, WorkloadInformationCard } from "./WorkloadInfoCard";
+export { ContainerImagesList, type ContainerImageInfo } from "./ContainerImagesList";
+export { ReplicaProgress } from "./ReplicaProgress";
+export { MetadataCard } from "./MetadataCard";
+export { CompactEventsCard } from "./CompactEventsCard";
+export { WorkloadOverviewSidebar } from "./WorkloadOverviewSidebar";
+export { WorkloadPodsCard } from "./WorkloadPodsCard";

--- a/apps/client/src/modules/k8s/constants/event.ts
+++ b/apps/client/src/modules/k8s/constants/event.ts
@@ -1,0 +1,12 @@
+// Kubernetes core Event `type` values.
+export const EVENT_TYPE = {
+  NORMAL: "Normal",
+  WARNING: "Warning",
+} as const;
+
+// Tailwind background tone for an event indicator dot, keyed by Event `type`.
+// Fall back to `bg-muted-foreground` for unknown types.
+export const EVENT_TONE: Record<string, string> = {
+  [EVENT_TYPE.NORMAL]: "bg-emerald-500",
+  [EVENT_TYPE.WARNING]: "bg-amber-500",
+};

--- a/apps/client/src/modules/k8s/hooks/useOwnedPods.ts
+++ b/apps/client/src/modules/k8s/hooks/useOwnedPods.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { k8sPodConfig } from "@my-project/shared";
+import type { KubeObjectBase, Pod } from "@my-project/shared";
+import { useK8sResourceList } from "./useK8sResourceList";
+
+interface UseOwnedPodsOptions {
+  /** Label selector to use when the workload has no `spec.selector.matchLabels` (e.g. Job → `job-name`). */
+  fallbackLabels?: Record<string, string>;
+}
+
+/**
+ * Returns the pods owned by a workload by matching the workload's
+ * `spec.selector.matchLabels` against pod labels within the same namespace.
+ *
+ * Mirrors the existing client-side filter pattern (see the Pod detail sidebar's
+ * events card) rather than relying on server-side label selectors, keeping it
+ * consistent with how related resources are already surfaced.
+ */
+export function useOwnedPods(
+  workload: KubeObjectBase,
+  options?: UseOwnedPodsOptions
+): { pods: Pod[]; isLoading: boolean } {
+  const namespace = workload.metadata?.namespace ?? "";
+  const result = useK8sResourceList<Pod>(k8sPodConfig, namespace);
+  const allPods = result.data.array;
+
+  const spec = (workload as { spec?: { selector?: { matchLabels?: Record<string, string> } } }).spec;
+  const matchLabels = spec?.selector?.matchLabels ?? options?.fallbackLabels;
+
+  const pods = useMemo(() => {
+    const labels = matchLabels ?? {};
+    const keys = Object.keys(labels);
+    if (keys.length === 0) return [];
+    return allPods.filter((pod) => {
+      const podLabels = pod.metadata?.labels ?? {};
+      return keys.every((key) => podLabels[key] === labels[key]);
+    });
+    // matchLabels is recomputed each render; stringify keeps the dep stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allPods, JSON.stringify(matchLabels)]);
+
+  return { pods, isLoading: result.isLoading };
+}

--- a/apps/client/src/modules/k8s/pages/pods/detail/components/PodOverviewSidebar.tsx
+++ b/apps/client/src/modules/k8s/pages/pods/detail/components/PodOverviewSidebar.tsx
@@ -5,6 +5,7 @@ import { useK8sResourceList } from "../../../../hooks/useK8sResourceList";
 import { formatRelativeTime } from "@/core/utils/date-humanize/utils";
 import { k8sEventConfig } from "@my-project/shared";
 import type { KubeObjectBase, Pod } from "@my-project/shared";
+import { EVENT_TONE } from "../../../../constants/event";
 
 interface K8sEvent extends KubeObjectBase {
   type?: string;
@@ -21,11 +22,6 @@ interface K8sEvent extends KubeObjectBase {
     uid?: string;
   };
 }
-
-const EVENT_TONE: Record<string, string> = {
-  Normal: "bg-emerald-500",
-  Warning: "bg-amber-500",
-};
 
 function CompactEventsCard({ pod }: { pod: Pod }) {
   const ns = pod.metadata?.namespace ?? "";

--- a/apps/client/src/modules/k8s/registry/descriptors/cluster-role-bindings.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/cluster-role-bindings.ts
@@ -1,6 +1,7 @@
 import { Key } from "lucide-react";
 import { k8sClusterRoleBindingConfig } from "@my-project/shared";
 import { clusterRoleBindingColumns } from "./cluster-role-bindings.columns";
+import { ClusterRoleBindingOverviewTab } from "../../components/overrides/ClusterRoleBindingOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const clusterRoleBindingsDescriptor: ResourceDescriptor = {
@@ -12,4 +13,5 @@ export const clusterRoleBindingsDescriptor: ResourceDescriptor = {
   defaultSort: { sortBy: "name", order: "asc" },
   columns: clusterRoleBindingColumns,
   status: () => ({ phase: "Active", severity: "success" }),
+  overviewTab: ClusterRoleBindingOverviewTab,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/cluster-roles.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/cluster-roles.ts
@@ -1,6 +1,7 @@
 import { ShieldCheck } from "lucide-react";
 import { k8sClusterRoleConfig } from "@my-project/shared";
 import { clusterRoleColumns } from "./cluster-roles.columns";
+import { ClusterRoleOverviewTab } from "../../components/overrides/ClusterRoleOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const clusterRolesDescriptor: ResourceDescriptor = {
@@ -12,4 +13,5 @@ export const clusterRolesDescriptor: ResourceDescriptor = {
   defaultSort: { sortBy: "name", order: "asc" },
   columns: clusterRoleColumns,
   status: () => ({ phase: "Active", severity: "success" }),
+  overviewTab: ClusterRoleOverviewTab,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/columnHelpers.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/columnHelpers.tsx
@@ -2,10 +2,38 @@ import type { ReactElement } from "react";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
 import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { StatusIcon } from "@/core/components/StatusIcon";
 import { Tooltip } from "@/core/components/ui/tooltip";
 import { formatTimestamp, formatUnixTimestamp } from "@/core/utils/date-humanize";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
 
 export type RenderName = (data: KubeObjectBase) => ReactElement | string | number | undefined | null;
+
+/**
+ * Status column shared by every resource list descriptor. Each resource only
+ * differs by its `getStatusIcon`/`getStatusLabel` pair, so the JSX lives here.
+ */
+export const makeStatusColumn = <T extends KubeObjectBase>(
+  getStatusIcon: (data: T) => K8sResourceStatusIcon,
+  getStatusLabel: (data: T) => string,
+  baseWidth = 12
+): TableColumn<KubeObjectBase> => ({
+  id: "status",
+  label: "Status",
+  data: {
+    render: ({ data }) => {
+      const resource = data as T;
+      const icon = getStatusIcon(resource);
+      return (
+        <div className="flex items-center gap-1.5">
+          <StatusIcon Icon={icon.component} color={icon.color} isSpinning={icon.isSpinning} width={14} />
+          <span className="text-sm">{getStatusLabel(resource)}</span>
+        </div>
+      );
+    },
+  },
+  cell: { baseWidth },
+});
 
 export const makeNameColumn = (renderName: RenderName): TableColumn<KubeObjectBase> => ({
   id: "name",

--- a/apps/client/src/modules/k8s/registry/descriptors/cronjobs.actions.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/cronjobs.actions.tsx
@@ -1,0 +1,110 @@
+import { Pause, Play, Rocket } from "lucide-react";
+import { k8sCronJobConfig, k8sJobConfig, CRONJOB_NAME_LABEL, RUN_NOW_ANNOTATION } from "@my-project/shared";
+import type { KubeObjectBase, KubeObjectDraft } from "@my-project/shared";
+import { ButtonWithPermission } from "@/core/components/ButtonWithPermission";
+import { useDialogOpener } from "@/core/providers/Dialog/hooks";
+import { ConfirmDialog } from "@/core/components/Confirm";
+import { usePermissions } from "@/k8s/api/hooks/usePermissions";
+import { useK8sUpdate } from "@/modules/k8s/hooks/useK8sUpdate";
+import { useBasicCRUD } from "@/k8s/api/hooks/useBasicCRUD";
+
+interface CronJobView extends KubeObjectBase {
+  spec?: {
+    suspend?: boolean;
+    jobTemplate?: {
+      metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> };
+      spec?: Record<string, unknown>;
+    };
+  };
+}
+
+/**
+ * Header actions for CronJob:
+ *  - Run now: creates a one-off Job from `spec.jobTemplate` owned by the CronJob.
+ *  - Suspend / Resume: flips `spec.suspend` via a full-object update.
+ */
+export function CronJobHeaderActions({ item }: { item: KubeObjectBase }) {
+  const cronJob = item as CronJobView;
+  const namespace = cronJob.metadata?.namespace ?? "";
+  const name = cronJob.metadata?.name ?? "";
+  const suspended = cronJob.spec?.suspend === true;
+
+  const cronJobPerms = usePermissions({
+    group: k8sCronJobConfig.group,
+    version: k8sCronJobConfig.version,
+    resourcePlural: k8sCronJobConfig.pluralName,
+  });
+  const jobPerms = usePermissions({
+    group: k8sJobConfig.group,
+    version: k8sJobConfig.version,
+    resourcePlural: k8sJobConfig.pluralName,
+  });
+
+  const update = useK8sUpdate(k8sCronJobConfig);
+  const { triggerCreate } = useBasicCRUD<KubeObjectDraft>(k8sJobConfig);
+  const openConfirm = useDialogOpener(ConfirmDialog);
+
+  const handleToggleSuspend = () => {
+    openConfirm({
+      text: `${suspended ? "Resume" : "Suspend"} CronJob "${name}"?`,
+      actionCallback: async () => {
+        const body = structuredClone(item) as CronJobView;
+        body.spec = { ...(body.spec ?? {}), suspend: !suspended };
+        update.mutate({ namespace, name, body });
+      },
+    });
+  };
+
+  const handleRunNow = () => {
+    openConfirm({
+      text: `Trigger a manual run of CronJob "${name}" now?`,
+      actionCallback: async () => {
+        const template = cronJob.spec?.jobTemplate ?? {};
+        const jobName = `${name}-manual-${Math.floor(Date.now() / 1000)}`;
+        const job = {
+          apiVersion: k8sJobConfig.apiVersion,
+          kind: k8sJobConfig.kind,
+          metadata: {
+            name: jobName,
+            namespace,
+            labels: { ...(template.metadata?.labels ?? {}), [CRONJOB_NAME_LABEL]: name },
+            annotations: { ...(template.metadata?.annotations ?? {}), [RUN_NOW_ANNOTATION]: "true" },
+            ownerReferences: [
+              {
+                apiVersion: k8sCronJobConfig.apiVersion,
+                kind: k8sCronJobConfig.kind,
+                name,
+                uid: cronJob.metadata?.uid ?? "",
+                controller: false,
+                blockOwnerDeletion: true,
+              },
+            ],
+          },
+          spec: structuredClone(template.spec ?? {}),
+        } as unknown as KubeObjectDraft;
+
+        triggerCreate({ data: { resource: job } });
+      },
+    });
+  };
+
+  return (
+    <>
+      <ButtonWithPermission
+        allowed={jobPerms.data.create.allowed}
+        reason={jobPerms.data.create.reason ?? ""}
+        ButtonProps={{ variant: "outline", size: "sm", onClick: handleRunNow }}
+      >
+        <Rocket size={14} className="mr-1.5" /> Run now
+      </ButtonWithPermission>
+      <ButtonWithPermission
+        allowed={cronJobPerms.data.update.allowed}
+        reason={cronJobPerms.data.update.reason ?? ""}
+        ButtonProps={{ variant: "outline", size: "sm", onClick: handleToggleSuspend }}
+      >
+        {suspended ? <Play size={14} className="mr-1.5" /> : <Pause size={14} className="mr-1.5" />}
+        {suspended ? "Resume" : "Suspend"}
+      </ButtonWithPermission>
+    </>
+  );
+}

--- a/apps/client/src/modules/k8s/registry/descriptors/cronjobs.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/cronjobs.columns.tsx
@@ -1,11 +1,13 @@
 import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
-import { makeNameColumn, namespaceColumn, ageColumn } from "./columnHelpers";
+import { getCronJobStatusIcon, getCronJobStatusLabel } from "@/k8s/api/groups/batch/CronJob/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, namespaceColumn, ageColumn } from "./columnHelpers";
 
 export const cronJobColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
   namespaceColumn,
+  makeStatusColumn(getCronJobStatusIcon, getCronJobStatusLabel),
   {
     id: "schedule",
     label: "Schedule",
@@ -24,6 +26,17 @@ export const cronJobColumns = (renderName: RenderName): TableColumn<KubeObjectBa
       render: ({ data }) => {
         const s = data as { spec?: { suspend?: boolean } };
         return s.spec?.suspend ? "Yes" : "No";
+      },
+    },
+    cell: { baseWidth: 10 },
+  },
+  {
+    id: "active",
+    label: "Active",
+    data: {
+      render: ({ data }) => {
+        const s = data as { status?: { active?: unknown[] } };
+        return String(s.status?.active?.length ?? 0);
       },
     },
     cell: { baseWidth: 10 },

--- a/apps/client/src/modules/k8s/registry/descriptors/cronjobs.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/cronjobs.ts
@@ -1,6 +1,8 @@
 import { Clock } from "lucide-react";
 import { k8sCronJobConfig } from "@my-project/shared";
 import { cronJobColumns } from "./cronjobs.columns";
+import { CronJobOverviewTab } from "../../components/overrides/CronJobOverviewTab";
+import { CronJobHeaderActions } from "./cronjobs.actions";
 import type { ResourceDescriptor } from "../types";
 
 export const cronJobsDescriptor: ResourceDescriptor = {
@@ -15,4 +17,6 @@ export const cronJobsDescriptor: ResourceDescriptor = {
     const spec = (item as { spec?: { suspend?: boolean } }).spec;
     return spec?.suspend ? { phase: "Suspended", severity: "neutral" } : { phase: "Active", severity: "success" };
   },
+  overviewTab: CronJobOverviewTab,
+  actionsSlot: CronJobHeaderActions,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/daemonsets.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/daemonsets.columns.tsx
@@ -1,11 +1,14 @@
 import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
-import { makeNameColumn, namespaceColumn, ageColumn } from "./columnHelpers";
+import { ReplicaProgress } from "@/modules/k8s/components/workload";
+import { getDaemonSetStatusIcon, getDaemonSetStatusLabel } from "@/k8s/api/groups/apps/DaemonSet/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, namespaceColumn, ageColumn } from "./columnHelpers";
 
 export const daemonSetColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
   namespaceColumn,
+  makeStatusColumn(getDaemonSetStatusIcon, getDaemonSetStatusLabel),
   {
     id: "desired",
     label: "Desired",
@@ -33,8 +36,19 @@ export const daemonSetColumns = (renderName: RenderName): TableColumn<KubeObject
     label: "Ready",
     data: {
       render: ({ data }) => {
-        const s = data as { status?: { numberReady?: number } };
-        return String(s.status?.numberReady ?? 0);
+        const s = data as { status?: { numberReady?: number; desiredNumberScheduled?: number } };
+        return <ReplicaProgress ready={s.status?.numberReady ?? 0} desired={s.status?.desiredNumberScheduled ?? 0} />;
+      },
+    },
+    cell: { baseWidth: 12 },
+  },
+  {
+    id: "available",
+    label: "Available",
+    data: {
+      render: ({ data }) => {
+        const s = data as { status?: { numberAvailable?: number } };
+        return String(s.status?.numberAvailable ?? 0);
       },
     },
     cell: { baseWidth: 10 },

--- a/apps/client/src/modules/k8s/registry/descriptors/daemonsets.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/daemonsets.ts
@@ -2,6 +2,7 @@ import { Workflow } from "lucide-react";
 import { k8sDaemonSetConfig } from "@my-project/shared";
 import { daemonSetColumns } from "./daemonsets.columns";
 import { DaemonSetHeaderActions } from "./daemonsets.actions";
+import { DaemonSetOverviewTab } from "../../components/overrides/DaemonSetOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const daemonSetsDescriptor: ResourceDescriptor = {
@@ -20,5 +21,6 @@ export const daemonSetsDescriptor: ResourceDescriptor = {
       ? { phase: "Available", severity: "success" }
       : { phase: "Progressing", severity: "warning" };
   },
+  overviewTab: DaemonSetOverviewTab,
   actionsSlot: DaemonSetHeaderActions,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/deployments.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/deployments.columns.tsx
@@ -2,21 +2,24 @@ import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
 import { TextWithTooltip } from "@/core/components/TextWithTooltip";
-import { makeNameColumn, namespaceColumn, ageColumn } from "./columnHelpers";
+import { ReplicaProgress } from "@/modules/k8s/components/workload";
+import { getDeploymentStatusIcon, getDeploymentStatusLabel } from "@/k8s/api/groups/apps/Deployment/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, namespaceColumn, ageColumn } from "./columnHelpers";
 
 export const deploymentColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
   namespaceColumn,
+  makeStatusColumn(getDeploymentStatusIcon, getDeploymentStatusLabel),
   {
     id: "ready",
     label: "Ready",
     data: {
       render: ({ data }) => {
         const d = data as { status?: { readyReplicas?: number }; spec?: { replicas?: number } };
-        return `${d.status?.readyReplicas ?? 0}/${d.spec?.replicas ?? 0}`;
+        return <ReplicaProgress ready={d.status?.readyReplicas ?? 0} desired={d.spec?.replicas ?? 0} />;
       },
     },
-    cell: { baseWidth: 10 },
+    cell: { baseWidth: 12 },
   },
   {
     id: "up-to-date",

--- a/apps/client/src/modules/k8s/registry/descriptors/deployments.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/deployments.ts
@@ -2,6 +2,7 @@ import { Rocket } from "lucide-react";
 import { k8sDeploymentConfig } from "@my-project/shared";
 import { deploymentColumns } from "./deployments.columns";
 import { DeploymentHeaderActions } from "./deployments.actions";
+import { DeploymentOverviewTab } from "../../components/overrides/DeploymentOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const deploymentsDescriptor: ResourceDescriptor = {
@@ -22,5 +23,6 @@ export const deploymentsDescriptor: ResourceDescriptor = {
       ? { phase: "Available", severity: "success" }
       : { phase: "Progressing", severity: "warning" };
   },
+  overviewTab: DeploymentOverviewTab,
   actionsSlot: DeploymentHeaderActions,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/horizontal-pod-autoscalers.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/horizontal-pod-autoscalers.columns.tsx
@@ -1,22 +1,27 @@
 import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
-import { makeNameColumn, namespaceColumn, ageColumn } from "./columnHelpers";
+import {
+  getHPAStatusIcon,
+  getHPAStatusLabel,
+} from "@/k8s/api/groups/autoscaling/HorizontalPodAutoscaler/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, namespaceColumn, ageColumn } from "./columnHelpers";
 
 export const horizontalPodAutoscalerColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
   namespaceColumn,
+  makeStatusColumn(getHPAStatusIcon, getHPAStatusLabel),
   {
     id: "target",
-    label: "Target",
+    label: "Scale Target",
     data: {
       render: ({ data }) => {
         const s = data as { spec?: { scaleTargetRef?: { kind?: string; name?: string } } };
         const ref = s.spec?.scaleTargetRef;
-        return ref ? `${ref.kind ?? ""}/${ref.name ?? ""}` : "—";
+        return ref?.name ?? "—";
       },
     },
-    cell: { baseWidth: 20 },
+    cell: { baseWidth: 18 },
   },
   {
     id: "min",
@@ -41,23 +46,12 @@ export const horizontalPodAutoscalerColumns = (renderName: RenderName): TableCol
     cell: { baseWidth: 8 },
   },
   {
-    id: "current",
-    label: "Current",
+    id: "replicas",
+    label: "Replicas",
     data: {
       render: ({ data }) => {
         const s = data as { status?: { currentReplicas?: number } };
         return String(s.status?.currentReplicas ?? 0);
-      },
-    },
-    cell: { baseWidth: 10 },
-  },
-  {
-    id: "desired",
-    label: "Desired",
-    data: {
-      render: ({ data }) => {
-        const s = data as { status?: { desiredReplicas?: number } };
-        return String(s.status?.desiredReplicas ?? 0);
       },
     },
     cell: { baseWidth: 10 },

--- a/apps/client/src/modules/k8s/registry/descriptors/horizontal-pod-autoscalers.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/horizontal-pod-autoscalers.ts
@@ -1,6 +1,7 @@
 import { Gauge } from "lucide-react";
 import { k8sHorizontalPodAutoscalerConfig } from "@my-project/shared";
 import { horizontalPodAutoscalerColumns } from "./horizontal-pod-autoscalers.columns";
+import { HPAOverviewTab } from "../../components/overrides/HPAOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const horizontalPodAutoscalersDescriptor: ResourceDescriptor = {
@@ -11,5 +12,6 @@ export const horizontalPodAutoscalersDescriptor: ResourceDescriptor = {
   detailVariant: "namespaced",
   defaultSort: { sortBy: "name", order: "asc" },
   columns: horizontalPodAutoscalerColumns,
+  overviewTab: HPAOverviewTab,
   status: () => ({ phase: "Active", severity: "success" }),
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/jobs.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/jobs.columns.tsx
@@ -1,7 +1,9 @@
 import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
-import { makeNameColumn, namespaceColumn, ageColumn } from "./columnHelpers";
+import { ReplicaProgress } from "@/modules/k8s/components/workload";
+import { getJobStatusIcon, getJobStatusLabel } from "@/k8s/api/groups/batch/Job/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, namespaceColumn, ageColumn } from "./columnHelpers";
 
 const formatDuration = (start?: string, end?: string) => {
   if (!start) return "—";
@@ -17,13 +19,14 @@ const formatDuration = (start?: string, end?: string) => {
 export const jobColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
   namespaceColumn,
+  makeStatusColumn(getJobStatusIcon, getJobStatusLabel),
   {
     id: "completions",
     label: "Completions",
     data: {
       render: ({ data }) => {
         const s = data as { status?: { succeeded?: number }; spec?: { completions?: number } };
-        return `${s.status?.succeeded ?? 0}/${s.spec?.completions ?? 1}`;
+        return <ReplicaProgress ready={s.status?.succeeded ?? 0} desired={s.spec?.completions ?? 1} />;
       },
     },
     cell: { baseWidth: 14 },

--- a/apps/client/src/modules/k8s/registry/descriptors/jobs.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/jobs.ts
@@ -1,6 +1,7 @@
 import { Play } from "lucide-react";
 import { k8sJobConfig } from "@my-project/shared";
 import { jobColumns } from "./jobs.columns";
+import { JobOverviewTab } from "../../components/overrides/JobOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const jobsDescriptor: ResourceDescriptor = {
@@ -22,4 +23,5 @@ export const jobsDescriptor: ResourceDescriptor = {
     if (succeeded >= completions) return { phase: "Complete", severity: "success" };
     return { phase: "Running", severity: "info" };
   },
+  overviewTab: JobOverviewTab,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/namespaces.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/namespaces.columns.tsx
@@ -1,13 +1,15 @@
 import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
-import { makeNameColumn, ageColumn } from "./columnHelpers";
+import { getNamespaceStatusIcon, getNamespaceStatusLabel } from "@/k8s/api/groups/Core/Namespace/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, ageColumn } from "./columnHelpers";
 
 export const namespaceColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
+  makeStatusColumn(getNamespaceStatusIcon, getNamespaceStatusLabel),
   {
-    id: "status",
-    label: "Status",
+    id: "phase",
+    label: "Phase",
     data: {
       render: ({ data }) => {
         const s = data as { status?: { phase?: string } };

--- a/apps/client/src/modules/k8s/registry/descriptors/namespaces.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/namespaces.ts
@@ -1,6 +1,7 @@
 import { Boxes } from "lucide-react";
 import { k8sNamespaceConfig } from "@my-project/shared";
 import { namespaceColumns } from "./namespaces.columns";
+import { NamespaceOverviewTab } from "../../components/overrides/NamespaceOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const namespacesDescriptor: ResourceDescriptor = {
@@ -11,6 +12,7 @@ export const namespacesDescriptor: ResourceDescriptor = {
   detailVariant: "cluster",
   defaultSort: { sortBy: "name", order: "asc" },
   columns: namespaceColumns,
+  overviewTab: NamespaceOverviewTab,
   status: (item) => {
     const phase = (item as { status?: { phase?: string } }).status?.phase ?? "";
     if (phase === "Active") return { phase: "Active", severity: "success" };

--- a/apps/client/src/modules/k8s/registry/descriptors/persistent-volume-claims.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/persistent-volume-claims.columns.tsx
@@ -2,22 +2,13 @@ import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
 import { TextWithTooltip } from "@/core/components/TextWithTooltip";
-import { makeNameColumn, namespaceColumn, ageColumn } from "./columnHelpers";
+import { getPVCStatusIcon, getPVCStatusLabel } from "@/k8s/api/groups/Core/PersistentVolumeClaim/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, namespaceColumn, ageColumn } from "./columnHelpers";
 
 export const persistentVolumeClaimColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
   namespaceColumn,
-  {
-    id: "status",
-    label: "Status",
-    data: {
-      render: ({ data }) => {
-        const s = data as { status?: { phase?: string } };
-        return s.status?.phase ?? "—";
-      },
-    },
-    cell: { baseWidth: 12 },
-  },
+  makeStatusColumn(getPVCStatusIcon, getPVCStatusLabel),
   {
     id: "volume",
     label: "Volume",

--- a/apps/client/src/modules/k8s/registry/descriptors/persistent-volume-claims.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/persistent-volume-claims.ts
@@ -1,6 +1,7 @@
 import { Database } from "lucide-react";
 import { k8sPersistentVolumeClaimConfig } from "@my-project/shared";
 import { persistentVolumeClaimColumns } from "./persistent-volume-claims.columns";
+import { PVCOverviewTab } from "../../components/overrides/PVCOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const persistentVolumeClaimsDescriptor: ResourceDescriptor = {
@@ -17,4 +18,5 @@ export const persistentVolumeClaimsDescriptor: ResourceDescriptor = {
     if (phase === "Pending") return { phase: "Pending", severity: "warning" };
     return { phase: phase || "Unknown", severity: "neutral" };
   },
+  overviewTab: PVCOverviewTab,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/persistent-volumes.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/persistent-volumes.columns.tsx
@@ -2,21 +2,12 @@ import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
 import { TextWithTooltip } from "@/core/components/TextWithTooltip";
-import { makeNameColumn, ageColumn } from "./columnHelpers";
+import { getPVStatusIcon, getPVStatusLabel } from "@/k8s/api/groups/Core/PersistentVolume/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, ageColumn } from "./columnHelpers";
 
 export const persistentVolumeColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
-  {
-    id: "status",
-    label: "Status",
-    data: {
-      render: ({ data }) => {
-        const s = data as { status?: { phase?: string } };
-        return s.status?.phase ?? "—";
-      },
-    },
-    cell: { baseWidth: 12 },
-  },
+  makeStatusColumn(getPVStatusIcon, getPVStatusLabel),
   {
     id: "capacity",
     label: "Capacity",

--- a/apps/client/src/modules/k8s/registry/descriptors/persistent-volumes.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/persistent-volumes.ts
@@ -1,6 +1,7 @@
 import { HardDrive } from "lucide-react";
 import { k8sPersistentVolumeConfig } from "@my-project/shared";
 import { persistentVolumeColumns } from "./persistent-volumes.columns";
+import { PVOverviewTab } from "../../components/overrides/PVOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const persistentVolumesDescriptor: ResourceDescriptor = {
@@ -11,6 +12,7 @@ export const persistentVolumesDescriptor: ResourceDescriptor = {
   detailVariant: "cluster",
   defaultSort: { sortBy: "name", order: "asc" },
   columns: persistentVolumeColumns,
+  overviewTab: PVOverviewTab,
   status: (item) => {
     const phase = (item as { status?: { phase?: string } }).status?.phase ?? "";
     if (phase === "Bound") return { phase: "Bound", severity: "success" };

--- a/apps/client/src/modules/k8s/registry/descriptors/role-bindings.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/role-bindings.ts
@@ -1,6 +1,7 @@
 import { Users } from "lucide-react";
 import { k8sRoleBindingConfig } from "@my-project/shared";
 import { roleBindingColumns } from "./role-bindings.columns";
+import { RoleBindingOverviewTab } from "../../components/overrides/RoleBindingOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const roleBindingsDescriptor: ResourceDescriptor = {
@@ -12,4 +13,5 @@ export const roleBindingsDescriptor: ResourceDescriptor = {
   defaultSort: { sortBy: "name", order: "asc" },
   columns: roleBindingColumns,
   status: () => ({ phase: "Active", severity: "success" }),
+  overviewTab: RoleBindingOverviewTab,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/roles.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/roles.ts
@@ -1,6 +1,7 @@
 import { Shield } from "lucide-react";
 import { k8sRoleConfig } from "@my-project/shared";
 import { roleColumns } from "./roles.columns";
+import { RoleOverviewTab } from "../../components/overrides/RoleOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const rolesDescriptor: ResourceDescriptor = {
@@ -12,4 +13,5 @@ export const rolesDescriptor: ResourceDescriptor = {
   defaultSort: { sortBy: "name", order: "asc" },
   columns: roleColumns,
   status: () => ({ phase: "Active", severity: "success" }),
+  overviewTab: RoleOverviewTab,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/services.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/services.columns.tsx
@@ -24,7 +24,7 @@ export const serviceColumns = (renderName: RenderName): TableColumn<KubeObjectBa
     data: {
       render: ({ data }) => {
         const s = data as { spec?: { clusterIP?: string } };
-        return s.spec?.clusterIP ?? "—";
+        return <TextWithTooltip text={s.spec?.clusterIP ?? "—"} />;
       },
     },
     cell: { baseWidth: 14 },

--- a/apps/client/src/modules/k8s/registry/descriptors/services.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/services.ts
@@ -1,6 +1,7 @@
 import { Network } from "lucide-react";
 import { k8sServiceConfig } from "@my-project/shared";
 import { serviceColumns } from "./services.columns";
+import { ServiceOverviewTab } from "../../components/overrides/ServiceOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const servicesDescriptor: ResourceDescriptor = {
@@ -12,4 +13,5 @@ export const servicesDescriptor: ResourceDescriptor = {
   defaultSort: { sortBy: "name", order: "asc" },
   columns: serviceColumns,
   status: () => ({ phase: "Active", severity: "success" }),
+  overviewTab: ServiceOverviewTab,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/statefulsets.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/statefulsets.columns.tsx
@@ -2,21 +2,24 @@ import type { RenderName } from "./columnHelpers";
 import type { TableColumn } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
 import { TextWithTooltip } from "@/core/components/TextWithTooltip";
-import { makeNameColumn, namespaceColumn, ageColumn } from "./columnHelpers";
+import { ReplicaProgress } from "@/modules/k8s/components/workload";
+import { getStatefulSetStatusIcon, getStatefulSetStatusLabel } from "@/k8s/api/groups/apps/StatefulSet/utils/getStatus";
+import { makeNameColumn, makeStatusColumn, namespaceColumn, ageColumn } from "./columnHelpers";
 
 export const statefulSetColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
   namespaceColumn,
+  makeStatusColumn(getStatefulSetStatusIcon, getStatefulSetStatusLabel),
   {
     id: "ready",
     label: "Ready",
     data: {
       render: ({ data }) => {
         const s = data as { status?: { readyReplicas?: number }; spec?: { replicas?: number } };
-        return `${s.status?.readyReplicas ?? 0}/${s.spec?.replicas ?? 0}`;
+        return <ReplicaProgress ready={s.status?.readyReplicas ?? 0} desired={s.spec?.replicas ?? 0} />;
       },
     },
-    cell: { baseWidth: 10 },
+    cell: { baseWidth: 12 },
   },
   {
     id: "up-to-date",

--- a/apps/client/src/modules/k8s/registry/descriptors/statefulsets.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/statefulsets.ts
@@ -2,6 +2,7 @@ import { Layers2 } from "lucide-react";
 import { k8sStatefulSetConfig } from "@my-project/shared";
 import { statefulSetColumns } from "./statefulsets.columns";
 import { StatefulSetHeaderActions } from "./statefulsets.actions";
+import { StatefulSetOverviewTab } from "../../components/overrides/StatefulSetOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const statefulSetsDescriptor: ResourceDescriptor = {
@@ -22,5 +23,6 @@ export const statefulSetsDescriptor: ResourceDescriptor = {
       ? { phase: "Available", severity: "success" }
       : { phase: "Progressing", severity: "warning" };
   },
+  overviewTab: StatefulSetOverviewTab,
   actionsSlot: StatefulSetHeaderActions,
 };

--- a/apps/client/src/modules/k8s/registry/descriptors/storage-classes.columns.tsx
+++ b/apps/client/src/modules/k8s/registry/descriptors/storage-classes.columns.tsx
@@ -4,6 +4,8 @@ import type { KubeObjectBase } from "@my-project/shared";
 import { TextWithTooltip } from "@/core/components/TextWithTooltip";
 import { makeNameColumn, ageColumn } from "./columnHelpers";
 
+const DEFAULT_CLASS_ANNOTATION = "storageclass.kubernetes.io/is-default-class";
+
 export const storageClassColumns = (renderName: RenderName): TableColumn<KubeObjectBase>[] => [
   makeNameColumn(renderName),
   {
@@ -38,6 +40,17 @@ export const storageClassColumns = (renderName: RenderName): TableColumn<KubeObj
       },
     },
     cell: { baseWidth: 20 },
+  },
+  {
+    id: "default",
+    label: "Default",
+    data: {
+      render: ({ data }) => {
+        const isDefault = data.metadata?.annotations?.[DEFAULT_CLASS_ANNOTATION] === "true";
+        return isDefault ? "Yes" : "No";
+      },
+    },
+    cell: { baseWidth: 10 },
   },
   ageColumn,
 ];

--- a/apps/client/src/modules/k8s/registry/descriptors/storage-classes.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/storage-classes.ts
@@ -1,6 +1,7 @@
 import { FileType } from "lucide-react";
 import { k8sStorageClassConfig } from "@my-project/shared";
 import { storageClassColumns } from "./storage-classes.columns";
+import { StorageClassOverviewTab } from "../../components/overrides/StorageClassOverviewTab";
 import type { ResourceDescriptor } from "../types";
 
 export const storageClassesDescriptor: ResourceDescriptor = {
@@ -12,4 +13,5 @@ export const storageClassesDescriptor: ResourceDescriptor = {
   defaultSort: { sortBy: "name", order: "asc" },
   columns: storageClassColumns,
   status: () => ({ phase: "Active", severity: "success" }),
+  overviewTab: StorageClassOverviewTab,
 };

--- a/packages/shared/src/models/k8s/groups/batch/CronJob/labels.ts
+++ b/packages/shared/src/models/k8s/groups/batch/CronJob/labels.ts
@@ -1,1 +1,7 @@
-export {};
+// Label set by the CronJob controller on every Job it creates, referencing the
+// owning CronJob's name. Used to list the Jobs spawned by a given CronJob.
+export const CRONJOB_NAME_LABEL = "cronjob.kubernetes.io/name";
+
+// Annotation KubeRocketCI writes onto a Job template to trigger an immediate
+// ("run now") manual run of a CronJob.
+export const RUN_NOW_ANNOTATION = "krci.kubernetes.io/run-now";


### PR DESCRIPTION
Add OverviewTab override components for workloads (Deployment, StatefulSet, DaemonSet, Job, CronJob, HPA), storage (PV, PVC, StorageClass), networking (Service, Ingress), config (ConfigMap, Secret), RBAC (Role/Binding, ClusterRole/Binding) and Namespace, backed by a shared workload/ and rbac/ component library plus per-resource getStatus utils and a useOwnedPods hook.

Register the new columns/actions descriptors for each resource.
