### PR TITLE
EPMDEDP-17082: fix: prevent release branches from being created from a commit

### DIFF
--- a/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/Form/index.tsx
+++ b/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/Form/index.tsx
@@ -1,6 +1,5 @@
-import { codebaseBranchStatus, codebaseVersioning, krciCommonLabels } from "@my-project/shared";
+import { isKRCIVersioning, codebaseBranchStatus, krciCommonLabels } from "@my-project/shared";
 import type { Codebase, CodebaseBranch } from "@my-project/shared";
-import React from "react";
 import { useCreateCodebaseBranchForm } from "../../providers/form/hooks";
 import {
   BranchName,
@@ -28,40 +27,46 @@ interface FormProps {
 export const Form = ({ codebase, defaultBranch, pipelines }: FormProps) => {
   const form = useCreateCodebaseBranchForm();
 
-  const defaultBranchVersion = defaultBranch?.spec.version;
-
-  const canCreateReleaseBranch = React.useMemo(
-    () =>
-      (codebase.spec.versioning.type === codebaseVersioning.edp ||
-        codebase.spec.versioning.type === codebaseVersioning.semver) &&
-      defaultBranch?.status?.status === codebaseBranchStatus.created,
-    [codebase.spec.versioning.type, defaultBranch]
-  );
+  const defaultBranchVersion = defaultBranch?.spec.version ?? undefined;
 
   const releaseFieldValue = useStore(form.store, (state) => state.values.release);
 
-  const isDefaultBranchProtected = React.useMemo(() => {
-    return !!defaultBranch?.metadata?.labels?.[krciCommonLabels.editProtection];
-  }, [defaultBranch]);
+  const isDefaultBranchProtected = !!defaultBranch?.metadata?.labels?.[krciCommonLabels.editProtection];
+
+  const supportsReleaseVersioning = isKRCIVersioning(codebase.spec.versioning.type);
+
+  const isDefaultBranchReady = defaultBranch?.status?.status === codebaseBranchStatus.created;
+
+  const canCreateReleaseBranch = supportsReleaseVersioning && isDefaultBranchReady;
+
+  let releaseBranchDisabledReason: string | undefined;
+  if (!supportsReleaseVersioning) {
+    releaseBranchDisabledReason = "Release branches are available only for codebases using EDP or SemVer versioning.";
+  } else if (!isDefaultBranchReady) {
+    releaseBranchDisabledReason =
+      "Release branches can be created only after the default branch has been successfully provisioned.";
+  } else if (isDefaultBranchProtected) {
+    releaseBranchDisabledReason =
+      "The default branch is protected from editing, so a release branch cannot be created from it.";
+  }
 
   return (
     <>
       <div className="flex flex-col gap-4">
-        {canCreateReleaseBranch && (
-          <div>
-            <ReleaseBranch
-              isDefaultBranchProtected={isDefaultBranchProtected}
-              defaultBranchVersion={defaultBranchVersion!}
-            />
-          </div>
-        )}
+        <div>
+          <ReleaseBranch
+            disabledReason={releaseBranchDisabledReason}
+            defaultBranchVersion={defaultBranchVersion}
+            defaultBranchName={defaultBranch?.spec.branchName ?? ""}
+          />
+        </div>
         {releaseFieldValue ? (
           <div>
-            <ReleaseBranchName defaultBranchVersion={defaultBranchVersion!} />
+            <ReleaseBranchName defaultBranchVersion={defaultBranchVersion} />
           </div>
         ) : (
           <div>
-            <BranchName codebase={codebase} defaultBranchVersion={defaultBranchVersion!} />
+            <BranchName codebase={codebase} defaultBranchVersion={defaultBranchVersion} />
           </div>
         )}
         <div>

--- a/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/BranchName/types.ts
+++ b/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/BranchName/types.ts
@@ -2,5 +2,5 @@ import type { Codebase } from "@my-project/shared";
 
 export interface BranchNameProps {
   codebase: Codebase;
-  defaultBranchVersion: string;
+  defaultBranchVersion?: string;
 }

--- a/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/ReleaseBranch/index.tsx
+++ b/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/ReleaseBranch/index.tsx
@@ -10,6 +10,8 @@ import {
 } from "@my-project/shared";
 import { Switch } from "@/core/components/ui/switch";
 import { Label } from "@/core/components/ui/label";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { Info } from "lucide-react";
 import { useStore } from "@tanstack/react-form";
 
 const createReleaseName = (versionFieldValue: string) => {
@@ -22,9 +24,11 @@ const createReleaseName = (versionFieldValue: string) => {
   return createReleaseNameString(major, minor);
 };
 
-export const ReleaseBranch = ({ isDefaultBranchProtected, defaultBranchVersion }: ReleaseBranchProps) => {
+export const ReleaseBranch = ({ disabledReason, defaultBranchVersion, defaultBranchName }: ReleaseBranchProps) => {
   const form = useCreateCodebaseBranchForm();
   const releaseValue = useStore(form.store, (state) => state.values.release);
+
+  const isDisabled = !!disabledReason;
 
   const handleReleaseValueChange = React.useCallback(
     (checked: boolean) => {
@@ -33,7 +37,14 @@ export const ReleaseBranch = ({ isDefaultBranchProtected, defaultBranchVersion }
 
       form.setFieldValue("release", checked);
 
-      if (!version || !defaultBranchVersion || isDefaultBranchProtected) {
+      // A release branch must always be cut from the default branch. Reset the source
+      // here so a commit/branch selected before enabling the switch can't redefine it.
+      if (checked) {
+        form.setFieldValue("fromType", "branch" as const);
+        form.setFieldValue("fromCommit", defaultBranchName);
+      }
+
+      if (!version || !defaultBranchVersion || isDisabled) {
         return;
       }
 
@@ -59,21 +70,26 @@ export const ReleaseBranch = ({ isDefaultBranchProtected, defaultBranchVersion }
         form.setFieldValue("defaultBranchVersionPostfix", postfix);
       }
     },
-    [defaultBranchVersion, form, isDefaultBranchProtected]
+    [defaultBranchVersion, defaultBranchName, form, isDisabled]
   );
 
   return (
     <div className="flex items-center justify-between rounded-lg border p-4">
-      <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1.5">
         <Label htmlFor="release-branch" className="text-sm font-medium">
           Release branch
         </Label>
+        {disabledReason && (
+          <Tooltip title={disabledReason}>
+            <Info size={16} className="text-muted-foreground" />
+          </Tooltip>
+        )}
       </div>
       <Switch
         id="release-branch"
         checked={releaseValue || false}
         onCheckedChange={handleReleaseValueChange}
-        disabled={isDefaultBranchProtected}
+        disabled={isDisabled}
       />
     </div>
   );

--- a/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/ReleaseBranch/types.ts
+++ b/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/ReleaseBranch/types.ts
@@ -1,4 +1,5 @@
 export interface ReleaseBranchProps {
-  isDefaultBranchProtected: boolean;
-  defaultBranchVersion: string;
+  disabledReason?: string;
+  defaultBranchVersion?: string;
+  defaultBranchName: string;
 }

--- a/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/ReleaseBranchName/types.ts
+++ b/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/components/fields/ReleaseBranchName/types.ts
@@ -1,3 +1,3 @@
 export interface BranchNameProps {
-  defaultBranchVersion: string;
+  defaultBranchVersion?: string;
 }

--- a/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/hooks/useDefaultValues.ts
+++ b/apps/client/src/modules/platform/codebases/components/CreateCodebaseBranchForm/hooks/useDefaultValues.ts
@@ -2,7 +2,7 @@ import React from "react";
 import { CODEBASE_BRANCH_FORM_NAMES } from "../constants";
 import type { CreateCodebaseBranchFormValues } from "../types";
 import type { Codebase, CodebaseBranch } from "@my-project/shared";
-import { codebaseVersioning, getVersionAndPostfixFromVersioningString } from "@my-project/shared";
+import { isKRCIVersioning, getVersionAndPostfixFromVersioningString } from "@my-project/shared";
 
 interface UseDefaultValuesProps {
   codebase: Codebase;
@@ -36,7 +36,7 @@ export const useDefaultValues = ({ codebase, defaultBranch, pipelines }: UseDefa
       return base;
     }
 
-    if (versioningType !== codebaseVersioning.edp && versioningType !== codebaseVersioning.semver) {
+    if (!isKRCIVersioning(versioningType)) {
       return base;
     }
 

--- a/apps/client/src/modules/platform/codebases/pages/details/components/BranchList/components/BranchListItem/components/Summary/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/details/components/BranchList/components/BranchListItem/components/Summary/index.tsx
@@ -9,12 +9,7 @@ import { LinkCreationService } from "@/k8s/services/link-creation";
 import { useCodebaseWatch, useGitServerWatch } from "@/modules/platform/codebases/pages/details/hooks/data";
 import { Badge } from "@/core/components/ui/badge";
 import { Tooltip } from "@/core/components/ui/tooltip";
-import {
-  checkForKRCIVersioning,
-  checkIsDefaultBranch,
-  codebaseBranchStatus,
-  getPipelineRunStatus,
-} from "@my-project/shared";
+import { isKRCIVersioning, checkIsDefaultBranch, codebaseBranchStatus, getPipelineRunStatus } from "@my-project/shared";
 import { ExternalLink } from "lucide-react";
 import React from "react";
 import { Actions } from "../Actions";
@@ -33,7 +28,7 @@ export function Summary({ codebaseBranch, latestBuildPipelineRun, latestSecurity
   const codebaseBranchStatusIcon = getCodebaseBranchStatusIcon(codebaseBranch);
   const lastPipelineRunStatusIcon = getPipelineRunStatusIcon(latestBuildPipelineRun);
 
-  const isKRCIVersioning = checkForKRCIVersioning(codebase?.spec.versioning.type);
+  const supportsKRCIVersioning = isKRCIVersioning(codebase?.spec.versioning.type);
 
   const { status: lastPipelineRunStatus, reason: lastPipelineRunReason } = getPipelineRunStatus(latestBuildPipelineRun);
 
@@ -112,7 +107,7 @@ export function Summary({ codebaseBranch, latestBuildPipelineRun, latestSecurity
             </div>
           )}
 
-          {isKRCIVersioning ? (
+          {supportsKRCIVersioning ? (
             <>
               <div className="flex items-center gap-1">
                 <span className="text-xs">Build:</span>

--- a/packages/shared/src/utils/isKRCIVersioning.test.ts
+++ b/packages/shared/src/utils/isKRCIVersioning.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isKRCIVersioning } from "./isKRCIVersioning.js";
+import { codebaseVersioning } from "../models/index.js";
+
+describe("isKRCIVersioning", () => {
+  it("returns true for edp versioning", () => {
+    expect(isKRCIVersioning(codebaseVersioning.edp)).toBe(true);
+  });
+
+  it("returns true for semver versioning", () => {
+    expect(isKRCIVersioning(codebaseVersioning.semver)).toBe(true);
+  });
+
+  it("returns false for default versioning", () => {
+    expect(isKRCIVersioning(codebaseVersioning.default)).toBe(false);
+  });
+
+  it("returns false when versioning type is undefined", () => {
+    expect(isKRCIVersioning(undefined)).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/isKRCIVersioning.ts
+++ b/packages/shared/src/utils/isKRCIVersioning.ts
@@ -1,4 +1,4 @@
 import { CodebaseVersioning, codebaseVersioning } from "../models/index.js";
 
-export const checkForKRCIVersioning = (versioningType: CodebaseVersioning | undefined) =>
+export const isKRCIVersioning = (versioningType: CodebaseVersioning | undefined) =>
   versioningType === codebaseVersioning.edp || versioningType === codebaseVersioning.semver;


### PR DESCRIPTION
- Reset the branch source to the default branch (fromType=branch, fromCommit=defaultBranchName) when the Release toggle is enabled, so a commit selected beforehand can no longer redefine where the release branch is cut from
- Disable the Commit Hash option while Release is on to block the reverse order
- Surface release-eligibility as a disabled switch with a tooltip reason instead of hiding the control entirely
- Reuse the shared isKRCIVersioning predicate (renamed from checkForKRCIVersioning) and add unit coverage for it
