### PR TITLE
EPMDEDP-17085: feat: add Service Account token login and make OIDC optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ packages/shared — shared types, models, K8s resource interfaces
 - All tRPC endpoints use `protectedProcedure` (never `publicProcedure`)
 - All tRPC inputs validated with Zod schemas (no raw string params)
 - K8s API calls use `idToken` as bearer — never service account tokens
+- **SA token login** is the one sanctioned exception to both rules above: the pre-session `loginWithServiceAccountToken` `publicProcedure` passes a raw SA token as the K8s bearer via `K8sClient.fromToken()` → `getSelfSubjectReview()` to validate it (that call *is* the auth step); every other K8s call still uses the session `idToken`, so don't flag it.
 - CEL filter strings: client uses `escapeCELString()`, server uses regex-constrained Zod
 - Mutation pattern: `structuredClone()` + mutate (not functional filter); `no-param-reassign` is OFF
 - Shared labels/constants go under the K8s resource type they apply TO (e.g., Pod labels in `Core/Pod/labels.ts`)
@@ -33,6 +34,6 @@ packages/shared — shared types, models, K8s resource interfaces
 ## Security — Never
 
 - Expose `idToken` or session secrets in client bundles
-- Use `publicProcedure` for any endpoint accessing K8s
+- Use `publicProcedure` for any endpoint accessing K8s (except SA token login above)
 - Interpolate unsanitized user input into CEL filter strings
 - Skip Zod validation on tRPC inputs

--- a/apps/client/src/core/auth/pages/login/view.tsx
+++ b/apps/client/src/core/auth/pages/login/view.tsx
@@ -33,11 +33,88 @@ const HELP_MENU_LIST = [
   },
 ];
 
+interface TokenFormProps {
+  idPrefix: string;
+  label: string;
+  helpText: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onCancel: () => void;
+  isPending: boolean;
+  isError: boolean;
+  errorMessage?: string;
+}
+
+function TokenForm({
+  idPrefix,
+  label,
+  helpText,
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+  isPending,
+  isError,
+  errorMessage,
+}: TokenFormProps) {
+  return (
+    <div className="w-full">
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor={`${idPrefix}-token`}>{label}</Label>
+          <Textarea
+            id={`${idPrefix}-token`}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="Paste your token here..."
+            rows={4}
+            className="font-mono text-sm"
+            disabled={isPending}
+            spellCheck={false}
+          />
+          <p className="text-muted-foreground text-xs">{helpText}</p>
+        </div>
+        {isError && (
+          <Alert variant="destructive" title="Error">
+            {errorMessage || "Invalid token. Please try again."}
+          </Alert>
+        )}
+        <div className="flex gap-2">
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={isPending} className="flex-1">
+            Cancel
+          </Button>
+          <Button type="submit" variant="default" disabled={isPending || !value.trim()} className="flex-1">
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Signing In
+              </>
+            ) : (
+              "Sign In"
+            )}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
 export default function LoginPage() {
-  const { loginMutation, loginCallbackMutation, loginWithTokenMutation } = useAuth();
+  const {
+    loginMutation,
+    loginCallbackMutation,
+    loginWithTokenMutation,
+    loginWithServiceAccountTokenMutation,
+    oidcEnabled,
+  } = useAuth();
   const search = useSearch({ from: routeAuthLogin.fullPath });
+
+  const [showMoreOptions, setShowMoreOptions] = useState(false);
   const [showTokenInput, setShowTokenInput] = useState(false);
+  const [showSATokenInput, setShowSATokenInput] = useState(false);
   const [token, setToken] = useState("");
+  const [saToken, setSaToken] = useState("");
 
   const isSessionExpired = search?.reason === "session-expired";
 
@@ -62,12 +139,44 @@ export default function LoginPage() {
     [loginWithTokenMutation, search?.redirect, token]
   );
 
+  const handleSATokenSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (saToken.trim()) {
+        loginWithServiceAccountTokenMutation!.mutate!({
+          token: saToken.trim(),
+          redirectSearchParam: search?.redirect,
+        });
+      }
+    },
+    [loginWithServiceAccountTokenMutation, search?.redirect, saToken]
+  );
+
+  // The two token forms are mutually exclusive: opening one closes the other and
+  // clears its field, so only a single token is ever entered at a time. A form's
+  // own field is cleared only when it collapses, so re-opening preserves whatever
+  // was already typed.
   const handleTokenButtonClick = useCallback(() => {
-    setShowTokenInput(!showTokenInput);
+    setShowSATokenInput(false);
+    setSaToken("");
     if (showTokenInput) {
       setToken("");
     }
+    setShowTokenInput((prev) => !prev);
   }, [showTokenInput]);
+
+  const handleSATokenButtonClick = useCallback(() => {
+    setShowTokenInput(false);
+    setToken("");
+    if (showSATokenInput) {
+      setSaToken("");
+    }
+    setShowSATokenInput((prev) => !prev);
+  }, [showSATokenInput]);
+
+  // When OIDC is disabled the SA-token option is shown directly (not hidden
+  // behind "More options"), since it is the only available login method.
+  const showSecondaryOptions = showMoreOptions || !oidcEnabled;
 
   return (
     <div className="flex w-full grow items-center justify-center">
@@ -89,89 +198,96 @@ export default function LoginPage() {
 
           <div className="w-full max-w-72">
             <div className="flex flex-col gap-4">
-              {loginMutation?.isPending ? (
-                <Button variant="default" className="w-full" disabled>
-                  <Loader2 className="animate-spin" />
-                  Signing In
-                </Button>
-              ) : (
-                <Button variant="default" className="w-full" onClick={handleLogin}>
-                  Sign In
-                </Button>
-              )}
-              <div className="flex flex-row items-center gap-2 px-4">
-                <hr className="border-secondary-dark grow border-dashed" />
-                <span>or</span>
-                <hr className="border-secondary-dark grow border-dashed" />
-              </div>
-              <Button
-                variant="outline"
-                className={`w-full ${showTokenInput ? "border-primary" : ""}`}
-                onClick={handleTokenButtonClick}
-                disabled={loginWithTokenMutation?.isPending}
-              >
-                {loginWithTokenMutation?.isPending ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Signing In
-                  </>
-                ) : (
-                  "Use Token"
-                )}
-              </Button>
-            </div>
-          </div>
-
-          {showTokenInput && (
-            <div className="w-full">
-              <form onSubmit={handleTokenSubmit} className="flex flex-col gap-3">
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="token">Access Token</Label>
-                  <Textarea
-                    id="token"
-                    value={token}
-                    onChange={(e) => setToken(e.target.value)}
-                    placeholder="Paste your access token here..."
-                    rows={4}
-                    className="font-mono text-sm"
-                    disabled={loginWithTokenMutation?.isPending}
-                    spellCheck={false}
-                  />
-                  <p className="text-muted-foreground text-xs">Enter your OIDC access token to sign in.</p>
-                </div>
-                {loginWithTokenMutation?.isError && (
-                  <Alert variant="destructive" title="Error">
-                    {loginWithTokenMutation.error?.message || "Invalid token. Please try again."}
-                  </Alert>
-                )}
-                <div className="flex gap-2">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    onClick={handleTokenButtonClick}
-                    disabled={loginWithTokenMutation?.isPending}
-                    className="flex-1"
-                  >
-                    Cancel
+              {oidcEnabled && (
+                <>
+                  {loginMutation?.isPending ? (
+                    <Button variant="default" className="w-full" disabled>
+                      <Loader2 className="animate-spin" />
+                      Signing In
+                    </Button>
+                  ) : (
+                    <Button variant="default" className="w-full" onClick={handleLogin}>
+                      Sign In
+                    </Button>
+                  )}
+                  <div className="flex flex-row items-center gap-2 px-4">
+                    <hr className="border-secondary-dark grow border-dashed" />
+                    <span>or</span>
+                    <hr className="border-secondary-dark grow border-dashed" />
+                  </div>
+                  <Button variant="link" className="w-full" onClick={() => setShowMoreOptions((prev) => !prev)}>
+                    More options
                   </Button>
+                </>
+              )}
+
+              {showSecondaryOptions && (
+                <>
+                  {oidcEnabled && (
+                    <Button
+                      variant="outline"
+                      className={`w-full ${showTokenInput ? "border-primary" : ""}`}
+                      onClick={handleTokenButtonClick}
+                      disabled={loginWithTokenMutation?.isPending}
+                    >
+                      {loginWithTokenMutation?.isPending ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Signing In
+                        </>
+                      ) : (
+                        "Use Token"
+                      )}
+                    </Button>
+                  )}
                   <Button
-                    type="submit"
-                    variant="default"
-                    disabled={loginWithTokenMutation?.isPending || !token.trim()}
-                    className="flex-1"
+                    variant="outline"
+                    className={`w-full ${showSATokenInput ? "border-primary" : ""}`}
+                    onClick={handleSATokenButtonClick}
+                    disabled={loginWithServiceAccountTokenMutation?.isPending}
                   >
-                    {loginWithTokenMutation?.isPending ? (
+                    {loginWithServiceAccountTokenMutation?.isPending ? (
                       <>
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                         Signing In
                       </>
                     ) : (
-                      "Sign In"
+                      "Use Service Account Token"
                     )}
                   </Button>
-                </div>
-              </form>
+                </>
+              )}
             </div>
+          </div>
+
+          {showTokenInput && oidcEnabled && (
+            <TokenForm
+              idPrefix="oidc"
+              label="Access Token"
+              helpText="Enter your OIDC access token to sign in."
+              value={token}
+              onChange={setToken}
+              onSubmit={handleTokenSubmit}
+              onCancel={handleTokenButtonClick}
+              isPending={!!loginWithTokenMutation?.isPending}
+              isError={!!loginWithTokenMutation?.isError}
+              errorMessage={loginWithTokenMutation?.error?.message}
+            />
+          )}
+
+          {showSATokenInput && (
+            <TokenForm
+              idPrefix="sa"
+              label="Service Account Token"
+              helpText="Paste a Kubernetes Service Account token (e.g. from `kubectl create token <sa> -n <ns>`)."
+              value={saToken}
+              onChange={setSaToken}
+              onSubmit={handleSATokenSubmit}
+              onCancel={handleSATokenButtonClick}
+              isPending={!!loginWithServiceAccountTokenMutation?.isPending}
+              isError={!!loginWithServiceAccountTokenMutation?.isError}
+              errorMessage={loginWithServiceAccountTokenMutation?.error?.message}
+            />
           )}
 
           {loginMutation?.isError || loginCallbackMutation?.isError ? (

--- a/apps/client/src/core/auth/provider/context.ts
+++ b/apps/client/src/core/auth/provider/context.ts
@@ -3,7 +3,10 @@ import {
   LoginOutput,
   LoginCallbackInput,
   LoginCallbackOutput,
+  LoginWithTokenInput,
   LoginWithTokenOutput,
+  LoginWithSATokenInput,
+  LoginWithSATokenOutput,
   LogoutOutput,
 } from "@my-project/shared";
 import { UseMutationResult } from "@tanstack/react-query";
@@ -13,35 +16,44 @@ export type AuthLoginOutput = LoginOutput;
 export type AuthCallbackLoginInput = LoginCallbackInput;
 export type AuthCallbackLoginOutput = LoginCallbackOutput;
 export type AuthLoginWithTokenOutput = LoginWithTokenOutput;
+export type AuthLoginWithSATokenOutput = LoginWithSATokenOutput;
 export type AuthLogoutOutput = LogoutOutput;
 
 export interface LoginMutationInput {
   redirectSearchParam: string | undefined;
 }
 
-export interface LoginWithTokenMutationInput {
-  token: string;
-  redirectSearchParam?: string;
-}
+export type LoginWithTokenMutationInput = LoginWithTokenInput;
+
+export type LoginWithSATokenMutationInput = LoginWithSATokenInput;
 
 export interface AuthContextValue {
   loginMutation: UseMutationResult<AuthLoginOutput, Error, LoginMutationInput> | null;
   loginCallbackMutation: UseMutationResult<AuthCallbackLoginOutput, Error, AuthCallbackLoginInput> | null;
   loginWithTokenMutation: UseMutationResult<AuthLoginWithTokenOutput, Error, LoginWithTokenMutationInput> | null;
+  loginWithServiceAccountTokenMutation: UseMutationResult<
+    AuthLoginWithSATokenOutput,
+    Error,
+    LoginWithSATokenMutationInput
+  > | null;
   logoutMutation: UseMutationResult<AuthLogoutOutput, Error, void> | null;
   user: OIDCUser | undefined;
   isLoading: boolean;
   isAuthenticated: boolean;
   authInProgress: boolean;
+  /** Whether OIDC is configured server-side. When false, only SA-token login is offered. */
+  oidcEnabled: boolean;
 }
 
 export const AuthContext = React.createContext<AuthContextValue>({
   loginMutation: null,
   loginCallbackMutation: null,
   loginWithTokenMutation: null,
+  loginWithServiceAccountTokenMutation: null,
   logoutMutation: null,
   user: undefined,
   isLoading: false,
   isAuthenticated: false,
   authInProgress: false,
+  oidcEnabled: true,
 });

--- a/apps/client/src/core/auth/provider/provider.tsx
+++ b/apps/client/src/core/auth/provider/provider.tsx
@@ -1,14 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   AuthCallbackLoginInput,
   AuthCallbackLoginOutput,
   AuthContext,
   AuthLoginOutput,
   AuthLoginWithTokenOutput,
+  AuthLoginWithSATokenOutput,
   AuthLogoutOutput,
   LoginMutationInput,
   LoginWithTokenMutationInput,
+  LoginWithSATokenMutationInput,
 } from "./context";
 import { trpcHttpClient } from "@/core/providers/trpc/http-client";
 import { LoadingProgressBar } from "@/core/components/ui/LoadingProgressBar";
@@ -40,6 +42,33 @@ export const AuthProvider = ({ children }: React.PropsWithChildren) => {
   });
 
   const isAuthenticated = meQuery.isFetched && !!meQuery.data;
+
+  const oidcConfigQuery = useQuery({
+    queryKey: ["config.oidc"],
+    queryFn: () => trpc.config.oidc.query(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: 1,
+  });
+  // Default to true so the OIDC "Sign In" button isn't briefly hidden while the
+  // config loads in OIDC-enabled deployments. Set to false only once the server
+  // confirms OIDC is not configured (SA-only mode).
+  const oidcEnabled = oidcConfigQuery.data?.oidcEnabled ?? true;
+
+  // Shared success handler for the token-based logins (direct token + SA token):
+  // cache the resolved user, then navigate to the post-login redirect.
+  const handleTokenLoginSuccess = useCallback(
+    ({ success, userInfo, clientSearch }: AuthLoginWithTokenOutput) => {
+      if (success && userInfo) {
+        queryClient.setQueryData(["auth.me"], userInfo);
+
+        const redirect = new URLSearchParams(clientSearch || "").get("redirect") || routeHome.fullPath;
+
+        router.navigate({ to: redirect, replace: true });
+      }
+    },
+    [queryClient]
+  );
 
   const loginMutation = useMutation<AuthLoginOutput, Error, LoginMutationInput>({
     mutationKey: ["auth.login"],
@@ -86,16 +115,25 @@ export const AuthProvider = ({ children }: React.PropsWithChildren) => {
         redirectSearchParam,
       });
     },
-    onSuccess: ({ success, userInfo, clientSearch }) => {
-      if (success && userInfo) {
-        queryClient.setQueryData(["auth.me"], userInfo);
-
-        const clientSearchParams = new URLSearchParams(clientSearch || "");
-        const redirect = clientSearchParams.get("redirect") || routeHome.fullPath;
-
-        router.navigate({ to: redirect, replace: true });
-      }
+    onSuccess: handleTokenLoginSuccess,
+    onError: () => {
+      // Error handled in component
     },
+  });
+
+  const loginWithServiceAccountTokenMutation = useMutation<
+    AuthLoginWithSATokenOutput,
+    Error,
+    LoginWithSATokenMutationInput
+  >({
+    mutationKey: ["auth.loginWithServiceAccountToken"],
+    mutationFn: ({ token, redirectSearchParam }) => {
+      return trpc.auth.loginWithServiceAccountToken.mutate({
+        token,
+        redirectSearchParam,
+      });
+    },
+    onSuccess: handleTokenLoginSuccess,
     onError: () => {
       // Error handled in component
     },
@@ -131,11 +169,13 @@ export const AuthProvider = ({ children }: React.PropsWithChildren) => {
       loginMutation,
       loginCallbackMutation,
       loginWithTokenMutation,
+      loginWithServiceAccountTokenMutation,
       logoutMutation,
       user: meQuery.data,
       isLoading: meQuery.isLoading,
       isAuthenticated,
       authInProgress,
+      oidcEnabled,
     }),
     [
       authInProgress,
@@ -143,9 +183,11 @@ export const AuthProvider = ({ children }: React.PropsWithChildren) => {
       loginCallbackMutation,
       loginMutation,
       loginWithTokenMutation,
+      loginWithServiceAccountTokenMutation,
       logoutMutation,
       meQuery.data,
       meQuery.isLoading,
+      oidcEnabled,
     ]
   );
 

--- a/apps/server/env.d.ts
+++ b/apps/server/env.d.ts
@@ -9,11 +9,12 @@ declare global {
 
       PORTAL_URL: string;
 
-      OIDC_ISSUER_URL: string;
-      OIDC_CLIENT_ID: string;
-      OIDC_CLIENT_SECRET: string;
-      OIDC_SCOPE: string;
-      OIDC_CODE_CHALLENGE_METHOD: string;
+      // Optional: when unset, the portal runs in SA-token-only mode (no OIDC).
+      OIDC_ISSUER_URL?: string;
+      OIDC_CLIENT_ID?: string;
+      OIDC_CLIENT_SECRET?: string;
+      OIDC_SCOPE?: string;
+      OIDC_CODE_CHALLENGE_METHOD?: string;
 
       API_PREFIX: string;
 

--- a/apps/server/src/config/development/index.test.ts
+++ b/apps/server/src/config/development/index.test.ts
@@ -6,11 +6,6 @@ describe("LocalFastifyServer", () => {
     "API_PREFIX",
     "SERVER_SECRET",
     "SERVER_PORT",
-    "OIDC_ISSUER_URL",
-    "OIDC_CLIENT_ID",
-    "OIDC_CLIENT_SECRET",
-    "OIDC_SCOPE",
-    "OIDC_CODE_CHALLENGE_METHOD",
     "PORTAL_URL",
     "TEKTON_RESULTS_URL",
   ];
@@ -34,11 +29,23 @@ describe("LocalFastifyServer", () => {
     });
 
     it("should throw when a required key is missing", () => {
-      delete process.env.OIDC_ISSUER_URL;
+      delete process.env.PORTAL_URL;
 
       expect(() =>
         LocalFastifyServer.validateRequiredEnv(requiredKeys)
-      ).toThrow("Missing required OIDC_ISSUER_URL environment variable");
+      ).toThrow("Missing required PORTAL_URL environment variable");
+    });
+
+    it("does not require OIDC_* vars (SA-token-only deployments)", () => {
+      delete process.env.OIDC_ISSUER_URL;
+      delete process.env.OIDC_CLIENT_ID;
+      delete process.env.OIDC_CLIENT_SECRET;
+      delete process.env.OIDC_SCOPE;
+      delete process.env.OIDC_CODE_CHALLENGE_METHOD;
+
+      expect(() =>
+        LocalFastifyServer.validateRequiredEnv(requiredKeys)
+      ).not.toThrow();
     });
 
     it("should throw when a required key is empty string", () => {

--- a/apps/server/src/config/development/index.ts
+++ b/apps/server/src/config/development/index.ts
@@ -22,15 +22,13 @@ export class LocalFastifyServer {
   fastify: FastifyInstance;
 
   constructor() {
+    // OIDC_* vars are intentionally NOT required: the portal supports OIDC-less
+    // (Service Account token only) deployments. When OIDC is unset, OIDC login
+    // controls are hidden client-side and SA-token login is used instead.
     LocalFastifyServer.validateRequiredEnv([
       "API_PREFIX",
       "SERVER_SECRET",
       "SERVER_PORT",
-      "OIDC_ISSUER_URL",
-      "OIDC_CLIENT_ID",
-      "OIDC_CLIENT_SECRET",
-      "OIDC_SCOPE",
-      "OIDC_CODE_CHALLENGE_METHOD",
       "PORTAL_URL",
       "TEKTON_RESULTS_URL",
     ]);
@@ -89,11 +87,11 @@ export class LocalFastifyServer {
     registerOpenApi(this.fastify, {
       sessionStore,
       oidcConfig: {
-        issuerURL: process.env.OIDC_ISSUER_URL!,
-        clientID: process.env.OIDC_CLIENT_ID!,
-        clientSecret: process.env.OIDC_CLIENT_SECRET!,
-        scope: process.env.OIDC_SCOPE!,
-        codeChallengeMethod: process.env.OIDC_CODE_CHALLENGE_METHOD!,
+        issuerURL: process.env.OIDC_ISSUER_URL ?? "",
+        clientID: process.env.OIDC_CLIENT_ID ?? "",
+        clientSecret: process.env.OIDC_CLIENT_SECRET ?? "",
+        scope: process.env.OIDC_SCOPE ?? "",
+        codeChallengeMethod: process.env.OIDC_CODE_CHALLENGE_METHOD ?? "",
       },
       portalUrl: process.env.PORTAL_URL!,
     });
@@ -125,11 +123,12 @@ export class LocalFastifyServer {
               session,
               sessionStore,
               oidcConfig: {
-                issuerURL: process.env.OIDC_ISSUER_URL!,
-                clientID: process.env.OIDC_CLIENT_ID!,
-                clientSecret: process.env.OIDC_CLIENT_SECRET!,
-                scope: process.env.OIDC_SCOPE!,
-                codeChallengeMethod: process.env.OIDC_CODE_CHALLENGE_METHOD!,
+                issuerURL: process.env.OIDC_ISSUER_URL ?? "",
+                clientID: process.env.OIDC_CLIENT_ID ?? "",
+                clientSecret: process.env.OIDC_CLIENT_SECRET ?? "",
+                scope: process.env.OIDC_SCOPE ?? "",
+                codeChallengeMethod:
+                  process.env.OIDC_CODE_CHALLENGE_METHOD ?? "",
               },
               portalUrl: process.env.PORTAL_URL!,
             });

--- a/apps/server/src/config/production/index.test.ts
+++ b/apps/server/src/config/production/index.test.ts
@@ -6,11 +6,6 @@ describe("ProductionFastifyServer", () => {
     "API_PREFIX",
     "SERVER_SECRET",
     "SERVER_PORT",
-    "OIDC_ISSUER_URL",
-    "OIDC_CLIENT_ID",
-    "OIDC_CLIENT_SECRET",
-    "OIDC_SCOPE",
-    "OIDC_CODE_CHALLENGE_METHOD",
     "PORTAL_URL",
     "TEKTON_RESULTS_URL",
   ];
@@ -35,13 +30,13 @@ describe("ProductionFastifyServer", () => {
     });
 
     it("should not throw when a key is missing (production only logs)", () => {
-      delete process.env.OIDC_ISSUER_URL;
+      delete process.env.PORTAL_URL;
 
       expect(() =>
         ProductionFastifyServer.validateRequiredEnv(requiredKeys)
       ).not.toThrow();
       expect(console.error).toHaveBeenCalledWith(
-        "Missing required OIDC_ISSUER_URL environment variable"
+        "Missing required PORTAL_URL environment variable"
       );
     });
 

--- a/apps/server/src/config/production/index.ts
+++ b/apps/server/src/config/production/index.ts
@@ -23,15 +23,13 @@ export class ProductionFastifyServer {
   fastify: FastifyInstance;
 
   constructor() {
+    // OIDC_* vars are intentionally NOT required: the portal supports OIDC-less
+    // (Service Account token only) deployments. When OIDC is unset, OIDC login
+    // controls are hidden client-side and SA-token login is used instead.
     ProductionFastifyServer.validateRequiredEnv([
       "API_PREFIX",
       "SERVER_SECRET",
       "SERVER_PORT",
-      "OIDC_ISSUER_URL",
-      "OIDC_CLIENT_ID",
-      "OIDC_CLIENT_SECRET",
-      "OIDC_SCOPE",
-      "OIDC_CODE_CHALLENGE_METHOD",
       "PORTAL_URL",
       "TEKTON_RESULTS_URL",
     ]);
@@ -109,11 +107,11 @@ export class ProductionFastifyServer {
     registerOpenApi(this.fastify, {
       sessionStore,
       oidcConfig: {
-        issuerURL: process.env.OIDC_ISSUER_URL!,
-        clientID: process.env.OIDC_CLIENT_ID!,
-        clientSecret: process.env.OIDC_CLIENT_SECRET!,
-        scope: process.env.OIDC_SCOPE!,
-        codeChallengeMethod: process.env.OIDC_CODE_CHALLENGE_METHOD!,
+        issuerURL: process.env.OIDC_ISSUER_URL ?? "",
+        clientID: process.env.OIDC_CLIENT_ID ?? "",
+        clientSecret: process.env.OIDC_CLIENT_SECRET ?? "",
+        scope: process.env.OIDC_SCOPE ?? "",
+        codeChallengeMethod: process.env.OIDC_CODE_CHALLENGE_METHOD ?? "",
       },
       portalUrl: process.env.PORTAL_URL!,
     });
@@ -145,11 +143,12 @@ export class ProductionFastifyServer {
               session,
               sessionStore,
               oidcConfig: {
-                issuerURL: process.env.OIDC_ISSUER_URL!,
-                clientID: process.env.OIDC_CLIENT_ID!,
-                clientSecret: process.env.OIDC_CLIENT_SECRET!,
-                scope: process.env.OIDC_SCOPE!,
-                codeChallengeMethod: process.env.OIDC_CODE_CHALLENGE_METHOD!,
+                issuerURL: process.env.OIDC_ISSUER_URL ?? "",
+                clientID: process.env.OIDC_CLIENT_ID ?? "",
+                clientSecret: process.env.OIDC_CLIENT_SECRET ?? "",
+                scope: process.env.OIDC_SCOPE ?? "",
+                codeChallengeMethod:
+                  process.env.OIDC_CODE_CHALLENGE_METHOD ?? "",
               },
               portalUrl: process.env.PORTAL_URL!,
             });

--- a/packages/shared/src/models/auth/schema.ts
+++ b/packages/shared/src/models/auth/schema.ts
@@ -5,7 +5,10 @@ export const loginInputSchema = z.string().startsWith("/");
 
 export const loginCallbackInputSchema = z.string();
 
-export const loginCallbackOutputSchema = z
+// Shared success-output shape for login procedures that establish a session
+// (callback, direct token, SA token): success flag, resolved user identity
+// (with optional OIDC issuer URL), and the client-side redirect query.
+export const loginSuccessOutputSchema = z
   .object({
     success: z.boolean(),
     userInfo: OIDCUserSchema.extend({
@@ -14,6 +17,8 @@ export const loginCallbackOutputSchema = z
     clientSearch: z.string().optional(),
   })
   .strict();
+
+export const loginCallbackOutputSchema = loginSuccessOutputSchema;
 
 export const loginOutputSchema = z
   .object({
@@ -35,12 +40,13 @@ export const loginWithTokenInputSchema = z
   })
   .strict();
 
-export const loginWithTokenOutputSchema = z
+export const loginWithTokenOutputSchema = loginSuccessOutputSchema;
+
+export const loginWithSATokenInputSchema = z
   .object({
-    success: z.boolean(),
-    userInfo: OIDCUserSchema.extend({
-      issuerUrl: z.string().optional(),
-    }).optional(),
-    clientSearch: z.string().optional(),
+    token: z.string().min(1, "Service account token is required"),
+    redirectSearchParam: z.string().startsWith("/").optional(),
   })
   .strict();
+
+export const loginWithSATokenOutputSchema = loginSuccessOutputSchema;

--- a/packages/shared/src/models/auth/types.ts
+++ b/packages/shared/src/models/auth/types.ts
@@ -8,6 +8,8 @@ import {
   meOutputSchema,
   loginWithTokenInputSchema,
   loginWithTokenOutputSchema,
+  loginWithSATokenInputSchema,
+  loginWithSATokenOutputSchema,
 } from "./schema.js";
 
 export type LoginInput = z.infer<typeof loginInputSchema>;
@@ -25,3 +27,7 @@ export type MeOutput = z.infer<typeof meOutputSchema>;
 export type LoginWithTokenInput = z.infer<typeof loginWithTokenInputSchema>;
 
 export type LoginWithTokenOutput = z.infer<typeof loginWithTokenOutputSchema>;
+
+export type LoginWithSATokenInput = z.infer<typeof loginWithSATokenInputSchema>;
+
+export type LoginWithSATokenOutput = z.infer<typeof loginWithSATokenOutputSchema>;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -6,5 +6,6 @@ export * from "./types.js";
 export * from "./truncateName.js";
 export * from "./versioning.js";
 export * from "./stripLeadingSlash.js";
+export * from "./stripTrailingSlash.js";
 export * from "./tryParseJsonArray.js";
 export * from "./sortByName.js";

--- a/packages/shared/src/utils/stripTrailingSlash.test.ts
+++ b/packages/shared/src/utils/stripTrailingSlash.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { stripTrailingSlash } from "./stripTrailingSlash.js";
+
+describe("stripTrailingSlash", () => {
+  it("should strip a single trailing slash", () => {
+    expect(stripTrailingSlash("https://host/")).toBe("https://host");
+  });
+
+  it("should strip multiple trailing slashes", () => {
+    expect(stripTrailingSlash("https://host///")).toBe("https://host");
+  });
+
+  it("should return string unchanged if no trailing slash", () => {
+    expect(stripTrailingSlash("https://host")).toBe("https://host");
+  });
+
+  it("should handle a single slash", () => {
+    expect(stripTrailingSlash("/")).toBe("");
+  });
+
+  it("should not strip internal slashes", () => {
+    expect(stripTrailingSlash("https://host/a/b/")).toBe("https://host/a/b");
+  });
+
+  it("should return empty string for empty input", () => {
+    expect(stripTrailingSlash("")).toBe("");
+  });
+
+  it("should return empty string for null", () => {
+    expect(stripTrailingSlash(null)).toBe("");
+  });
+
+  it("should return empty string for undefined", () => {
+    expect(stripTrailingSlash(undefined)).toBe("");
+  });
+
+  it("should run in linear time on a long run of trailing slashes", () => {
+    const input = `https://host${"/".repeat(100000)}`;
+    expect(stripTrailingSlash(input)).toBe("https://host");
+  });
+});

--- a/packages/shared/src/utils/stripTrailingSlash.ts
+++ b/packages/shared/src/utils/stripTrailingSlash.ts
@@ -1,0 +1,26 @@
+/**
+ * Strips all trailing slashes from a string if present.
+ * Returns empty string for null/undefined input.
+ *
+ * Uses a linear scan (no regex) on purpose: an anchored quantifier like
+ * `/\/+$/` exhibits super-linear (O(n^2)) backtracking on a long run of
+ * trailing slashes, which static analyzers flag as a ReDoS risk. This is O(n).
+ *
+ * @example
+ * stripTrailingSlash("https://host/")   // "https://host"
+ * stripTrailingSlash("https://host///") // "https://host"
+ * stripTrailingSlash("https://host")    // "https://host"
+ * stripTrailingSlash("")                // ""
+ */
+export function stripTrailingSlash(path: string | null | undefined): string {
+  if (!path) {
+    return "";
+  }
+
+  let end = path.length;
+  while (end > 0 && path.charCodeAt(end - 1) === 47 /* "/" */) {
+    end--;
+  }
+
+  return end === path.length ? path : path.slice(0, end);
+}

--- a/packages/trpc/src/__mocks__/k8s-client.ts
+++ b/packages/trpc/src/__mocks__/k8s-client.ts
@@ -18,6 +18,8 @@ export type MockK8sClient = {
   createResource: Mock;
   replaceResource: Mock;
   patchResource: Mock;
+  fetchApiPath: Mock;
+  getSelfSubjectReview: Mock;
 } & K8sClient;
 
 export function createMockedK8sClient(mockSession: CustomSession): MockK8sClient {
@@ -58,6 +60,8 @@ export function createMockedK8sClient(mockSession: CustomSession): MockK8sClient
     createResource: vi.fn(),
     replaceResource: vi.fn(),
     patchResource: vi.fn(),
+    fetchApiPath: vi.fn(),
+    getSelfSubjectReview: vi.fn(),
   };
 
   return mockK8sClient as MockK8sClient;

--- a/packages/trpc/src/clients/gitfusion/index.ts
+++ b/packages/trpc/src/clients/gitfusion/index.ts
@@ -7,6 +7,7 @@ import {
   GitFusionPullRequestListResponse,
   GitLabPipelineResponse,
   GitLabPipelineVariable,
+  stripTrailingSlash,
 } from "@my-project/shared";
 
 // =============================================================================
@@ -111,7 +112,7 @@ export class GitFusionClient {
     }
 
     // Remove trailing slash if present
-    this.apiBaseURL = apiBaseURL.replace(/\/$/, "");
+    this.apiBaseURL = stripTrailingSlash(apiBaseURL);
     this.timeoutMs = timeoutMs;
   }
 

--- a/packages/trpc/src/clients/k8s/index.test.ts
+++ b/packages/trpc/src/clients/k8s/index.test.ts
@@ -514,4 +514,82 @@ describe("K8sClient", () => {
       expect(result.items).toHaveLength(3);
     });
   });
+
+  describe("fromToken", () => {
+    it("builds a client carrying the token with the oidc-user fallback name", () => {
+      const client = K8sClient.fromToken("sa-token");
+      const kc = client.KubeConfig!;
+
+      expect(kc).not.toBeNull();
+      expect(kc.users).toEqual([{ name: "oidc-user", token: "sa-token" }]);
+    });
+  });
+
+  describe("getSelfSubjectReview", () => {
+    const makeKubeConfigWithServer = () =>
+      ({
+        loadFromDefault: vi.fn(),
+        loadFromCluster: vi.fn(),
+        getCurrentCluster: vi.fn().mockReturnValue({ name: "test-cluster", server: "https://k8s.example.com" }),
+        getCurrentContext: vi.fn().mockReturnValue("test-context"),
+        getCurrentUser: vi.fn().mockReturnValue({}),
+        setCurrentContext: vi.fn(),
+        applyToHTTPSOptions: vi.fn(),
+        users: [],
+        contexts: [],
+        clusters: [],
+        currentContext: "test-context",
+      }) as unknown as KubeConfig;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("POSTs a SelfSubjectReview to the cluster and returns the parsed userInfo", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({
+          apiVersion: "authentication.k8s.io/v1",
+          kind: "SelfSubjectReview",
+          status: {
+            userInfo: {
+              username: "system:serviceaccount:edp:edp-admin",
+              uid: "uid-1",
+              groups: ["system:authenticated"],
+            },
+          },
+        }),
+      } as never);
+
+      const client = K8sClient.fromToken("sa-token");
+      const result = await client.getSelfSubjectReview();
+
+      const call0 = fetchMock.mock.calls[0]!;
+      expect(call0[0]).toBe("https://k8s.example.com/apis/authentication.k8s.io/v1/selfsubjectreviews");
+      expect(call0[1]!.method).toBe("POST");
+      expect(JSON.parse(call0[1]!.body as string)).toMatchObject({
+        apiVersion: "authentication.k8s.io/v1",
+        kind: "SelfSubjectReview",
+      });
+      expect(result.status?.userInfo?.username).toBe("system:serviceaccount:edp:edp-admin");
+    });
+
+    it("throws K8sApiError on a non-2xx response (e.g. 401)", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        text: async () => "{}",
+      } as never);
+
+      const client = K8sClient.fromToken("bad-token");
+
+      await expect(client.getSelfSubjectReview()).rejects.toBeInstanceOf(K8sApiError);
+    });
+  });
 });

--- a/packages/trpc/src/clients/k8s/index.ts
+++ b/packages/trpc/src/clients/k8s/index.ts
@@ -15,6 +15,25 @@ type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 export type PatchType = "strategic" | "merge" | "json";
 export type PatchSubresource = "scale" | "status";
 
+// SelfSubjectReview response shape (authentication.k8s.io/v1). The generated
+// V1SelfSubjectReview / V1UserInfo types are not re-exported from
+// @kubernetes/client-node's top-level index, so we declare minimal
+// plain-object interfaces for the fields we consume.
+export interface K8sSelfSubjectUserInfo {
+  username?: string;
+  uid?: string;
+  groups?: string[];
+  extra?: Record<string, string[]>;
+}
+
+export interface K8sSelfSubjectReviewResponse {
+  apiVersion?: string;
+  kind?: string;
+  status?: {
+    userInfo?: K8sSelfSubjectUserInfo;
+  };
+}
+
 export class K8sClient {
   KubeConfig: KubeConfig | null;
   // Captures the specific reason the KubeConfig could not be initialized so
@@ -77,6 +96,60 @@ export class K8sClient {
       },
     ];
     this.KubeConfig.setCurrentContext(currentContext);
+  }
+
+  /**
+   * Builds a K8sClient that authenticates with a raw bearer token, without
+   * requiring a full session. Used by the Service Account token login path to
+   * validate a token against the cluster (via {@link getSelfSubjectReview})
+   * before any session exists. Reuses the standard constructor by passing a
+   * minimal synthetic session carrying only the token, so cluster/CA loading
+   * and token injection behave exactly as for a real session.
+   */
+  static fromToken(token: string): K8sClient {
+    const now = Date.now();
+    const syntheticSession = {
+      user: {
+        data: undefined,
+        secret: {
+          idToken: token,
+          idTokenExpiresAt: now + 60_000,
+          accessToken: token,
+          accessTokenExpiresAt: now + 60_000,
+          refreshToken: "",
+        },
+      },
+    } as unknown as CustomSession;
+
+    return new K8sClient(syntheticSession);
+  }
+
+  /**
+   * Calls the Kubernetes SelfSubjectReview API
+   * (POST /apis/authentication.k8s.io/v1/selfsubjectreviews) to validate the
+   * bearer token injected into this client and return the caller's identity.
+   * This is the same mechanism `kubectl auth whoami` uses. Requires Kubernetes
+   * 1.28+ (GA; 1.26-1.27 expose it as beta). Throws K8sApiError on non-2xx.
+   */
+  async getSelfSubjectReview(): Promise<K8sSelfSubjectReviewResponse> {
+    if (!this.KubeConfig) {
+      throw new Error("KubeConfig is not initialized");
+    }
+
+    const cluster = this.KubeConfig.getCurrentCluster();
+    if (!cluster) {
+      throw new Error("No current cluster found");
+    }
+
+    const url = `${cluster.server}/apis/authentication.k8s.io/v1/selfsubjectreviews`;
+    const body = {
+      apiVersion: "authentication.k8s.io/v1",
+      kind: "SelfSubjectReview",
+      metadata: {},
+      spec: {},
+    };
+
+    return this.makeRequest("POST", url, body) as unknown as K8sSelfSubjectReviewResponse;
   }
 
   /**

--- a/packages/trpc/src/clients/oidc/index.ts
+++ b/packages/trpc/src/clients/oidc/index.ts
@@ -17,6 +17,7 @@ import { createRemoteJWKSet, errors as joseErrors, jwtVerify } from "jose";
 
 import { getJwtPayloadClaim } from "../../utils/jwt/index.js";
 import { getTokenExpirationTime } from "../../utils/getTokenExpirationTime/index.js";
+import { buildTokenInfoFromToken } from "../../utils/buildTokenInfoFromToken/index.js";
 
 /**
  * Normalize the groups claim from OIDC providers.
@@ -462,27 +463,6 @@ export class OIDCClient {
     accessTokenExpiresAt: number;
     refreshToken: string;
   } {
-    const DEFAULT_EXPIRATION_MS = 5 * 60 * 1000; // 5 minutes
-    const MAX_SESSION_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-    let expiresAt: number;
-
-    try {
-      expiresAt = getTokenExpirationTime(token);
-    } catch {
-      // Opaque token or missing exp — cannot determine expiration, use default
-      expiresAt = Date.now() + DEFAULT_EXPIRATION_MS;
-    }
-
-    // Cap expiration to prevent attacker-controlled far-future exp claims
-    expiresAt = Math.min(expiresAt, Date.now() + MAX_SESSION_DURATION_MS);
-
-    return {
-      idToken: token,
-      idTokenExpiresAt: expiresAt,
-      accessToken: token,
-      accessTokenExpiresAt: expiresAt,
-      refreshToken: "",
-    };
+    return buildTokenInfoFromToken(token);
   }
 }

--- a/packages/trpc/src/clients/prometheus/index.ts
+++ b/packages/trpc/src/clients/prometheus/index.ts
@@ -1,5 +1,10 @@
 import { TRPCError } from "@trpc/server";
-import { promqlMatrixResponseSchema, promqlVectorResponseSchema, PROMETHEUS_TIMEOUT_MS } from "@my-project/shared";
+import {
+  promqlMatrixResponseSchema,
+  promqlVectorResponseSchema,
+  PROMETHEUS_TIMEOUT_MS,
+  stripTrailingSlash,
+} from "@my-project/shared";
 import type { PromQLMatrixResponse, PromQLVectorResponse } from "@my-project/shared";
 import type { ZodType } from "zod";
 
@@ -11,7 +16,7 @@ export interface PrometheusClientConfig {
 /** Read PROMETHEUS_URL once at module load. */
 function loadConfig(): { baseURL: string } {
   return {
-    baseURL: (process.env.PROMETHEUS_URL || "").replace(/\/$/, ""),
+    baseURL: stripTrailingSlash(process.env.PROMETHEUS_URL),
   };
 }
 

--- a/packages/trpc/src/clients/sonarqube/index.ts
+++ b/packages/trpc/src/clients/sonarqube/index.ts
@@ -11,6 +11,7 @@ import {
   BatchMeasuresResponse,
   IssuesQueryParams,
   IssuesSearchResponse,
+  stripTrailingSlash,
 } from "@my-project/shared";
 
 // =============================================================================
@@ -116,7 +117,7 @@ export class SonarQubeClient {
     }
 
     // Remove trailing slash if present
-    this.apiBaseURL = apiBaseURL.replace(/\/$/, "");
+    this.apiBaseURL = stripTrailingSlash(apiBaseURL);
     this.token = token;
     this.timeoutMs = timeoutMs;
   }

--- a/packages/trpc/src/procedures/protected/index.test.ts
+++ b/packages/trpc/src/procedures/protected/index.test.ts
@@ -10,7 +10,15 @@ vi.mock("../../clients/oidc/index.js", () => ({
   OIDCClient: vi.fn(),
 }));
 
+const { mockAuthenticateSA } = vi.hoisted(() => ({ mockAuthenticateSA: vi.fn() }));
+vi.mock("../../utils/authenticateServiceAccountToken/index.js", () => ({
+  authenticateServiceAccountToken: mockAuthenticateSA,
+}));
+
 const MockedOIDCClient = OIDCClient as unknown as Mock;
+
+const b64url = (o: object) => Buffer.from(JSON.stringify(o)).toString("base64url");
+const makeJwt = (payload: object) => `${b64url({ alg: "none", typ: "JWT" })}.${b64url(payload)}.sig`;
 
 describe("protected procedure", () => {
   let mockContext: ReturnType<typeof createMockedContext>;
@@ -206,6 +214,73 @@ describe("protected procedure", () => {
 
       await expect(caller.testProtected()).rejects.toThrow();
       expect(mockContext.session.user).toBeUndefined();
+    });
+  });
+
+  // Issuer-routed Bearer authentication: an SA token (or any token when OIDC is
+  // unconfigured) is validated against the cluster via SelfSubjectReview, so the
+  // CLI can present an SA token in the Authorization header in any configuration.
+  describe("issuer-routed Bearer authentication (Service Account tokens)", () => {
+    const saResult = {
+      data: {
+        sub: "sa-uid",
+        name: "edp-admin",
+        preferred_username: "system:serviceaccount:edp:edp-admin",
+        email: "",
+        groups: ["system:authenticated"],
+        default_namespace: "edp",
+      },
+      secret: {
+        idToken: "sa-token",
+        idTokenExpiresAt: 1800000000000,
+        accessToken: "sa-token",
+        accessTokenExpiresAt: 1800000000000,
+        refreshToken: "",
+      },
+    };
+
+    beforeEach(() => {
+      mockContext.session.user = undefined;
+      mockAuthenticateSA.mockResolvedValue(saResult);
+    });
+
+    it("routes to the SA path when OIDC is not configured", async () => {
+      mockContext.oidcConfig.issuerURL = "";
+      setBearerHeader("any-sa-token");
+
+      const caller = createTestRouterCaller(mockContext);
+      const result = await caller.testProtected();
+
+      expect(result).toBe(true);
+      expect(mockAuthenticateSA).toHaveBeenCalledWith("any-sa-token");
+      expect(mockDiscoverOrThrow).not.toHaveBeenCalled();
+      expect(mockContext.session.user).toEqual(saResult);
+    });
+
+    it("routes to the SA path when the token issuer differs from the OIDC issuer", async () => {
+      mockContext.oidcConfig.issuerURL = "https://oidc.example.com";
+      const saToken = makeJwt({ iss: "https://kubernetes.default.svc" });
+      setBearerHeader(saToken);
+
+      const caller = createTestRouterCaller(mockContext);
+      const result = await caller.testProtected();
+
+      expect(result).toBe(true);
+      expect(mockAuthenticateSA).toHaveBeenCalledWith(saToken);
+      expect(mockValidateTokenAndGetUserInfo).not.toHaveBeenCalled();
+    });
+
+    it("routes to the OIDC path when the token issuer matches the OIDC issuer", async () => {
+      mockContext.oidcConfig.issuerURL = "https://oidc.example.com";
+      const oidcToken = makeJwt({ iss: "https://oidc.example.com" });
+      setBearerHeader(oidcToken);
+
+      const caller = createTestRouterCaller(mockContext);
+      const result = await caller.testProtected();
+
+      expect(result).toBe(true);
+      expect(mockValidateTokenAndGetUserInfo).toHaveBeenCalled();
+      expect(mockAuthenticateSA).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/trpc/src/procedures/protected/index.ts
+++ b/packages/trpc/src/procedures/protected/index.ts
@@ -4,6 +4,9 @@ import type { FastifyRequest } from "fastify";
 import type { OIDCUser } from "@my-project/shared";
 import { ERROR_NO_SESSION_FOUND, ERROR_TOKEN_EXPIRED } from "../../routers/auth/errors/index.js";
 import { OIDCClient, type OIDCConfig } from "../../clients/oidc/index.js";
+import { getJwtPayloadClaim } from "../../utils/jwt/index.js";
+import { authenticateServiceAccountToken } from "../../utils/authenticateServiceAccountToken/index.js";
+import { type TokenInfo } from "../../utils/buildTokenInfoFromToken/index.js";
 import { t } from "../../trpc.js";
 
 const DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -93,25 +96,59 @@ async function getOrRefreshDiscovery(oidcConfig: OIDCConfig): Promise<{ client: 
   }
 }
 
+/**
+ * Decides whether a Bearer token should be validated via OIDC or via the
+ * Kubernetes Service Account path (SelfSubjectReview).
+ *
+ * - OIDC unconfigured → always SA (the only option in SA-only deployments).
+ * - Token's `iss` matches the configured OIDC issuer → OIDC.
+ * - Token is opaque or has a foreign `iss` (e.g. a cluster SA token whose issuer
+ *   is the API server) → SA.
+ *
+ * Routing is an optimization, not a trust decision: each path independently
+ * validates the token (OIDC signature/userinfo, or cluster SelfSubjectReview),
+ * so a token cannot bypass validation by influencing the route.
+ */
+function shouldUseOidc(token: string, oidcConfig: OIDCConfig): boolean {
+  if (!oidcConfig.issuerURL) {
+    return false;
+  }
+
+  let iss: unknown;
+  try {
+    iss = getJwtPayloadClaim(token, "iss");
+  } catch {
+    // Not a JWT (e.g. an opaque OIDC access token) — route to OIDC, which
+    // validates it via userinfo. Legacy Secret-based SA tokens (pre-1.22,
+    // non-expiring) are also opaque and would land here; they are unsupported
+    // (SelfSubjectReview requires 1.28+) and correctly surface as UNAUTHORIZED.
+    return true;
+  }
+
+  if (typeof iss !== "string") {
+    return true;
+  }
+
+  return iss.replace(/\/+$/, "") === oidcConfig.issuerURL.replace(/\/+$/, "");
+}
+
 export async function authenticateBearerToken(
   token: string,
   oidcConfig: OIDCConfig
-): Promise<{
-  data: OIDCUser;
-  secret: {
-    idToken: string;
-    idTokenExpiresAt: number;
-    accessToken: string;
-    accessTokenExpiresAt: number;
-    refreshToken: string;
-  };
-}> {
-  const { client, config } = await getOrRefreshDiscovery(oidcConfig);
+): Promise<{ data: OIDCUser; secret: TokenInfo }> {
+  if (shouldUseOidc(token, oidcConfig)) {
+    const { client, config } = await getOrRefreshDiscovery(oidcConfig);
 
-  const data = await client.validateTokenAndGetUserInfo(config, token);
-  const secret = client.validateTokenAndGetTokenInfo(token);
+    const data = await client.validateTokenAndGetUserInfo(config, token);
+    const secret = client.validateTokenAndGetTokenInfo(token);
 
-  return { data, secret };
+    return { data, secret };
+  }
+
+  // Service Account token (or any token in an OIDC-less deployment): validate
+  // against the cluster via SelfSubjectReview. CLI clients can therefore present
+  // an SA token in the Authorization header in any configuration.
+  return authenticateServiceAccountToken(token);
 }
 
 export const protectedProcedure = t.procedure.use(async ({ ctx, next }) => {

--- a/packages/trpc/src/procedures/protected/index.ts
+++ b/packages/trpc/src/procedures/protected/index.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import type { Configuration } from "openid-client";
 import type { FastifyRequest } from "fastify";
-import type { OIDCUser } from "@my-project/shared";
+import { type OIDCUser, stripTrailingSlash } from "@my-project/shared";
 import { ERROR_NO_SESSION_FOUND, ERROR_TOKEN_EXPIRED } from "../../routers/auth/errors/index.js";
 import { OIDCClient, type OIDCConfig } from "../../clients/oidc/index.js";
 import { getJwtPayloadClaim } from "../../utils/jwt/index.js";
@@ -129,7 +129,7 @@ function shouldUseOidc(token: string, oidcConfig: OIDCConfig): boolean {
     return true;
   }
 
-  return iss.replace(/\/+$/, "") === oidcConfig.issuerURL.replace(/\/+$/, "");
+  return stripTrailingSlash(iss) === stripTrailingSlash(oidcConfig.issuerURL);
 }
 
 export async function authenticateBearerToken(

--- a/packages/trpc/src/routers/auth/index.ts
+++ b/packages/trpc/src/routers/auth/index.ts
@@ -2,6 +2,7 @@ import { t } from "../../trpc.js";
 import { authLoginProcedure } from "./procedures/login/index.js";
 import { authLoginCallbackProcedure } from "./procedures/loginCallback/index.js";
 import { authLoginWithTokenProcedure } from "./procedures/loginWithToken/index.js";
+import { authLoginWithServiceAccountTokenProcedure } from "./procedures/loginWithServiceAccountToken/index.js";
 import { authLogoutProcedure } from "./procedures/logout/index.js";
 import { authMeProcedure } from "./procedures/me/index.js";
 
@@ -9,6 +10,7 @@ export const authRouter = t.router({
   login: authLoginProcedure,
   loginCallback: authLoginCallbackProcedure,
   loginWithToken: authLoginWithTokenProcedure,
+  loginWithServiceAccountToken: authLoginWithServiceAccountTokenProcedure,
   logout: authLogoutProcedure,
   me: authMeProcedure,
 });

--- a/packages/trpc/src/routers/auth/procedures/loginWithServiceAccountToken/index.test.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginWithServiceAccountToken/index.test.ts
@@ -1,0 +1,79 @@
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+import { TRPCError } from "@trpc/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuthSA } = vi.hoisted(() => ({ mockAuthSA: vi.fn() }));
+
+vi.mock("../../../../utils/authenticateServiceAccountToken/index.js", () => ({
+  authenticateServiceAccountToken: mockAuthSA,
+}));
+
+describe("authLoginWithServiceAccountTokenProcedure", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+
+  const data = {
+    sub: "u1",
+    name: "edp-admin",
+    preferred_username: "system:serviceaccount:edp:edp-admin",
+    email: "",
+    groups: ["system:authenticated"],
+    default_namespace: "edp",
+  };
+
+  const secret = {
+    idToken: "sa-token",
+    idTokenExpiresAt: 1234567890,
+    accessToken: "sa-token",
+    accessTokenExpiresAt: 1234567890,
+    refreshToken: "",
+  };
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+    mockAuthSA.mockResolvedValue({ data, secret });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("validates the SA token, sets the session, and returns user info", async () => {
+    const caller = createCaller(mockContext);
+    const result = await caller.auth.loginWithServiceAccountToken({ token: "sa-token" });
+
+    expect(mockAuthSA).toHaveBeenCalledWith("sa-token");
+    expect(result.success).toBe(true);
+    expect(result.userInfo).toMatchObject({
+      sub: "u1",
+      name: "edp-admin",
+      default_namespace: "edp",
+    });
+    expect(result.clientSearch).toBe("");
+    expect(mockContext.session.user).toEqual({ data, secret });
+  });
+
+  it("includes redirect in clientSearch when redirectSearchParam is provided", async () => {
+    const caller = createCaller(mockContext);
+    const result = await caller.auth.loginWithServiceAccountToken({
+      token: "sa-token",
+      redirectSearchParam: "/pipelines",
+    });
+
+    expect(result.clientSearch).toBe("?redirect=/pipelines");
+  });
+
+  it("propagates UNAUTHORIZED and leaves session.user unset on rejection", async () => {
+    mockContext.session.user = undefined as unknown as typeof mockContext.session.user;
+    mockAuthSA.mockRejectedValueOnce(
+      new TRPCError({ code: "UNAUTHORIZED", message: "The service account token was rejected by the cluster." })
+    );
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.auth.loginWithServiceAccountToken({ token: "bad-token" })).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(mockContext.session.user).toBeUndefined();
+  });
+});

--- a/packages/trpc/src/routers/auth/procedures/loginWithServiceAccountToken/index.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginWithServiceAccountToken/index.ts
@@ -1,0 +1,24 @@
+import { publicProcedure } from "../../../../procedures/public/index.js";
+import { loginWithSATokenInputSchema, loginWithSATokenOutputSchema } from "@my-project/shared";
+import { authenticateServiceAccountToken } from "../../../../utils/authenticateServiceAccountToken/index.js";
+
+export const authLoginWithServiceAccountTokenProcedure = publicProcedure
+  .input(loginWithSATokenInputSchema)
+  .output(loginWithSATokenOutputSchema)
+  .mutation(async ({ input, ctx }) => {
+    const { token, redirectSearchParam } = input;
+
+    // Validates the SA token against the cluster (SelfSubjectReview) and builds
+    // the session identity + token info. Fully OIDC-independent.
+    const { data, secret } = await authenticateServiceAccountToken(token);
+
+    ctx.session.user = { data, secret };
+
+    const clientSearch = redirectSearchParam ? `?redirect=${redirectSearchParam}` : "";
+
+    return {
+      success: true,
+      userInfo: data,
+      clientSearch,
+    };
+  });

--- a/packages/trpc/src/routers/auth/procedures/logout/index.ts
+++ b/packages/trpc/src/routers/auth/procedures/logout/index.ts
@@ -5,14 +5,18 @@ import { OIDCClient } from "../../../../clients/oidc/index.js";
 export const authLogoutProcedure = publicProcedure.output(logoutOutputSchema).mutation(async ({ ctx }) => {
   let endSessionUrl: string | undefined;
 
-  try {
-    const idToken = ctx.session.user?.secret?.idToken;
-    const oidcClient = new OIDCClient(ctx.oidcConfig);
-    const config = await oidcClient.discover();
+  // Only attempt OIDC RP-initiated logout when OIDC is configured. In SA-only
+  // deployments (no OIDC), skip it entirely and do a local-only session destroy.
+  if (ctx.oidcConfig.issuerURL) {
+    try {
+      const idToken = ctx.session.user?.secret?.idToken;
+      const oidcClient = new OIDCClient(ctx.oidcConfig);
+      const config = await oidcClient.discover();
 
-    endSessionUrl = oidcClient.buildEndSessionUrl(config, idToken, ctx.portalUrl);
-  } catch {
-    // If OIDC discovery fails, proceed with local-only logout
+      endSessionUrl = oidcClient.buildEndSessionUrl(config, idToken, ctx.portalUrl);
+    } catch {
+      // If OIDC discovery fails, proceed with local-only logout
+    }
   }
 
   ctx.session.destroy();

--- a/packages/trpc/src/routers/config/index.test.ts
+++ b/packages/trpc/src/routers/config/index.test.ts
@@ -3,13 +3,23 @@ import { createCaller } from "../../routers/index.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("config.oidc", () => {
-  it("should return oidcIssuerUrl from context", async () => {
+  it("should return oidcIssuerUrl and oidcEnabled from context", async () => {
     const mockContext = createMockedContext();
     const caller = createCaller(mockContext);
 
     const result = await caller.config.oidc();
 
-    expect(result).toEqual({ oidcIssuerUrl: "https://mock-issuer.example.com" });
+    expect(result).toEqual({ oidcIssuerUrl: "https://mock-issuer.example.com", oidcEnabled: true });
+  });
+
+  it("reports oidcEnabled=false when no issuer URL is configured (SA-only mode)", async () => {
+    const mockContext = createMockedContext();
+    mockContext.oidcConfig.issuerURL = "";
+    const caller = createCaller(mockContext);
+
+    const result = await caller.config.oidc();
+
+    expect(result).toEqual({ oidcIssuerUrl: "", oidcEnabled: false });
   });
 });
 

--- a/packages/trpc/src/routers/config/index.ts
+++ b/packages/trpc/src/routers/config/index.ts
@@ -4,15 +4,19 @@ import { z } from "zod";
 
 export const configRouter = t.router({
   /**
-   * Returns only the OIDC issuer URL, accessible without authentication.
-   * Used by CLI for OIDC discovery before login.
+   * Returns the OIDC issuer URL and whether OIDC is enabled, accessible without
+   * authentication. Used by the CLI for OIDC discovery before login, and by the
+   * web client to decide whether to render OIDC login controls.
    */
   oidc: t.procedure
     .meta({ openapi: { method: "GET", path: "/v1/config/oidc", protect: false } })
     .input(z.void())
-    .output(z.object({ oidcIssuerUrl: z.string() }))
+    .output(z.object({ oidcIssuerUrl: z.string(), oidcEnabled: z.boolean() }))
     .query(({ ctx }) => ({
       oidcIssuerUrl: ctx.oidcConfig.issuerURL,
+      // OIDC is enabled when an issuer URL is configured. When false, the client
+      // hides OIDC login controls and offers only Service Account token login.
+      oidcEnabled: !!ctx.oidcConfig.issuerURL,
     })),
 
   /**

--- a/packages/trpc/src/utils/authenticateServiceAccountToken/index.test.ts
+++ b/packages/trpc/src/utils/authenticateServiceAccountToken/index.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { K8sApiError } from "@my-project/shared";
+import { K8sClient } from "../../clients/k8s/index.js";
+import { authenticateServiceAccountToken } from "./index.js";
+
+vi.mock("../../clients/k8s/index.js", () => ({
+  K8sClient: { fromToken: vi.fn() },
+}));
+
+const mockFromToken = K8sClient.fromToken as unknown as Mock;
+
+function stubClient(opts: {
+  kubeConfig?: unknown;
+  initError?: string | null;
+  review?: unknown;
+  reviewError?: unknown;
+}) {
+  const getSelfSubjectReview = vi.fn();
+  if (opts.reviewError) {
+    getSelfSubjectReview.mockRejectedValue(opts.reviewError);
+  } else {
+    getSelfSubjectReview.mockResolvedValue(opts.review);
+  }
+
+  mockFromToken.mockReturnValue({
+    KubeConfig: opts.kubeConfig === undefined ? {} : opts.kubeConfig,
+    kubeConfigInitError: opts.initError ?? null,
+    getSelfSubjectReview,
+  });
+
+  return getSelfSubjectReview;
+}
+
+describe("authenticateServiceAccountToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("validates the token via SelfSubjectReview and maps the SA identity", async () => {
+    stubClient({
+      review: {
+        status: {
+          userInfo: {
+            username: "system:serviceaccount:edp:edp-admin",
+            uid: "u1",
+            groups: ["system:authenticated"],
+          },
+        },
+      },
+    });
+
+    const { data, secret } = await authenticateServiceAccountToken("sa-token");
+
+    expect(mockFromToken).toHaveBeenCalledWith("sa-token");
+    expect(data.sub).toBe("u1");
+    expect(data.name).toBe("edp-admin");
+    expect(data.default_namespace).toBe("edp");
+    expect(secret.idToken).toBe("sa-token");
+    expect(secret.accessToken).toBe("sa-token");
+    expect(secret.refreshToken).toBe("");
+  });
+
+  it("throws INTERNAL_SERVER_ERROR when the K8s client cannot initialize", async () => {
+    stubClient({ kubeConfig: null, initError: "No cluster configuration found in kubeconfig." });
+
+    await expect(authenticateServiceAccountToken("t")).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+      message: expect.stringContaining("No cluster configuration"),
+    });
+  });
+
+  it.each([401, 403])("maps HTTP %s to UNAUTHORIZED", async (status) => {
+    stubClient({ reviewError: new K8sApiError(status, "x", "{}") });
+
+    await expect(authenticateServiceAccountToken("t")).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("maps HTTP 404 to INTERNAL_SERVER_ERROR (cluster lacks SelfSubjectReview)", async () => {
+    stubClient({ reviewError: new K8sApiError(404, "Not Found", "{}") });
+
+    await expect(authenticateServiceAccountToken("t")).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+      message: expect.stringContaining("SelfSubjectReview"),
+    });
+  });
+
+  it("maps unexpected (non-K8sApiError) errors to INTERNAL_SERVER_ERROR", async () => {
+    stubClient({ reviewError: new Error("network down") });
+
+    await expect(authenticateServiceAccountToken("t")).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
+  });
+
+  it("throws when the cluster returns an empty identity", async () => {
+    stubClient({ review: { status: { userInfo: {} } } });
+
+    await expect(authenticateServiceAccountToken("t")).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+      message: expect.stringContaining("empty identity"),
+    });
+  });
+});

--- a/packages/trpc/src/utils/authenticateServiceAccountToken/index.ts
+++ b/packages/trpc/src/utils/authenticateServiceAccountToken/index.ts
@@ -1,0 +1,74 @@
+import { TRPCError } from "@trpc/server";
+import { K8sApiError, type OIDCUser } from "@my-project/shared";
+
+import { K8sClient } from "../../clients/k8s/index.js";
+import { buildTokenInfoFromToken, type TokenInfo } from "../buildTokenInfoFromToken/index.js";
+import { mapSelfSubjectReviewToOIDCUser } from "../mapSelfSubjectReviewToOIDCUser/index.js";
+
+// Legacy (Secret-based) Service Account tokens have no `exp` claim and do not
+// expire. Bound tokens (`kubectl create token`) carry `exp` and use it. We pass
+// a 24h default (the session cap) so legacy tokens yield a full-length session
+// instead of the 5-minute default used for opaque OIDC access tokens.
+const SA_DEFAULT_EXPIRATION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Authenticates a Kubernetes Service Account token by validating it against the
+ * cluster via SelfSubjectReview (the same call as `kubectl auth whoami`) and
+ * building the session `data` (identity) and `secret` (token info) objects.
+ *
+ * This path is OIDC-independent — it never constructs an OIDCClient — so it
+ * works in deployments with no OIDC configured. Shared by the web
+ * `loginWithServiceAccountToken` procedure and the stateless Bearer auth path,
+ * keeping both aligned.
+ */
+export async function authenticateServiceAccountToken(token: string): Promise<{
+  data: OIDCUser;
+  secret: TokenInfo;
+}> {
+  const k8sClient = K8sClient.fromToken(token);
+
+  if (!k8sClient.KubeConfig) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: `Could not initialize Kubernetes client: ${k8sClient.kubeConfigInitError ?? "unknown error"}`,
+    });
+  }
+
+  let userInfo;
+  try {
+    const review = await k8sClient.getSelfSubjectReview();
+    userInfo = review.status?.userInfo;
+  } catch (err) {
+    if (err instanceof K8sApiError) {
+      if (err.statusCode === 401 || err.statusCode === 403) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "The service account token was rejected by the cluster. Verify the token is valid and not expired.",
+        });
+      }
+      if (err.statusCode === 404) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message:
+            "The cluster does not support SelfSubjectReview. This requires Kubernetes 1.28+ (GA) or 1.26+ (beta).",
+        });
+      }
+    }
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Failed to validate the service account token against the cluster.",
+    });
+  }
+
+  if (!userInfo?.username) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Cluster returned an empty identity for this token.",
+    });
+  }
+
+  return {
+    data: mapSelfSubjectReviewToOIDCUser(userInfo),
+    secret: buildTokenInfoFromToken(token, SA_DEFAULT_EXPIRATION_MS),
+  };
+}

--- a/packages/trpc/src/utils/buildTokenInfoFromToken/index.test.ts
+++ b/packages/trpc/src/utils/buildTokenInfoFromToken/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { buildTokenInfoFromToken } from "./index.js";
+
+const b64url = (o: object) => Buffer.from(JSON.stringify(o)).toString("base64url");
+const makeJwt = (payload: object) => `${b64url({ alg: "none", typ: "JWT" })}.${b64url(payload)}.sig`;
+
+const ONE_HOUR_S = 3600;
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+describe("buildTokenInfoFromToken", () => {
+  const NOW = 1_700_000_000_000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the JWT exp claim when present and within the cap", () => {
+    const expSec = Math.floor(NOW / 1000) + ONE_HOUR_S;
+    const token = makeJwt({ exp: expSec });
+
+    const info = buildTokenInfoFromToken(token);
+
+    expect(info.idToken).toBe(token);
+    expect(info.accessToken).toBe(token);
+    expect(info.refreshToken).toBe("");
+    expect(info.idTokenExpiresAt).toBe(expSec * 1000);
+    expect(info.accessTokenExpiresAt).toBe(expSec * 1000);
+  });
+
+  it("falls back to the 5-minute default for opaque (non-JWT) tokens", () => {
+    const info = buildTokenInfoFromToken("opaque-token");
+
+    expect(info.idTokenExpiresAt).toBe(NOW + 5 * 60 * 1000);
+  });
+
+  it("falls back to the provided default for tokens without an exp claim", () => {
+    const token = makeJwt({ sub: "no-exp" });
+
+    const info = buildTokenInfoFromToken(token, 7000);
+
+    expect(info.idTokenExpiresAt).toBe(NOW + 7000);
+  });
+
+  it("gives a legacy (no-exp) SA token a full 24h session when passed the SA default", () => {
+    const token = makeJwt({ sub: "legacy-sa" });
+
+    const info = buildTokenInfoFromToken(token, TWENTY_FOUR_HOURS_MS);
+
+    expect(info.idTokenExpiresAt).toBe(NOW + TWENTY_FOUR_HOURS_MS);
+  });
+
+  it("caps a far-future exp claim at 24h", () => {
+    const expSec = Math.floor(NOW / 1000) + 48 * ONE_HOUR_S;
+    const token = makeJwt({ exp: expSec });
+
+    const info = buildTokenInfoFromToken(token);
+
+    expect(info.idTokenExpiresAt).toBe(NOW + TWENTY_FOUR_HOURS_MS);
+  });
+});

--- a/packages/trpc/src/utils/buildTokenInfoFromToken/index.ts
+++ b/packages/trpc/src/utils/buildTokenInfoFromToken/index.ts
@@ -1,0 +1,48 @@
+import { getTokenExpirationTime } from "../getTokenExpirationTime/index.js";
+
+export type TokenInfo = {
+  idToken: string;
+  idTokenExpiresAt: number;
+  accessToken: string;
+  accessTokenExpiresAt: number;
+  refreshToken: string;
+};
+
+const DEFAULT_EXPIRATION_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_SESSION_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Extracts token metadata for token-based logins that provide a single token
+ * (OIDC access-token login, Kubernetes Service Account token login, and the
+ * stateless Bearer path). The token is stored as both idToken and accessToken,
+ * and no refresh token is available, so the session expires when the token does.
+ *
+ * Expiration is taken from the JWT `exp` claim when present. When the token has
+ * no decodable `exp` (opaque OIDC tokens, or legacy non-expiring Service Account
+ * tokens), `defaultExpirationMs` is used instead. Callers that expect long-lived
+ * tokens (e.g. legacy SA tokens) pass a larger default. The result is always
+ * capped at MAX_SESSION_DURATION_MS to prevent attacker-controlled far-future
+ * `exp` claims from extending the session indefinitely.
+ */
+export function buildTokenInfoFromToken(token: string, defaultExpirationMs: number = DEFAULT_EXPIRATION_MS): TokenInfo {
+  const now = Date.now();
+  let expiresAt: number;
+
+  try {
+    expiresAt = getTokenExpirationTime(token);
+  } catch {
+    // Opaque token or missing exp — cannot determine expiration, use default
+    expiresAt = now + defaultExpirationMs;
+  }
+
+  // Cap expiration to prevent attacker-controlled far-future exp claims
+  expiresAt = Math.min(expiresAt, now + MAX_SESSION_DURATION_MS);
+
+  return {
+    idToken: token,
+    idTokenExpiresAt: expiresAt,
+    accessToken: token,
+    accessTokenExpiresAt: expiresAt,
+    refreshToken: "",
+  };
+}

--- a/packages/trpc/src/utils/mapSelfSubjectReviewToOIDCUser/index.test.ts
+++ b/packages/trpc/src/utils/mapSelfSubjectReviewToOIDCUser/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { mapSelfSubjectReviewToOIDCUser } from "./index.js";
+
+describe("mapSelfSubjectReviewToOIDCUser", () => {
+  it("parses namespace and SA name from a service account username", () => {
+    const user = mapSelfSubjectReviewToOIDCUser({
+      username: "system:serviceaccount:edp-delivery:edp-admin",
+      uid: "uid-123",
+      groups: ["system:serviceaccounts", "system:serviceaccounts:edp-delivery", "system:authenticated"],
+    });
+
+    expect(user.sub).toBe("uid-123");
+    expect(user.name).toBe("edp-admin");
+    expect(user.preferred_username).toBe("system:serviceaccount:edp-delivery:edp-admin");
+    expect(user.email).toBe("");
+    expect(user.default_namespace).toBe("edp-delivery");
+    expect(user.groups).toEqual([
+      "system:serviceaccounts",
+      "system:serviceaccounts:edp-delivery",
+      "system:authenticated",
+    ]);
+  });
+
+  it("falls back to the username for sub when uid is missing", () => {
+    const user = mapSelfSubjectReviewToOIDCUser({ username: "system:serviceaccount:ns:sa" });
+
+    expect(user.sub).toBe("system:serviceaccount:ns:sa");
+    expect(user.groups).toEqual([]);
+  });
+
+  it("handles non-service-account usernames without a default namespace", () => {
+    const user = mapSelfSubjectReviewToOIDCUser({ username: "kube-admin", uid: "abc" });
+
+    expect(user.name).toBe("kube-admin");
+    expect(user.preferred_username).toBe("kube-admin");
+    expect(user.default_namespace).toBeUndefined();
+  });
+
+  it("always populates a non-empty sub (tektonResults cache-key safety)", () => {
+    // An empty sub would collapse every SA into the shared "anonymous" cache bucket.
+    expect(mapSelfSubjectReviewToOIDCUser({ username: "system:serviceaccount:ns:sa" }).sub).toBeTruthy();
+    expect(mapSelfSubjectReviewToOIDCUser({ uid: "only-uid" }).sub).toBe("only-uid");
+  });
+});

--- a/packages/trpc/src/utils/mapSelfSubjectReviewToOIDCUser/index.ts
+++ b/packages/trpc/src/utils/mapSelfSubjectReviewToOIDCUser/index.ts
@@ -1,0 +1,38 @@
+import type { OIDCUser } from "@my-project/shared";
+import type { K8sSelfSubjectUserInfo } from "../../clients/k8s/index.js";
+
+/**
+ * Maps a Kubernetes SelfSubjectReview `status.userInfo` to the OIDCUser shape
+ * the portal session requires (so Service Account identities flow through the
+ * same session/UI code as OIDC users).
+ *
+ * Service Account usernames look like "system:serviceaccount:<namespace>:<name>".
+ * - sub: uid || username — MUST be non-empty: tektonResults.getSummary keys its
+ *   per-user cache on `sub`; an empty value would collapse every SA into the
+ *   shared "anonymous" bucket.
+ * - name: the SA short name (e.g. "edp-admin"), falling back to the full username.
+ * - preferred_username: the full username (e.g. "system:serviceaccount:edp:edp-admin").
+ * - email: "" — SAs have no email. OIDCUser.email is z.string() (not .email()),
+ *   so an empty string is valid and renders harmlessly in the UI.
+ * - groups: passed through as-is (display-only; authorization is enforced by the
+ *   Kubernetes API via SelfSubjectAccessReview with the token).
+ * - default_namespace: the namespace parsed from an SA username, else undefined.
+ */
+export function mapSelfSubjectReviewToOIDCUser(userInfo: K8sSelfSubjectUserInfo): OIDCUser {
+  const username = userInfo.username ?? "";
+  const uid = userInfo.uid ?? "";
+  const groups = userInfo.groups ?? [];
+
+  const saMatch = username.match(/^system:serviceaccount:([^:]+):([^:]+)$/);
+  const defaultNamespace = saMatch?.[1];
+  const displayName = saMatch?.[2] ?? username;
+
+  return {
+    sub: uid || username,
+    name: displayName,
+    preferred_username: username,
+    email: "",
+    groups,
+    default_namespace: defaultNamespace,
+  };
+}


### PR DESCRIPTION
Previously, the portal could only authenticate through an OIDC provider, which blocked its use in clusters without Keycloak/Azure AD configured. This adds Kubernetes Service Account token login and makes OIDC configuration optional.

- The server starts and runs without OIDC env vars; OIDC is no longer required at startup.
- SA tokens are validated against the cluster via SelfSubjectReview before a session is established; invalid or expired tokens are rejected with no session.
- When OIDC is unconfigured the login screen offers SA-token login only; when configured, OIDC sign-in stays primary with SA-token login under "More options".
- The stateless Bearer path routes a token to OIDC or the cluster by issuer, each path independently validating the token.
- Session lifetime follows the token expiry, capped at a safe upper bound.
