### PR TITLE
EPMDEDP-17088: fix: enable search filtering in freeSolo combobox

### DIFF
--- a/apps/client/src/core/components/ui/combobox-multiple-with-input/index.tsx
+++ b/apps/client/src/core/components/ui/combobox-multiple-with-input/index.tsx
@@ -7,6 +7,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/core/components/ui/po
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from "@/core/components/ui/command";
 import { cn } from "@/core/utils/classname";
 import { ComboboxOption } from "@/core/components/ui/combobox";
+import { filterComboboxOptions, renderComboboxOption } from "@/core/components/ui/combobox/utils";
 
 export interface ComboboxMultipleWithInputProps {
   value: string[];
@@ -71,6 +72,15 @@ export const ComboboxMultipleWithInput = React.forwardRef<HTMLInputElement, Comb
       }
     };
 
+    const handleOpenChange = (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      // Closing the popover ends the search: drop the in-progress text so the
+      // next open starts with the full, unfiltered list.
+      if (!nextOpen) {
+        setInputValue("");
+      }
+    };
+
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
       setInputValue(newValue);
@@ -92,21 +102,11 @@ export const ComboboxMultipleWithInput = React.forwardRef<HTMLInputElement, Comb
 
     const availableOptions = React.useMemo(() => {
       const unselectedOptions = options.filter((option) => !value.includes(option.value));
-
-      if (!inputValue.trim()) {
-        return unselectedOptions;
-      }
-
-      const searchTerm = inputValue.toLowerCase();
-      return unselectedOptions.filter((option) => {
-        const valueMatch = option.value.toLowerCase().includes(searchTerm);
-        const labelMatch = typeof option.label === "string" ? option.label.toLowerCase().includes(searchTerm) : false;
-        return valueMatch || labelMatch;
-      });
+      return filterComboboxOptions(unselectedOptions, inputValue);
     }, [options, value, inputValue]);
 
     return (
-      <Popover open={open} onOpenChange={setOpen} modal={false}>
+      <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
         <PopoverTrigger asChild>
           <div className="relative flex w-full items-center" aria-hidden="true">
             <div
@@ -196,13 +196,7 @@ export const ComboboxMultipleWithInput = React.forwardRef<HTMLInputElement, Comb
                     disabled={option.disabled}
                     onSelect={() => handleOptionSelect(option.value)}
                   >
-                    {renderOption ? (
-                      renderOption(option)
-                    ) : typeof option.label === "string" ? (
-                      <span className="truncate">{option.label}</span>
-                    ) : (
-                      option.label
-                    )}
+                    {renderComboboxOption(option, renderOption)}
                   </CommandItem>
                 ))}
               </CommandGroup>

--- a/apps/client/src/core/components/ui/combobox-with-input/index.test.tsx
+++ b/apps/client/src/core/components/ui/combobox-with-input/index.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { ComboboxWithInput } from "./index";
+
+const options = [
+  { value: "feature/test-184", label: "feature/test-184" },
+  { value: "feature/test-1779-2", label: "feature/test-1779-2" },
+  { value: "release/1.29", label: "release/1.29" },
+  { value: "main", label: "main" },
+];
+
+/**
+ * Mirrors how the form (FormCombobox → field.handleChange) wires the combobox:
+ * every keystroke is committed to the value prop and fed straight back in. This
+ * is the exact pattern that previously defeated filtering.
+ */
+function ControlledCombobox({ initialValue = "" }: { initialValue?: string }) {
+  const [value, setValue] = React.useState(initialValue);
+  return (
+    <ComboboxWithInput value={value} onValueChange={setValue} options={options} placeholder="Select branch name" />
+  );
+}
+
+function setupCombobox(initialValue = "") {
+  const user = userEvent.setup();
+  render(<ControlledCombobox initialValue={initialValue} />);
+  const input = screen.getByPlaceholderText<HTMLInputElement>("Select branch name");
+  return { user, input };
+}
+
+function expectFullListVisible() {
+  for (const option of options) {
+    expect(screen.getByText(option.value)).toBeInTheDocument();
+  }
+}
+
+describe("ComboboxWithInput", () => {
+  it("filters options as the user types, even though each keystroke is committed to value", async () => {
+    const { user, input } = setupCombobox();
+    await user.click(input);
+
+    // Full list is visible before typing.
+    expectFullListVisible();
+
+    await user.type(input, "release");
+
+    // Only the matching option remains — this is the regression guard.
+    expect(screen.getByText("release/1.29")).toBeInTheDocument();
+    expect(screen.queryByText("feature/test-184")).not.toBeInTheDocument();
+    expect(screen.queryByText("feature/test-1779-2")).not.toBeInTheDocument();
+    expect(screen.queryByText("main")).not.toBeInTheDocument();
+  });
+
+  it("shows the full list (not pre-filtered) when reopening a field that already has a value", async () => {
+    const { user, input } = setupCombobox("main");
+    await user.click(input);
+
+    // All options stay reachable even though "main" is the committed value.
+    expectFullListVisible();
+  });
+
+  it("selecting an option commits its value and closes the dropdown", async () => {
+    const { user, input } = setupCombobox();
+    await user.click(input);
+    await user.type(input, "release");
+    await user.click(screen.getByText("release/1.29"));
+
+    expect(input.value).toBe("release/1.29");
+    // Dropdown is closed: the other options are no longer in the document.
+    expect(screen.queryByText("feature/test-184")).not.toBeInTheDocument();
+    expect(screen.queryByText("main")).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/src/core/components/ui/combobox-with-input/index.tsx
+++ b/apps/client/src/core/components/ui/combobox-with-input/index.tsx
@@ -5,6 +5,7 @@ import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from "@
 import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
 import { cn } from "@/core/utils/classname";
 import { ComboboxOption } from "@/core/components/ui/combobox";
+import { filterComboboxOptions, renderComboboxOption } from "@/core/components/ui/combobox/utils";
 
 export interface ComboboxWithInputProps {
   value?: string;
@@ -36,20 +37,32 @@ export const ComboboxWithInput = React.forwardRef<HTMLInputElement, ComboboxWith
     ref
   ) => {
     const [open, setOpen] = React.useState(false);
-    const [inputValue, setInputValue] = React.useState(value || "");
+    // In-progress search text while the user is typing. `null` means the user
+    // is not typing, so the input mirrors the committed `value` prop directly.
+    // Keeping the search text separate from `value` (rather than mirroring the
+    // prop into local state) is what lets filtering work even though every
+    // keystroke is committed upward via onValueChange.
+    const [typingValue, setTypingValue] = React.useState<string | null>(null);
     const inputRef = React.useRef<HTMLInputElement>(null);
 
     // Merge refs
     React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 
-    // Sync inputValue with value prop
-    React.useEffect(() => {
-      setInputValue(value || "");
-    }, [value]);
+    const hasUserTyped = typingValue !== null;
+    const inputValue = typingValue ?? value;
+
+    const handleOpenChange = (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      // Closing the popover ends the search: drop the in-progress text so the
+      // next open starts from the committed value with the full, unfiltered list.
+      if (!nextOpen) {
+        setTypingValue(null);
+      }
+    };
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
-      setInputValue(newValue);
+      setTypingValue(newValue);
       onValueChange?.(newValue);
       // Keep dropdown open when typing
       if (!open) {
@@ -58,27 +71,21 @@ export const ComboboxWithInput = React.forwardRef<HTMLInputElement, ComboboxWith
     };
 
     const handleOptionSelect = (optionValue: string) => {
+      setTypingValue(null);
       onValueChange?.(optionValue);
-      setInputValue(optionValue);
       setOpen(false);
     };
 
-    // Filter options only when the user is actively typing (inputValue
-    // differs from the committed field value). When they match the user
-    // is just viewing a pre-selected value, so show the full list.
-    const availableOptions = React.useMemo(() => {
-      if (!inputValue.trim() || inputValue === value) return options;
-
-      const searchTerm = inputValue.toLowerCase();
-      return options.filter((option) => {
-        const valueMatch = option.value.toLowerCase().includes(searchTerm);
-        const labelMatch = typeof option.label === "string" ? option.label.toLowerCase().includes(searchTerm) : false;
-        return valueMatch || labelMatch;
-      });
-    }, [options, inputValue, value]);
+    // Filter options only while the user is actively typing. When viewing a
+    // committed/pre-selected value, show the full list so the other options
+    // stay reachable.
+    const availableOptions = React.useMemo(
+      () => (hasUserTyped ? filterComboboxOptions(options, inputValue) : options),
+      [options, inputValue, hasUserTyped]
+    );
 
     return (
-      <Popover open={open} onOpenChange={setOpen} modal={false}>
+      <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
         <PopoverTrigger asChild>
           <div className="relative flex w-full items-center" aria-hidden="true">
             <div
@@ -127,13 +134,7 @@ export const ComboboxWithInput = React.forwardRef<HTMLInputElement, ComboboxWith
                       disabled={option.disabled}
                       onSelect={() => handleOptionSelect(option.value)}
                     >
-                      {renderOption ? (
-                        renderOption(option)
-                      ) : typeof option.label === "string" ? (
-                        <span className="truncate">{option.label}</span>
-                      ) : (
-                        option.label
-                      )}
+                      {renderComboboxOption(option, renderOption)}
                       <CheckIcon className={cn("ml-auto size-4", isSelected ? "opacity-100" : "opacity-0")} />
                     </CommandItem>
                   );

--- a/apps/client/src/core/components/ui/combobox/utils.tsx
+++ b/apps/client/src/core/components/ui/combobox/utils.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import type { ComboboxOption } from "./index";
+
+/**
+ * Case-insensitive substring filter over an option's value, string label, and
+ * keywords. Returns all options when `search` is empty/whitespace. Shared by the
+ * free-text combobox variants, which disable cmdk's built-in filtering and drive
+ * the option list themselves.
+ */
+export function filterComboboxOptions(options: ComboboxOption[], search: string): ComboboxOption[] {
+  const term = search.trim().toLowerCase();
+  if (!term) return options;
+  return options.filter((option) => {
+    if (option.value.toLowerCase().includes(term)) return true;
+    if (typeof option.label === "string" && option.label.toLowerCase().includes(term)) return true;
+    return option.keywords?.some((keyword) => keyword.toLowerCase().includes(term)) ?? false;
+  });
+}
+
+/** Render an option's content, preferring a caller-supplied `renderOption`. */
+export function renderComboboxOption(
+  option: ComboboxOption,
+  renderOption?: (option: ComboboxOption) => React.ReactNode
+): React.ReactNode {
+  if (renderOption) return renderOption(option);
+  return typeof option.label === "string" ? <span className="truncate">{option.label}</span> : option.label;
+}

--- a/apps/client/src/test/setup.ts
+++ b/apps/client/src/test/setup.ts
@@ -51,3 +51,9 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: vi.fn(),
   })),
 });
+
+// Mock DOM APIs that Radix / cmdk rely on but jsdom does not implement.
+Element.prototype.scrollIntoView = vi.fn();
+Element.prototype.hasPointerCapture = vi.fn(() => false);
+Element.prototype.setPointerCapture = vi.fn();
+Element.prototype.releasePointerCapture = vi.fn();


### PR DESCRIPTION
- Root cause: ComboboxWithInput committed every keystroke to the form value, making the inputValue===value filter guard always true, so the option list was never filtered (affected all single-select freeSolo comboboxes: branch dialog, GitOps/codebase Owner & RepositoryName, namespaces switcher)
- Track active-typing state and ignore the value-sync echo so typing filters the list while a pre-selected value still shows the full list
- Add regression tests for ComboboxWithInput filtering
