### PR TITLE
EPMDEDP-16788: feat: redesign Kubernetes cluster overview dashboard

### DIFF
--- a/apps/client/src/modules/k8s/pages/overview/components/CapacityCard.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/CapacityCard.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { Skeleton } from "@/core/components/ui/skeleton";
+import type { Node as K8sNode, Pod } from "@my-project/shared";
+import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
+import { computeClusterResources, formatCores, formatMemory, type ResourceUsage } from "../utils/quantity";
+import { ThresholdBar } from "./ThresholdBar";
+
+interface CapacityCardProps {
+  nodes: UseWatchListResult<K8sNode>;
+  pods: UseWatchListResult<Pod>;
+}
+
+export function CapacityCard({ nodes, pods }: CapacityCardProps) {
+  const totals = useMemo(
+    () => computeClusterResources(nodes.data.array, pods.data.array),
+    [nodes.data.array, pods.data.array]
+  );
+  const loading = nodes.isLoading || pods.isLoading;
+
+  return (
+    <Card>
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="text-sm font-semibold">Compute capacity</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-6 p-4 pt-2 sm:grid-cols-2">
+        <ResourceBlock title="CPU" unit="cores" usage={totals.cpu} format={formatCores} loading={loading} />
+        <ResourceBlock title="Memory" usage={totals.memory} format={formatMemory} loading={loading} />
+      </CardContent>
+    </Card>
+  );
+}
+
+interface ResourceBlockProps {
+  title: string;
+  unit?: string;
+  usage: ResourceUsage;
+  format: (value: number) => string;
+  loading: boolean;
+}
+
+function ResourceBlock({ title, unit, usage, format, loading }: ResourceBlockProps) {
+  return (
+    <div className="space-y-2.5">
+      <div className="flex items-baseline justify-between">
+        <span className="text-sm font-medium">{title}</span>
+        <span className="text-muted-foreground text-xs">
+          {loading ? "—" : `${format(usage.capacity)}${unit ? ` ${unit}` : ""} allocatable`}
+        </span>
+      </div>
+      {loading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-2 w-full" />
+          <Skeleton className="h-2 w-full" />
+        </div>
+      ) : (
+        <>
+          <MetricRow label="Requests" value={usage.requests} max={usage.capacity} format={format} />
+          <MetricRow label="Limits" value={usage.limits} max={usage.capacity} format={format} />
+        </>
+      )}
+    </div>
+  );
+}
+
+interface MetricRowProps {
+  label: string;
+  value: number;
+  max: number;
+  format: (value: number) => string;
+}
+
+function MetricRow({ label, value, max, format }: MetricRowProps) {
+  const pct = max > 0 ? (value / max) * 100 : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between text-xs">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="tabular-nums">
+          {format(value)} / {format(max)} <span className="text-muted-foreground">({Math.round(pct)}%)</span>
+        </span>
+      </div>
+      <ThresholdBar pct={pct} />
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/ClusterInfoBar.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/ClusterInfoBar.tsx
@@ -1,0 +1,48 @@
+import { Cpu, Server, Tag, Boxes } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Skeleton } from "@/core/components/ui/skeleton";
+
+interface ClusterInfoBarProps {
+  clusterName?: string;
+  kubernetesVersion?: string;
+  platform?: string;
+  nodeCount: number;
+  loading: boolean;
+}
+
+export function ClusterInfoBar({ clusterName, kubernetesVersion, platform, nodeCount, loading }: ClusterInfoBarProps) {
+  return (
+    <div className="bg-card flex flex-wrap items-center gap-x-8 gap-y-3 rounded-lg border px-4 py-3">
+      <InfoChip icon={Boxes} label="Cluster" value={clusterName || "—"} />
+      <InfoChip icon={Tag} label="Kubernetes" value={kubernetesVersion} loading={loading} />
+      <InfoChip icon={Server} label="Platform" value={platform} loading={loading} />
+      <InfoChip icon={Cpu} label="Nodes" value={String(nodeCount)} loading={loading} />
+    </div>
+  );
+}
+
+function InfoChip({
+  icon: Icon,
+  label,
+  value,
+  loading,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value?: string;
+  loading?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className="text-muted-foreground h-4 w-4 shrink-0" aria-hidden />
+      <div className="min-w-0">
+        <p className="text-muted-foreground text-[10px] tracking-wide uppercase">{label}</p>
+        {loading ? (
+          <Skeleton className="mt-0.5 h-4 w-24" />
+        ) : (
+          <p className="truncate text-sm font-medium">{value || "—"}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/DonutChart.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/DonutChart.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer } from "recharts";
+import { Skeleton } from "@/core/components/ui/skeleton";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+
+export interface DonutSlice {
+  name: string;
+  value: number;
+  color: string;
+  // recharts v3 data rows must be index-signature compatible
+  [key: string]: string | number;
+}
+
+interface DonutChartProps {
+  data: DonutSlice[];
+  size?: number;
+  thickness?: number;
+  centerValue?: ReactNode;
+  centerLabel?: ReactNode;
+}
+
+/** A zero total renders one neutral ring so the widget never collapses to an empty box. */
+export function DonutChart({ data, size = 116, thickness = 14, centerValue, centerLabel }: DonutChartProps) {
+  const total = data.reduce((sum, slice) => sum + slice.value, 0);
+  const slices: DonutSlice[] =
+    total > 0 ? data.filter((slice) => slice.value > 0) : [{ name: "None", value: 1, color: STATUS_COLOR.UNKNOWN }];
+
+  const outerRadius = size / 2;
+  const innerRadius = outerRadius - thickness;
+
+  return (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={slices}
+            dataKey="value"
+            nameKey="name"
+            cx="50%"
+            cy="50%"
+            innerRadius={innerRadius}
+            outerRadius={outerRadius}
+            paddingAngle={total > 0 ? 2 : 0}
+            stroke="none"
+            isAnimationActive={false}
+          >
+            {slices.map((slice, index) => (
+              <Cell key={`cell-${index}`} fill={slice.color} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+      {(centerValue != null || centerLabel != null) && (
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          {centerValue != null && (
+            <span className="text-foreground text-xl leading-none font-semibold tabular-nums">{centerValue}</span>
+          )}
+          {centerLabel != null && (
+            <span className="text-muted-foreground mt-0.5 text-[10px] tracking-wide uppercase">{centerLabel}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DonutLegend({ slices }: { slices: DonutSlice[] }) {
+  return (
+    <ul className="flex flex-col gap-1">
+      {slices.map((slice, index) => (
+        <li key={`${slice.name}-${index}`} className="flex items-center gap-1.5 text-xs">
+          <span
+            className="inline-block h-2 w-2 shrink-0 rounded-full"
+            style={{ backgroundColor: slice.color }}
+            aria-hidden
+          />
+          <span className="text-muted-foreground truncate">{slice.name}</span>
+          <span className="text-foreground ml-auto tabular-nums">{slice.value}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface DonutCardBodyProps {
+  slices: DonutSlice[];
+  isLoading: boolean;
+  size: number;
+  thickness: number;
+  centerValue?: ReactNode;
+  centerLabel?: ReactNode;
+  emptyText: string;
+}
+
+export function DonutCardBody({
+  slices,
+  isLoading,
+  size,
+  thickness,
+  centerValue,
+  centerLabel,
+  emptyText,
+}: DonutCardBodyProps) {
+  return (
+    <>
+      <DonutChart data={slices} size={size} thickness={thickness} centerValue={centerValue} centerLabel={centerLabel} />
+      <div className="min-w-0 flex-1">
+        {isLoading ? (
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+        ) : slices.length > 0 ? (
+          <DonutLegend slices={slices} />
+        ) : (
+          <span className="text-muted-foreground text-xs">{emptyText}</span>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/PodPhaseCard.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/PodPhaseCard.tsx
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import type { Pod } from "@my-project/shared";
+import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
+import { DonutCardBody, type DonutSlice } from "./DonutChart";
+import { POD_PHASE_COLOR } from "../utils/status-color";
+
+const PHASE_ORDER = ["Running", "Pending", "Succeeded", "Failed", "Unknown"];
+
+export function PodPhaseCard({ result }: { result: UseWatchListResult<Pod> }) {
+  const pods = result.data.array;
+
+  const slices = useMemo<DonutSlice[]>(() => {
+    const counts = new Map<string, number>();
+    for (const pod of pods) {
+      const phase = pod.status?.phase ?? "Unknown";
+      counts.set(phase, (counts.get(phase) ?? 0) + 1);
+    }
+    return [...counts.keys()]
+      .sort((a, b) => orderIndex(a) - orderIndex(b))
+      .map((name) => ({ name, value: counts.get(name) ?? 0, color: POD_PHASE_COLOR[name] ?? STATUS_COLOR.UNKNOWN }));
+  }, [pods]);
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="p-3 pb-1">
+        <CardTitle className="text-sm font-semibold">Pods by phase</CardTitle>
+      </CardHeader>
+      <CardContent className="flex items-center gap-4 p-3 pt-1">
+        <DonutCardBody
+          slices={slices}
+          isLoading={result.isLoading}
+          size={104}
+          thickness={13}
+          centerValue={pods.length}
+          centerLabel="pods"
+          emptyText="No pods"
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function orderIndex(phase: string): number {
+  const index = PHASE_ORDER.indexOf(phase);
+  return index === -1 ? PHASE_ORDER.length : index;
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/RecentEventsCard.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/RecentEventsCard.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { Skeleton } from "@/core/components/ui/skeleton";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { formatRelativeTime } from "@/core/utils/date-humanize/utils";
+import { PATH_K8S_EVENTS_FULL } from "@/modules/k8s/constants/paths";
+import { EVENT_TONE } from "@/modules/k8s/constants/event";
+import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
+import type { OverviewEvent } from "../types";
+
+const MAX_EVENTS = 25;
+
+function eventTimestamp(event: OverviewEvent): string | undefined {
+  return event.lastTimestamp ?? event.eventTime ?? event.metadata?.creationTimestamp;
+}
+
+function eventTime(event: OverviewEvent): number {
+  const raw = eventTimestamp(event);
+  if (!raw) return 0;
+  const time = new Date(raw).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+interface RecentEventsCardProps {
+  clusterName: string;
+  result: UseWatchListResult<OverviewEvent>;
+}
+
+export function RecentEventsCard({ clusterName, result }: RecentEventsCardProps) {
+  const sorted = useMemo(
+    () => [...result.data.array].sort((a, b) => eventTime(b) - eventTime(a)).slice(0, MAX_EVENTS),
+    [result.data.array]
+  );
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between p-4 pb-2">
+        <CardTitle className="text-sm font-semibold">Recent events</CardTitle>
+        <Link
+          to={PATH_K8S_EVENTS_FULL}
+          params={{ clusterName }}
+          className="text-muted-foreground hover:text-foreground text-xs"
+        >
+          View all
+        </Link>
+      </CardHeader>
+      <CardContent className="p-4 pt-1">
+        {result.isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <Skeleton key={index} className="h-8 w-full" />
+            ))}
+          </div>
+        ) : sorted.length === 0 ? (
+          <p className="text-muted-foreground py-6 text-center text-sm">No recent events.</p>
+        ) : (
+          <ul className="max-h-80 space-y-2.5 overflow-y-auto pr-1">
+            {sorted.map((event, index) => {
+              const timestamp = eventTimestamp(event);
+              return (
+                <li
+                  key={event.metadata?.uid ?? `${timestamp ?? "event"}-${index}`}
+                  className="flex items-start gap-2 text-xs"
+                >
+                  <span
+                    className={`mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full ${
+                      EVENT_TONE[event.type ?? ""] ?? "bg-muted-foreground"
+                    }`}
+                    aria-hidden
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="text-foreground truncate font-mono">{event.reason ?? "—"}</span>
+                      <span className="text-muted-foreground shrink-0">{formatRelativeTime(timestamp)}</span>
+                    </div>
+                    <div className="text-muted-foreground truncate">
+                      {event.involvedObject?.kind}
+                      {event.involvedObject?.name ? ` · ${event.involvedObject.name}` : ""}
+                    </div>
+                    {event.message && (
+                      <Tooltip title={event.message}>
+                        <span className="text-muted-foreground line-clamp-2 block">{event.message}</span>
+                      </Tooltip>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/SectionHeading.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/SectionHeading.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function SectionHeading({ children }: { children: ReactNode }) {
+  return <h2 className="text-muted-foreground mb-2 text-xs font-semibold tracking-wide uppercase">{children}</h2>;
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/StatCards.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/StatCards.tsx
@@ -1,0 +1,200 @@
+import { useMemo } from "react";
+import type { ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { AlertCircle, ArrowRight, Box, CircleCheck, Layers, Server, SquareStack } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Card, CardContent } from "@/core/components/ui/card";
+import { Skeleton } from "@/core/components/ui/skeleton";
+import { PATH_K8S_LIST_FULL, PATH_K8S_NODES_FULL, PATH_K8S_PODS_FULL } from "@/modules/k8s/constants/paths";
+import type { KubeObjectBase, Namespace, Node as K8sNode, Pod } from "@my-project/shared";
+import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
+import type { WorkloadResults } from "../hooks/useClusterOverview";
+import { WORKLOAD_KINDS, workloadHealth, type WorkloadKind } from "../utils/workload";
+
+interface StatCardsProps {
+  clusterName: string;
+  nodes: UseWatchListResult<K8sNode>;
+  pods: UseWatchListResult<Pod>;
+  namespaces: UseWatchListResult<Namespace>;
+  workloads: WorkloadResults;
+}
+
+export function StatCards({ clusterName, nodes, pods, namespaces, workloads }: StatCardsProps) {
+  const nodeStats = useMemo(() => {
+    const items = nodes.data.array;
+    let ready = 0;
+    for (const node of items) {
+      const conditions = (node.status?.conditions ?? []) as unknown as Array<{ type?: string; status?: string }>;
+      if (conditions.find((c) => c.type === "Ready")?.status === "True") ready += 1;
+    }
+    return { total: items.length, ready };
+  }, [nodes.data.array]);
+
+  const podStats = useMemo(() => {
+    let running = 0;
+    let problems = 0;
+    for (const pod of pods.data.array) {
+      const phase = pod.status?.phase;
+      if (phase === "Running") running += 1;
+      else if (phase === "Failed" || phase === "Unknown") problems += 1;
+    }
+    return { total: pods.data.array.length, running, problems };
+  }, [pods.data.array]);
+
+  // Bind the (memoized, stable) arrays to locals so the memo recomputes only on
+  // real data changes — not on every render, since `workloads` is a fresh object each time.
+  const deploymentItems = workloads.deployments.data.array;
+  const statefulSetItems = workloads.statefulsets.data.array;
+  const daemonSetItems = workloads.daemonsets.data.array;
+  const jobItems = workloads.jobs.data.array;
+  const cronJobItems = workloads.cronjobs.data.array;
+
+  const workloadStats = useMemo(() => {
+    const groups: Array<[WorkloadKind, KubeObjectBase[]]> = [
+      ["deployments", deploymentItems],
+      ["statefulsets", statefulSetItems],
+      ["daemonsets", daemonSetItems],
+      ["jobs", jobItems],
+      ["cronjobs", cronJobItems],
+    ];
+    let total = 0;
+    let healthy = 0;
+    for (const [key, items] of groups) {
+      const stats = workloadHealth(items, key);
+      total += stats.total;
+      healthy += stats.healthy;
+    }
+    return { total, healthy };
+  }, [deploymentItems, statefulSetItems, daemonSetItems, jobItems, cronJobItems]);
+
+  const namespaceStats = useMemo(() => {
+    let terminating = 0;
+    for (const ns of namespaces.data.array) {
+      if (ns.status?.phase === "Terminating") terminating += 1;
+    }
+    return { total: namespaces.data.array.length, terminating };
+  }, [namespaces.data.array]);
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <Link to={PATH_K8S_NODES_FULL} params={{ clusterName }} className="group block">
+        <StatCardBody
+          icon={Server}
+          label="Nodes"
+          value={nodeStats.total}
+          loading={nodes.isLoading}
+          health={
+            nodeStats.total > 0 ? (
+              <HealthLine
+                ok={nodeStats.ready === nodeStats.total}
+                okText={`All ${nodeStats.total} ready`}
+                badText={`${nodeStats.total - nodeStats.ready} not ready`}
+              />
+            ) : null
+          }
+        />
+      </Link>
+
+      <Link to={PATH_K8S_PODS_FULL} params={{ clusterName }} className="group block">
+        <StatCardBody
+          icon={Box}
+          label="Pods"
+          value={podStats.total}
+          loading={pods.isLoading}
+          health={
+            podStats.total > 0 ? (
+              <HealthLine
+                ok={podStats.problems === 0}
+                okText={`${podStats.running} running`}
+                badText={`${podStats.problems} not healthy`}
+              />
+            ) : null
+          }
+        />
+      </Link>
+
+      <Link to={PATH_K8S_LIST_FULL} params={{ clusterName, kind: "deployments" }} className="group block">
+        <StatCardBody
+          icon={Layers}
+          label="Workloads"
+          value={workloadStats.total}
+          loading={WORKLOAD_KINDS.some(({ key }) => workloads[key].isLoading)}
+          health={
+            workloadStats.total > 0 ? (
+              <HealthLine
+                ok={workloadStats.healthy === workloadStats.total}
+                okText={`${workloadStats.healthy} healthy`}
+                badText={`${workloadStats.total - workloadStats.healthy} degraded`}
+              />
+            ) : null
+          }
+        />
+      </Link>
+
+      <Link to={PATH_K8S_LIST_FULL} params={{ clusterName, kind: "namespaces" }} className="group block">
+        <StatCardBody
+          icon={SquareStack}
+          label="Namespaces"
+          value={namespaceStats.total}
+          loading={namespaces.isLoading}
+          health={
+            namespaceStats.total > 0 ? (
+              <HealthLine
+                ok={namespaceStats.terminating === 0}
+                okText="All active"
+                badText={`${namespaceStats.terminating} terminating`}
+              />
+            ) : null
+          }
+        />
+      </Link>
+    </div>
+  );
+}
+
+interface StatCardBodyProps {
+  icon: LucideIcon;
+  label: string;
+  value: number;
+  loading: boolean;
+  health: ReactNode;
+}
+
+function StatCardBody({ icon: Icon, label, value, loading, health }: StatCardBodyProps) {
+  return (
+    <Card className="hover:border-primary/40 h-full transition-colors">
+      <CardContent className="flex items-start gap-3 p-4">
+        <div className="bg-muted rounded-md p-2">
+          <Icon className="text-muted-foreground h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-muted-foreground text-xs tracking-wide uppercase">{label}</p>
+          {loading ? (
+            <Skeleton className="mt-1 h-7 w-12" />
+          ) : (
+            <p className="text-2xl font-semibold tabular-nums">{value}</p>
+          )}
+          {!loading && health}
+        </div>
+        <ArrowRight
+          className="text-muted-foreground/0 group-hover:text-muted-foreground mt-1 h-4 w-4 shrink-0 transition-colors"
+          aria-hidden
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function HealthLine({ ok, okText, badText }: { ok: boolean; okText: string; badText: string }) {
+  return ok ? (
+    <span className="text-status-success mt-1 flex items-center gap-1 text-xs">
+      <CircleCheck className="h-3.5 w-3.5" aria-hidden />
+      {okText}
+    </span>
+  ) : (
+    <span className="text-status-error mt-1 flex items-center gap-1 text-xs">
+      <AlertCircle className="h-3.5 w-3.5" aria-hidden />
+      {badText}
+    </span>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/ThresholdBar.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/ThresholdBar.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/core/utils/classname";
+
+export function ThresholdBar({ pct, className }: { pct: number; className?: string }) {
+  const clamped = Math.max(0, Math.min(100, Number.isFinite(pct) ? pct : 0));
+  const tone = clamped >= 90 ? "bg-status-error" : clamped >= 60 ? "bg-status-missing" : "bg-status-success";
+
+  return (
+    <div className={cn("bg-border/40 h-2 w-full overflow-hidden rounded-full", className)}>
+      <div className={cn("h-full rounded-full transition-all", tone)} style={{ width: `${clamped}%` }} />
+    </div>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/WorkloadStatusSection.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/WorkloadStatusSection.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
+import { PATH_K8S_LIST_FULL } from "@/modules/k8s/constants/paths";
+import type { KubeObjectBase } from "@my-project/shared";
+import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
+import type { WorkloadResults } from "../hooks/useClusterOverview";
+import { bucketWorkload, WORKLOAD_KINDS, type WorkloadKind } from "../utils/workload";
+import { DonutCardBody } from "./DonutChart";
+
+interface WorkloadStatusSectionProps {
+  clusterName: string;
+  workloads: WorkloadResults;
+}
+
+export function WorkloadStatusSection({ clusterName, workloads }: WorkloadStatusSectionProps) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      {WORKLOAD_KINDS.map(({ key, label }) => (
+        <WorkloadKindCard key={key} clusterName={clusterName} kind={key} label={label} result={workloads[key]} />
+      ))}
+    </div>
+  );
+}
+
+interface WorkloadKindCardProps {
+  clusterName: string;
+  kind: WorkloadKind;
+  label: string;
+  result: UseWatchListResult<KubeObjectBase>;
+}
+
+function WorkloadKindCard({ clusterName, kind, label, result }: WorkloadKindCardProps) {
+  const items = result.data.array;
+  const slices = useMemo(() => bucketWorkload(items, kind), [items, kind]);
+
+  return (
+    <Card>
+      <CardHeader className="p-3 pb-1">
+        <CardTitle className="text-sm font-semibold">
+          <Link to={PATH_K8S_LIST_FULL} params={{ clusterName, kind }} className="hover:underline">
+            {label}
+          </Link>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex items-center gap-4 p-3 pt-1">
+        <DonutCardBody
+          slices={slices}
+          isLoading={result.isLoading}
+          size={92}
+          thickness={11}
+          centerValue={items.length}
+          emptyText="No resources"
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/client/src/modules/k8s/pages/overview/hooks/useClusterOverview.ts
+++ b/apps/client/src/modules/k8s/pages/overview/hooks/useClusterOverview.ts
@@ -1,0 +1,72 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  k8sCronJobConfig,
+  k8sDaemonSetConfig,
+  k8sDeploymentConfig,
+  k8sEventConfig,
+  k8sJobConfig,
+  k8sNamespaceConfig,
+  k8sNodeConfig,
+  k8sPodConfig,
+  k8sStatefulSetConfig,
+  type KubeObjectBase,
+  type Namespace,
+  type Node as K8sNode,
+  type Pod,
+} from "@my-project/shared";
+import { useTRPCClient } from "@/core/providers/trpc";
+import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
+import { useK8sResourceList } from "@/modules/k8s/hooks/useK8sResourceList";
+import type { WatchStatus } from "@/modules/k8s/components/WatchConnectionIndicator";
+import type { OverviewEvent } from "../types";
+import type { WorkloadKind } from "../utils/workload";
+
+export type WorkloadResults = Record<WorkloadKind, UseWatchListResult<KubeObjectBase>>;
+
+export interface ClusterOverview {
+  nodes: UseWatchListResult<K8sNode>;
+  pods: UseWatchListResult<Pod>;
+  namespaces: UseWatchListResult<Namespace>;
+  events: UseWatchListResult<OverviewEvent>;
+  workloads: WorkloadResults;
+  clusterDetails: ReturnType<typeof useClusterDetailsQuery>;
+  watchStatus: WatchStatus;
+}
+
+function useClusterDetailsQuery() {
+  const trpc = useTRPCClient();
+  return useQuery({
+    queryKey: ["k8s.clusterDetails"],
+    queryFn: () => trpc.k8s.clusterDetails.query(),
+    staleTime: 60_000,
+  });
+}
+
+export function useClusterOverview(): ClusterOverview {
+  const nodes = useK8sResourceList<K8sNode>(k8sNodeConfig, "");
+  const pods = useK8sResourceList<Pod>(k8sPodConfig, "");
+  const namespaces = useK8sResourceList<Namespace>(k8sNamespaceConfig, "");
+  const events = useK8sResourceList<OverviewEvent>(k8sEventConfig, "");
+
+  const deployments = useK8sResourceList<KubeObjectBase>(k8sDeploymentConfig, "");
+  const statefulsets = useK8sResourceList<KubeObjectBase>(k8sStatefulSetConfig, "");
+  const daemonsets = useK8sResourceList<KubeObjectBase>(k8sDaemonSetConfig, "");
+  const jobs = useK8sResourceList<KubeObjectBase>(k8sJobConfig, "");
+  const cronjobs = useK8sResourceList<KubeObjectBase>(k8sCronJobConfig, "");
+
+  const clusterDetails = useClusterDetailsQuery();
+
+  const watches = [nodes, pods, namespaces, events, deployments, statefulsets, daemonsets, jobs, cronjobs];
+  const hasError = watches.some((watch) => watch.error);
+  const watchStatus: WatchStatus = hasError ? "error" : "connected";
+
+  return {
+    nodes,
+    pods,
+    namespaces,
+    events,
+    workloads: { deployments, statefulsets, daemonsets, jobs, cronjobs },
+    clusterDetails,
+    watchStatus,
+  };
+}

--- a/apps/client/src/modules/k8s/pages/overview/page.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/page.tsx
@@ -1,141 +1,68 @@
-import { Bell, Box, Layers, Server } from "lucide-react";
+import { LayoutDashboard } from "lucide-react";
+import { useParams } from "@tanstack/react-router";
 import { PageContentWrapper } from "@/core/components/PageContentWrapper";
 import { PageWrapper } from "@/core/components/PageWrapper";
-import { ErrorContent } from "@/core/components/ErrorContent";
-import { useK8sResourceList } from "../../hooks/useK8sResourceList";
-import { WatchConnectionIndicator, type WatchStatus } from "../../components/WatchConnectionIndicator";
-import {
-  k8sEventConfig,
-  k8sNamespaceConfig,
-  k8sNodeConfig,
-  k8sPodConfig,
-  k8sServiceConfig,
-  type KubeObjectBase,
-} from "@my-project/shared";
-import type { RequestError } from "@/core/types/global";
-
-interface MetricCardProps {
-  title: string;
-  value: string | number;
-  icon: typeof Server;
-  hasError?: boolean;
-}
-
-function MetricCard({ title, value, icon: Icon, hasError }: MetricCardProps) {
-  return (
-    <div className="bg-card flex items-center gap-3 rounded-md border p-4">
-      <Icon className="text-muted-foreground" />
-      <div>
-        <p className="text-muted-foreground text-xs uppercase">{title}</p>
-        <p className="text-xl font-semibold">{hasError ? "—" : value}</p>
-      </div>
-    </div>
-  );
-}
-
-interface NodeStatus {
-  conditions?: { type?: string; status?: string }[];
-  capacity?: Record<string, string>;
-}
-
-interface K8sEventLike extends KubeObjectBase {
-  type?: string;
-  reason?: string;
-  message?: string;
-  lastTimestamp?: string;
-  involvedObject?: { kind?: string; name?: string };
-}
+import { WatchConnectionIndicator } from "@/modules/k8s/components/WatchConnectionIndicator";
+import { useClusterOverview } from "./hooks/useClusterOverview";
+import { CapacityCard } from "./components/CapacityCard";
+import { ClusterInfoBar } from "./components/ClusterInfoBar";
+import { PodPhaseCard } from "./components/PodPhaseCard";
+import { RecentEventsCard } from "./components/RecentEventsCard";
+import { SectionHeading } from "./components/SectionHeading";
+import { StatCards } from "./components/StatCards";
+import { WorkloadStatusSection } from "./components/WorkloadStatusSection";
 
 export default function K8sOverviewPage() {
-  const nodes = useK8sResourceList<KubeObjectBase>(k8sNodeConfig, "");
-  const pods = useK8sResourceList<KubeObjectBase>(k8sPodConfig, "");
-  const namespaces = useK8sResourceList<KubeObjectBase>(k8sNamespaceConfig, "");
-  const services = useK8sResourceList<KubeObjectBase>(k8sServiceConfig, "");
-  const events = useK8sResourceList<K8sEventLike>(k8sEventConfig, "");
-
-  const nodeItems = (nodes.data?.array ?? []) as KubeObjectBase[];
-  const recentEvents = (events.data?.array ?? []).slice(0, 50);
-
-  const firstError: RequestError | null =
-    nodes.error ?? namespaces.error ?? services.error ?? pods.error ?? events.error ?? null;
-  const watchStatus: WatchStatus = firstError ? "error" : "connected";
+  const { clusterName } = useParams({ strict: false }) as { clusterName?: string };
+  const cluster = clusterName ?? "";
+  const overview = useClusterOverview();
 
   return (
     <PageWrapper
       breadcrumbs={[{ label: "Cluster" }, { label: "Overview" }]}
-      headerSlot={<WatchConnectionIndicator status={watchStatus} />}
+      headerSlot={<WatchConnectionIndicator status={overview.watchStatus} />}
     >
-      <PageContentWrapper icon={Layers} title="Cluster Overview">
-        <div className="grid gap-3 p-4 sm:grid-cols-2 lg:grid-cols-4">
-          <MetricCard title="Nodes" value={nodeItems.length} icon={Server} hasError={!!nodes.error} />
-          <MetricCard title="Pods" value={(pods.data?.array ?? []).length} icon={Box} hasError={!!pods.error} />
-          <MetricCard
-            title="Namespaces"
-            value={(namespaces.data?.array ?? []).length}
-            icon={Layers}
-            hasError={!!namespaces.error}
+      <PageContentWrapper icon={LayoutDashboard} title="Cluster Overview">
+        <div className="flex flex-col gap-6 pb-8">
+          <ClusterInfoBar
+            clusterName={cluster}
+            kubernetesVersion={overview.clusterDetails.data?.gitVersion}
+            platform={overview.clusterDetails.data?.platform}
+            nodeCount={overview.nodes.data.array.length}
+            loading={overview.clusterDetails.isLoading || overview.nodes.isLoading}
           />
-          <MetricCard
-            title="Services"
-            value={(services.data?.array ?? []).length}
-            icon={Bell}
-            hasError={!!services.error}
-          />
+
+          <section>
+            <SectionHeading>At a glance</SectionHeading>
+            <StatCards
+              clusterName={cluster}
+              nodes={overview.nodes}
+              pods={overview.pods}
+              namespaces={overview.namespaces}
+              workloads={overview.workloads}
+            />
+          </section>
+
+          <section>
+            <SectionHeading>Health</SectionHeading>
+            <div className="grid gap-4 lg:grid-cols-3">
+              <div className="lg:col-span-2">
+                <WorkloadStatusSection clusterName={cluster} workloads={overview.workloads} />
+              </div>
+              <PodPhaseCard result={overview.pods} />
+            </div>
+          </section>
+
+          <section>
+            <SectionHeading>Capacity</SectionHeading>
+            <CapacityCard nodes={overview.nodes} pods={overview.pods} />
+          </section>
+
+          <section>
+            <SectionHeading>Activity</SectionHeading>
+            <RecentEventsCard clusterName={cluster} result={overview.events} />
+          </section>
         </div>
-        <section className="border-t">
-          <h3 className="bg-muted/30 text-muted-foreground px-4 py-2 text-xs font-semibold uppercase">Nodes</h3>
-          {nodes.error ? (
-            <div className="p-4">
-              <ErrorContent error={nodes.error} />
-            </div>
-          ) : nodeItems.length === 0 ? (
-            <p className="text-muted-foreground p-4 text-sm">No nodes.</p>
-          ) : (
-            <ul className="divide-y">
-              {nodeItems.map((n) => {
-                const status = (n as { status?: NodeStatus }).status;
-                const ready = status?.conditions?.find((c) => c.type === "Ready");
-                return (
-                  <li key={n.metadata?.uid} className="px-4 py-2 text-sm">
-                    <span className="font-mono">{n.metadata?.name}</span>
-                    <span className="text-muted-foreground ml-2">
-                      {ready?.status === "True" ? "Ready" : "NotReady"} · CPU {status?.capacity?.cpu ?? "—"} · MEM{" "}
-                      {status?.capacity?.memory ?? "—"}
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </section>
-        <section className="border-t">
-          <h3 className="bg-muted/30 text-muted-foreground px-4 py-2 text-xs font-semibold uppercase">Recent Events</h3>
-          {events.error ? (
-            <div className="p-4">
-              <ErrorContent error={events.error} />
-            </div>
-          ) : recentEvents.length === 0 ? (
-            <p className="text-muted-foreground p-4 text-sm">No events.</p>
-          ) : (
-            <ul className="divide-y">
-              {recentEvents.map((e, i) => (
-                <li key={i} className="px-4 py-2 text-sm">
-                  <span
-                    className={`mr-2 inline-block h-2 w-2 rounded-full ${
-                      e.type === "Warning" ? "bg-amber-500" : "bg-emerald-500"
-                    }`}
-                    aria-hidden
-                  />
-                  <span className="font-mono">{e.reason}</span>
-                  <span className="text-muted-foreground ml-2">
-                    {e.involvedObject?.kind}/{e.involvedObject?.name}
-                  </span>
-                  <span className="ml-2">{e.message}</span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
       </PageContentWrapper>
     </PageWrapper>
   );

--- a/apps/client/src/modules/k8s/pages/overview/types.ts
+++ b/apps/client/src/modules/k8s/pages/overview/types.ts
@@ -1,0 +1,16 @@
+import type { KubeObjectBase } from "@my-project/shared";
+
+/** The shared `Event` schema is `.passthrough()`, so we type only the fields the overview renders. */
+export interface OverviewEvent extends KubeObjectBase {
+  type?: string;
+  reason?: string;
+  message?: string;
+  lastTimestamp?: string;
+  eventTime?: string;
+  involvedObject?: {
+    kind?: string;
+    namespace?: string;
+    name?: string;
+    uid?: string;
+  };
+}

--- a/apps/client/src/modules/k8s/pages/overview/utils/quantity.ts
+++ b/apps/client/src/modules/k8s/pages/overview/utils/quantity.ts
@@ -1,0 +1,123 @@
+import type { Node as K8sNode, Pod } from "@my-project/shared";
+
+const MEMORY_BINARY: Record<string, number> = {
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  Pi: 1024 ** 5,
+  Ei: 1024 ** 6,
+};
+
+const MEMORY_DECIMAL: Record<string, number> = {
+  k: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+};
+
+/**
+ * Parse a Kubernetes CPU quantity into fractional cores.
+ * Handles plain cores ("2"), millicores ("100m"), and metrics-style
+ * micro/nano cores ("500u" / "250000000n").
+ */
+export function parseCpuToCores(value?: string | number): number {
+  if (value == null) return 0;
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  const v = value.trim();
+  if (v === "") return 0;
+  if (v.endsWith("m")) return toNumber(v.slice(0, -1)) / 1000;
+  if (v.endsWith("u")) return toNumber(v.slice(0, -1)) / 1e6;
+  if (v.endsWith("n")) return toNumber(v.slice(0, -1)) / 1e9;
+  return toNumber(v);
+}
+
+/**
+ * Parse a Kubernetes memory quantity into bytes.
+ * Handles binary suffixes (Ki/Mi/Gi/…), decimal suffixes (k/M/G/…), and plain bytes.
+ */
+export function parseMemoryToBytes(value?: string | number): number {
+  if (value == null) return 0;
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  const v = value.trim();
+  if (v === "") return 0;
+
+  const binary = /^([0-9.]+)(Ki|Mi|Gi|Ti|Pi|Ei)$/.exec(v);
+  if (binary) return toNumber(binary[1]) * MEMORY_BINARY[binary[2]];
+
+  const decimal = /^([0-9.]+)([kKMGTPE])$/.exec(v);
+  if (decimal) {
+    const key = decimal[2] === "K" ? "k" : decimal[2];
+    return toNumber(decimal[1]) * (MEMORY_DECIMAL[key] ?? 1);
+  }
+
+  return toNumber(v);
+}
+
+function toNumber(value: string): number {
+  const n = Number.parseFloat(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export interface ResourceUsage {
+  capacity: number;
+  requests: number;
+  limits: number;
+}
+
+export interface ClusterResources {
+  cpu: ResourceUsage;
+  memory: ResourceUsage;
+}
+
+const TERMINAL_PHASES = new Set(["Succeeded", "Failed"]);
+
+/**
+ * Aggregate allocatable capacity from nodes and requested/limited resources from
+ * non-terminal pods. initContainer requests are intentionally omitted for
+ * overview-grade accuracy.
+ */
+export function computeClusterResources(nodes: K8sNode[], pods: Pod[]): ClusterResources {
+  let cpuCapacity = 0;
+  let memoryCapacity = 0;
+  for (const node of nodes) {
+    cpuCapacity += parseCpuToCores(node.status?.allocatable?.cpu);
+    memoryCapacity += parseMemoryToBytes(node.status?.allocatable?.memory);
+  }
+
+  let cpuRequests = 0;
+  let cpuLimits = 0;
+  let memoryRequests = 0;
+  let memoryLimits = 0;
+  for (const pod of pods) {
+    if (TERMINAL_PHASES.has(pod.status?.phase ?? "")) continue;
+    for (const container of pod.spec?.containers ?? []) {
+      cpuRequests += parseCpuToCores(container.resources?.requests?.cpu);
+      cpuLimits += parseCpuToCores(container.resources?.limits?.cpu);
+      memoryRequests += parseMemoryToBytes(container.resources?.requests?.memory);
+      memoryLimits += parseMemoryToBytes(container.resources?.limits?.memory);
+    }
+  }
+
+  return {
+    cpu: { capacity: cpuCapacity, requests: cpuRequests, limits: cpuLimits },
+    memory: { capacity: memoryCapacity, requests: memoryRequests, limits: memoryLimits },
+  };
+}
+
+export function formatCores(cores: number): string {
+  if (!Number.isFinite(cores) || cores <= 0) return "0";
+  if (cores >= 10) return cores.toFixed(0);
+  if (cores >= 1) return cores.toFixed(1);
+  return cores.toFixed(2);
+}
+
+export function formatMemory(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 Mi";
+  const gi = bytes / 1024 ** 3;
+  if (gi >= 1) return `${gi.toFixed(1)} Gi`;
+  const mi = bytes / 1024 ** 2;
+  return `${mi.toFixed(0)} Mi`;
+}

--- a/apps/client/src/modules/k8s/pages/overview/utils/status-color.ts
+++ b/apps/client/src/modules/k8s/pages/overview/utils/status-color.ts
@@ -1,0 +1,27 @@
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+
+export function severityColor(severity?: string): string {
+  switch (severity) {
+    case "success":
+      return STATUS_COLOR.SUCCESS;
+    case "warning":
+      return STATUS_COLOR.MISSING;
+    case "error":
+    case "destructive":
+      return STATUS_COLOR.ERROR;
+    case "info":
+      return STATUS_COLOR.IN_PROGRESS;
+    case "neutral":
+      return STATUS_COLOR.SUSPENDED;
+    default:
+      return STATUS_COLOR.UNKNOWN;
+  }
+}
+
+export const POD_PHASE_COLOR: Record<string, string> = {
+  Running: STATUS_COLOR.SUCCESS,
+  Pending: STATUS_COLOR.IN_PROGRESS,
+  Succeeded: STATUS_COLOR.SUSPENDED,
+  Failed: STATUS_COLOR.ERROR,
+  Unknown: STATUS_COLOR.UNKNOWN,
+};

--- a/apps/client/src/modules/k8s/pages/overview/utils/workload.ts
+++ b/apps/client/src/modules/k8s/pages/overview/utils/workload.ts
@@ -1,0 +1,37 @@
+import type { KubeObjectBase } from "@my-project/shared";
+import { resourceRegistry } from "@/modules/k8s/registry";
+import type { DonutSlice } from "../components/DonutChart";
+import { severityColor } from "./status-color";
+
+export type WorkloadKind = "deployments" | "statefulsets" | "daemonsets" | "jobs" | "cronjobs";
+
+export const WORKLOAD_KINDS: { key: WorkloadKind; label: string }[] = [
+  { key: "deployments", label: "Deployments" },
+  { key: "statefulsets", label: "StatefulSets" },
+  { key: "daemonsets", label: "DaemonSets" },
+  { key: "jobs", label: "Jobs" },
+  { key: "cronjobs", label: "CronJobs" },
+];
+
+export function bucketWorkload(items: KubeObjectBase[], kind: WorkloadKind): DonutSlice[] {
+  const statusFn = resourceRegistry[kind]?.status;
+  const buckets = new Map<string, { value: number; color: string }>();
+
+  for (const item of items) {
+    const status = statusFn?.(item) ?? { phase: "Unknown", severity: "neutral" };
+    const bucket = buckets.get(status.phase) ?? { value: 0, color: severityColor(status.severity) };
+    bucket.value += 1;
+    buckets.set(status.phase, bucket);
+  }
+
+  return [...buckets.entries()].map(([name, { value, color }]) => ({ name, value, color }));
+}
+
+export function workloadHealth(items: KubeObjectBase[], kind: WorkloadKind): { total: number; healthy: number } {
+  const statusFn = resourceRegistry[kind]?.status;
+  let healthy = 0;
+  for (const item of items) {
+    if (statusFn?.(item)?.severity === "success") healthy += 1;
+  }
+  return { total: items.length, healthy };
+}


### PR DESCRIPTION
- Replace the placeholder overview (raw count tiles, plain node/event lists) with a health-first cluster dashboard.
- Add stat cards (drill-down + health), per-kind workload status donuts, and a pod-phase breakdown.
- Add CPU/memory requests-vs-capacity bars and a cluster-wide recent-events feed.
- Aggregate data from existing live watch lists and the clusterDetails query; no backend changes, charts reuse recharts.
