### PR TITLE
EPMDEDP-16788: feat: reduce Kubernetes events volume on overview and detail views

### DIFF
--- a/apps/client/src/k8s/api/hooks/useWatch/query-keys/index.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/query-keys/index.ts
@@ -61,3 +61,16 @@ export function getK8sWatchItemQueryCacheKeyPrefix(
 export function getK8sDeploymentRevisionsQueryCacheKey(clusterName: string, namespace: string, name: string): string[] {
   return ["k8s:deploymentRevisions", clusterName, namespace, name];
 }
+
+export function getK8sListPollQueryCacheKey(
+  clusterName: string,
+  namespace: string | undefined,
+  group: string,
+  resourcePlural: string,
+  fieldSelector?: string,
+  limit?: number
+): (string | number | undefined)[] {
+  // Match the sibling builders' `undefined` sentinel; TanStack Query hashes a
+  // trailing undefined the same as null, and the type stays uniform with them.
+  return ["k8s:listPoll", clusterName, namespace ?? CLUSTER_SCOPE_KEY, group, resourcePlural, fieldSelector, limit];
+}

--- a/apps/client/src/modules/k8s/components/ResourceEventsTab/index.test.tsx
+++ b/apps/client/src/modules/k8s/components/ResourceEventsTab/index.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { k8sEventConfig } from "@my-project/shared";
+import type { KubeObjectBase } from "@my-project/shared";
+
+const pollMock = vi.fn();
+vi.mock("../../hooks/useK8sResourceListPoll", () => ({
+  useK8sResourceListPoll: (...args: unknown[]) => pollMock(...args),
+}));
+
+import { ResourceEventsTab } from "./index";
+import { EVENTS_POLL_INTERVAL_MS, RESOURCE_EVENTS_FETCH_LIMIT } from "../../constants/event";
+
+const item = {
+  apiVersion: "v1",
+  kind: "Pod",
+  metadata: { uid: "pod-uid-1", name: "my-pod", namespace: "ns", creationTimestamp: "2024-01-01T00:00:00Z" },
+};
+
+describe("ResourceEventsTab", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches with an involvedObject.uid fieldSelector and renders matching events", () => {
+    pollMock.mockReturnValue({
+      data: {
+        array: [{ type: "Warning", reason: "BackOff", message: "boom", involvedObject: { uid: "pod-uid-1" } }],
+      },
+    });
+
+    render(<ResourceEventsTab item={item} />);
+
+    expect(pollMock).toHaveBeenCalledWith(k8sEventConfig, "ns", {
+      fieldSelector: "involvedObject.uid=pod-uid-1",
+      limit: RESOURCE_EVENTS_FETCH_LIMIT,
+      refetchInterval: EVENTS_POLL_INTERVAL_MS,
+      enabled: true,
+    });
+    expect(screen.getByText("BackOff")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no events", () => {
+    pollMock.mockReturnValue({ data: { array: [] } });
+    render(<ResourceEventsTab item={item} />);
+    expect(screen.getByText("No events for this resource.")).toBeInTheDocument();
+  });
+
+  it("disables the fetch and shows the empty state for an unidentifiable item (no uid, no name)", () => {
+    pollMock.mockReturnValue({ data: { array: [] } });
+    // Deliberately malformed (no uid/name) — only reachable via a cast, which is
+    // why the runtime `enabled` guard exists rather than relying on the type.
+    const unidentified = { apiVersion: "v1", kind: "Pod", metadata: { namespace: "ns" } } as unknown as KubeObjectBase;
+    render(<ResourceEventsTab item={unidentified} />);
+    expect(pollMock).toHaveBeenCalledWith(
+      k8sEventConfig,
+      "ns",
+      expect.objectContaining({ fieldSelector: undefined, enabled: false })
+    );
+    expect(screen.getByText("No events for this resource.")).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/modules/k8s/components/ResourceEventsTab/index.tsx
+++ b/apps/client/src/modules/k8s/components/ResourceEventsTab/index.tsx
@@ -1,44 +1,24 @@
-import { useK8sResourceList } from "../../hooks/useK8sResourceList";
-import { k8sEventConfig } from "@my-project/shared";
 import type { KubeObjectBase } from "@my-project/shared";
-
-interface K8sEvent extends KubeObjectBase {
-  type?: string;
-  reason?: string;
-  message?: string;
-  involvedObject?: {
-    kind?: string;
-    namespace?: string;
-    name?: string;
-    uid?: string;
-  };
-}
+import { useResourceEvents } from "../../hooks/useResourceEvents";
+import { eventToneClass } from "../../constants/event";
 
 export function ResourceEventsTab({ item }: { item: KubeObjectBase }) {
-  const result = useK8sResourceList<K8sEvent>(k8sEventConfig, item.metadata?.namespace ?? "");
-  const events = (result.data as { array?: K8sEvent[] } | undefined)?.array ?? [];
-  const filtered = events.filter(
-    (e) =>
-      e.involvedObject?.uid === item.metadata?.uid ||
-      (e.involvedObject?.kind === item.kind &&
-        e.involvedObject?.name === item.metadata?.name &&
-        e.involvedObject?.namespace === item.metadata?.namespace)
-  );
+  const { data, isLoading } = useResourceEvents(item);
+  const events = data.array;
 
-  if (filtered.length === 0) {
+  if (isLoading) {
+    return <div className="text-muted-foreground p-4 text-sm">Loading events…</div>;
+  }
+
+  if (events.length === 0) {
     return <div className="text-muted-foreground p-4 text-sm">No events for this resource.</div>;
   }
 
   return (
     <ul className="divide-y">
-      {filtered.map((e, i) => (
+      {events.map((e, i) => (
         <li key={i} className="px-4 py-2 text-sm">
-          <span
-            className={`mr-2 inline-block h-2 w-2 rounded-full ${
-              e.type === "Warning" ? "bg-amber-500" : "bg-emerald-500"
-            }`}
-            aria-hidden
-          />
+          <span className={`mr-2 inline-block h-2 w-2 rounded-full ${eventToneClass(e.type)}`} aria-hidden />
           <span className="font-mono">{e.reason}</span>
           <span className="text-muted-foreground ml-2">{e.message}</span>
         </li>

--- a/apps/client/src/modules/k8s/components/workload/CompactEventsCard.test.tsx
+++ b/apps/client/src/modules/k8s/components/workload/CompactEventsCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { k8sEventConfig } from "@my-project/shared";
+import type { KubeObjectBase } from "@my-project/shared";
+
+const pollMock = vi.fn();
+vi.mock("../../hooks/useK8sResourceListPoll", () => ({
+  useK8sResourceListPoll: (...args: unknown[]) => pollMock(...args),
+}));
+
+import { CompactEventsCard } from "./CompactEventsCard";
+import { EVENTS_POLL_INTERVAL_MS, RESOURCE_EVENTS_FETCH_LIMIT } from "../../constants/event";
+
+const item = {
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: { uid: "dep-uid-1", name: "my-dep", namespace: "ns", creationTimestamp: "2024-01-01T00:00:00Z" },
+};
+
+describe("CompactEventsCard", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches with an involvedObject.uid fieldSelector and renders the latest events", () => {
+    pollMock.mockReturnValue({
+      data: {
+        array: [
+          { type: "Normal", reason: "ScalingReplicaSet", message: "scaled", involvedObject: { uid: "dep-uid-1" } },
+        ],
+      },
+    });
+
+    render(<CompactEventsCard item={item} />);
+
+    expect(pollMock).toHaveBeenCalledWith(k8sEventConfig, "ns", {
+      fieldSelector: "involvedObject.uid=dep-uid-1",
+      limit: RESOURCE_EVENTS_FETCH_LIMIT,
+      refetchInterval: EVENTS_POLL_INTERVAL_MS,
+      enabled: true,
+    });
+    expect(screen.getByText("ScalingReplicaSet")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no events", () => {
+    pollMock.mockReturnValue({ data: { array: [] } });
+    render(<CompactEventsCard item={item} />);
+    expect(screen.getByText("No recent events for this resource.")).toBeInTheDocument();
+  });
+
+  it("disables the fetch and shows the empty state for an unidentifiable item (no uid, no name)", () => {
+    pollMock.mockReturnValue({ data: { array: [] } });
+    // Deliberately malformed (no uid/name) — only reachable via a cast, which is
+    // why the runtime `enabled` guard exists rather than relying on the type.
+    const unidentified = {
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      metadata: { namespace: "ns" },
+    } as unknown as KubeObjectBase;
+    render(<CompactEventsCard item={unidentified} />);
+    expect(pollMock).toHaveBeenCalledWith(
+      k8sEventConfig,
+      "ns",
+      expect.objectContaining({ fieldSelector: undefined, enabled: false })
+    );
+    expect(screen.getByText("No recent events for this resource.")).toBeInTheDocument();
+  });
+});

--- a/apps/client/src/modules/k8s/components/workload/CompactEventsCard.tsx
+++ b/apps/client/src/modules/k8s/components/workload/CompactEventsCard.tsx
@@ -1,26 +1,11 @@
+import { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
 import { Tooltip } from "@/core/components/ui/tooltip";
 import { formatRelativeTime } from "@/core/utils/date-humanize/utils";
-import { k8sEventConfig } from "@my-project/shared";
 import type { KubeObjectBase } from "@my-project/shared";
-import { useK8sResourceList } from "../../hooks/useK8sResourceList";
-import { EVENT_TONE } from "../../constants/event";
-
-interface K8sEvent extends KubeObjectBase {
-  type?: string;
-  reason?: string;
-  message?: string;
-  count?: number;
-  lastTimestamp?: string;
-  eventTime?: string;
-  firstTimestamp?: string;
-  involvedObject?: {
-    kind?: string;
-    namespace?: string;
-    name?: string;
-    uid?: string;
-  };
-}
+import { useResourceEvents } from "../../hooks/useResourceEvents";
+import { getEventTimestamp, sortLatestEvents } from "../../utils/event";
+import { eventToneClass } from "../../constants/event";
 
 /**
  * Last-5 recent events for any namespaced object, matched by involvedObject
@@ -28,25 +13,10 @@ interface K8sEvent extends KubeObjectBase {
  * sidebar's local `CompactEventsCard` so every workload overview can reuse it.
  */
 export function CompactEventsCard({ item }: { item: KubeObjectBase }) {
-  const ns = item.metadata?.namespace ?? "";
-  const kind = (item as { kind?: string }).kind;
-  const result = useK8sResourceList<K8sEvent>(k8sEventConfig, ns);
-  const events = result.data.array;
+  const { data, isLoading } = useResourceEvents(item);
+  const events = data.array;
 
-  const filtered = events
-    .filter(
-      (e) =>
-        e.involvedObject?.uid === item.metadata?.uid ||
-        (e.involvedObject?.kind === kind &&
-          e.involvedObject?.name === item.metadata?.name &&
-          e.involvedObject?.namespace === ns)
-    )
-    .sort((a, b) => {
-      const ta = new Date(a.lastTimestamp ?? a.eventTime ?? a.metadata?.creationTimestamp ?? 0).getTime();
-      const tb = new Date(b.lastTimestamp ?? b.eventTime ?? b.metadata?.creationTimestamp ?? 0).getTime();
-      return tb - ta;
-    })
-    .slice(0, 5);
+  const recent = useMemo(() => sortLatestEvents(events, 5), [events]);
 
   return (
     <Card>
@@ -57,18 +27,18 @@ export function CompactEventsCard({ item }: { item: KubeObjectBase }) {
         </CardTitle>
       </CardHeader>
       <CardContent className="p-3 pt-1">
-        {filtered.length === 0 ? (
+        {isLoading ? (
+          <div className="text-muted-foreground text-xs">Loading events…</div>
+        ) : recent.length === 0 ? (
           <div className="text-muted-foreground text-xs">No recent events for this resource.</div>
         ) : (
           <ul className="space-y-2">
-            {filtered.map((e, i) => {
-              const ts = e.lastTimestamp ?? e.eventTime ?? e.metadata?.creationTimestamp;
+            {recent.map((e, i) => {
+              const ts = getEventTimestamp(e);
               return (
                 <li key={i} className="flex items-start gap-2 text-xs">
                   <span
-                    className={`mt-1 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full ${
-                      EVENT_TONE[e.type ?? ""] ?? "bg-muted-foreground"
-                    }`}
+                    className={`mt-1 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full ${eventToneClass(e.type)}`}
                     aria-hidden
                   />
                   <div className="min-w-0 flex-1">

--- a/apps/client/src/modules/k8s/constants/event.ts
+++ b/apps/client/src/modules/k8s/constants/event.ts
@@ -10,3 +10,26 @@ export const EVENT_TONE: Record<string, string> = {
   [EVENT_TYPE.NORMAL]: "bg-emerald-500",
   [EVENT_TYPE.WARNING]: "bg-amber-500",
 };
+
+// Tailwind background tone for an event indicator dot, falling back to
+// `bg-muted-foreground` for unknown/absent types.
+export function eventToneClass(type?: string): string {
+  return EVENT_TONE[type ?? ""] ?? "bg-muted-foreground";
+}
+
+// Poll interval (ms) for event views that fetch instead of watch. 30s keeps the
+// UI fresh without streaming every event in the namespace/cluster.
+export const EVENTS_POLL_INTERVAL_MS = 30_000;
+
+// Max events fetched for the cluster-wide overview "Recent events" card (renders
+// the newest 25). Core/v1 Events can't be sorted server-side, and `?limit` returns
+// the first N in etcd key order (namespace/name), NOT the newest — so on clusters
+// with more than this many live events the card can miss some recent ones. The gap
+// is bounded by events' ~1h TTL; raise this limit if the overview needs higher
+// fidelity (per-resource views are unaffected — the field selector scopes them).
+export const OVERVIEW_EVENTS_FETCH_LIMIT = 100;
+
+// Max events fetched for a single resource's detail/sidebar event views. A lone
+// resource accrues few events, so this is generous headroom that still bounds the
+// page (the involvedObject field selector already scopes it server-side).
+export const RESOURCE_EVENTS_FETCH_LIMIT = 100;

--- a/apps/client/src/modules/k8s/hooks/useK8sResourceListPoll.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sResourceListPoll.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { k8sEventConfig } from "@my-project/shared";
+
+const queryMock = vi.fn();
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({ k8s: { list: { query: queryMock } } }),
+}));
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: (sel: (s: { clusterName: string }) => unknown) => sel({ clusterName: "test-cluster" }),
+}));
+
+import { useK8sResourceListPoll } from "./useK8sResourceListPoll";
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    QueryClientProvider,
+    { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+    children
+  );
+
+describe("useK8sResourceListPoll", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards namespace, limit and fieldSelector and exposes data.array", async () => {
+    queryMock.mockResolvedValueOnce({
+      apiVersion: "v1",
+      kind: "EventList",
+      metadata: { resourceVersion: "1" },
+      items: [{ metadata: { name: "e1" } }, { metadata: { name: "e2" } }],
+    });
+
+    const { result } = renderHook(
+      () => useK8sResourceListPoll(k8sEventConfig, "ns", { limit: 50, fieldSelector: "involvedObject.uid=u1" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.data.array).toHaveLength(2));
+    expect(queryMock).toHaveBeenCalledWith({
+      clusterName: "test-cluster",
+      resourceConfig: k8sEventConfig,
+      namespace: "ns",
+      limit: 50,
+      fieldSelector: "involvedObject.uid=u1",
+    });
+    expect(result.current.isReady).toBe(true);
+  });
+
+  it("keeps an empty-string namespace (cluster-wide) instead of falling back to the stored namespace", async () => {
+    queryMock.mockResolvedValueOnce({
+      apiVersion: "v1",
+      kind: "EventList",
+      metadata: { resourceVersion: "1" },
+      items: [],
+    });
+
+    renderHook(() => useK8sResourceListPoll(k8sEventConfig, "", { limit: 100 }), { wrapper });
+
+    await waitFor(() => expect(queryMock).toHaveBeenCalled());
+    expect(queryMock).toHaveBeenCalledWith({
+      clusterName: "test-cluster",
+      resourceConfig: k8sEventConfig,
+      namespace: "",
+      limit: 100,
+      fieldSelector: undefined,
+    });
+  });
+
+  it("reports loading (not empty) during the placeholder phase", () => {
+    queryMock.mockReturnValueOnce(new Promise(() => {}));
+    const { result } = renderHook(() => useK8sResourceListPoll(k8sEventConfig, "ns", { limit: 10 }), {
+      wrapper,
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.isEmpty).toBe(false);
+  });
+
+  it("does not fetch when disabled (enabled: false)", () => {
+    const { result } = renderHook(() => useK8sResourceListPoll(k8sEventConfig, "ns", { enabled: false, limit: 10 }), {
+      wrapper,
+    });
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.data.array).toEqual([]);
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useK8sResourceListPoll.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sResourceListPoll.ts
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import { RequestError } from "@/core/types/global";
+import type { K8sResourceConfig, KubeObjectBase } from "@my-project/shared";
+import { CustomKubeObjectList, UseWatchListResult, k8sListInitialData } from "@/k8s/api/hooks/useWatch/types";
+import { getK8sListPollQueryCacheKey } from "@/k8s/api/hooks/useWatch/query-keys";
+
+export interface UseK8sResourceListPollOptions {
+  limit?: number;
+  fieldSelector?: string;
+  refetchInterval?: number;
+  enabled?: boolean;
+}
+
+/**
+ * Polled, bounded list of a K8s resource. Unlike `useK8sResourceList` this opens
+ * NO WebSocket watch: it fetches a single page (optionally `limit`-capped and
+ * `fieldSelector`-scoped) and refreshes on `refetchInterval`. Use for views that
+ * only need a small/scoped slice (e.g. the overview "Recent events" card or a
+ * single resource's events) instead of streaming the whole namespace/cluster.
+ */
+export function useK8sResourceListPoll<T extends KubeObjectBase>(
+  config: K8sResourceConfig,
+  namespace: string,
+  options: UseK8sResourceListPollOptions = {}
+): UseWatchListResult<T> {
+  const trpc = useTRPCClient();
+  const clusterName = useClusterStore((s) => s.clusterName);
+
+  const { limit, fieldSelector, refetchInterval, enabled = true } = options;
+
+  // Cluster-scoped resources carry no namespace; otherwise use the given one. An
+  // explicit "" stays cluster-wide on the server. Matches useK8sResourceList: the
+  // namespace is always passed by callers, so there is no stored-namespace fallback.
+  const _namespace = config.clusterScoped ? undefined : namespace;
+
+  const queryKey = getK8sListPollQueryCacheKey(
+    clusterName,
+    _namespace,
+    config.group,
+    config.pluralName,
+    fieldSelector,
+    limit
+  );
+
+  const query = useQuery<CustomKubeObjectList<T>, RequestError>({
+    queryKey,
+    queryFn: async () => {
+      const data = await trpc.k8s.list.query({
+        clusterName,
+        resourceConfig: config,
+        namespace: _namespace,
+        limit,
+        fieldSelector,
+      });
+
+      const itemsMap = new Map(data.items.map((item) => [item.metadata.name!, item as T]));
+
+      return {
+        apiVersion: data.apiVersion,
+        kind: data.kind,
+        metadata: data.metadata,
+        items: itemsMap,
+      };
+    },
+    placeholderData: k8sListInitialData as CustomKubeObjectList<T>,
+    refetchInterval,
+    enabled,
+  });
+
+  const data = useMemo(() => {
+    const items = query.data?.items ?? new Map<string, T>();
+    return {
+      array: Array.from(items.values()),
+      map: items,
+    };
+  }, [query.data?.items]);
+
+  return {
+    data,
+    query,
+    resourceVersion: query.data?.metadata?.resourceVersion,
+    // Deliberately stricter than useWatchList's `size === 0`: stays false during
+    // the placeholder/loading phase so consumers don't flash an empty state.
+    isEmpty: !query.isPlaceholderData && (query.data?.items.size ?? 0) === 0,
+    // A disabled query never fetches, so it is not "loading" — gate on `enabled`
+    // so consumers (e.g. useResourceEvents with no field selector) fall through to
+    // their empty state instead of showing a spinner forever.
+    isLoading: enabled && (query.isPending || query.isPlaceholderData),
+    isReady: query.isSuccess && !query.isPlaceholderData,
+    error: query.error,
+  };
+}

--- a/apps/client/src/modules/k8s/hooks/useResourceEvents.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useResourceEvents.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { k8sEventConfig } from "@my-project/shared";
+import type { KubeObjectBase } from "@my-project/shared";
+
+const pollMock = vi.fn();
+vi.mock("./useK8sResourceListPoll", () => ({
+  useK8sResourceListPoll: (...args: unknown[]) => pollMock(...args),
+}));
+
+import { useResourceEvents } from "./useResourceEvents";
+import { EVENTS_POLL_INTERVAL_MS, RESOURCE_EVENTS_FETCH_LIMIT } from "../constants/event";
+
+describe("useResourceEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pollMock.mockReturnValue({ data: { array: [] } });
+  });
+
+  it("scopes by involvedObject.uid and forwards limit/poll-interval with the fetch enabled", () => {
+    const item: KubeObjectBase = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: { uid: "pod-uid-1", name: "my-pod", namespace: "ns", creationTimestamp: "2024-01-01T00:00:00Z" },
+    };
+
+    renderHook(() => useResourceEvents(item));
+
+    expect(pollMock).toHaveBeenCalledWith(k8sEventConfig, "ns", {
+      fieldSelector: "involvedObject.uid=pod-uid-1",
+      limit: RESOURCE_EVENTS_FETCH_LIMIT,
+      refetchInterval: EVENTS_POLL_INTERVAL_MS,
+      enabled: true,
+    });
+  });
+
+  it("falls back to a kind+name+namespace selector when the item has no uid", () => {
+    const item = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: { name: "my-pod", namespace: "ns" },
+    } as unknown as KubeObjectBase;
+
+    renderHook(() => useResourceEvents(item));
+
+    expect(pollMock).toHaveBeenCalledWith(
+      k8sEventConfig,
+      "ns",
+      expect.objectContaining({
+        fieldSelector: "involvedObject.kind=Pod,involvedObject.name=my-pod,involvedObject.namespace=ns",
+        enabled: true,
+      })
+    );
+  });
+
+  it("disables the fetch when the item carries nothing identifying (no uid, no name)", () => {
+    // Deliberately malformed — only reachable via a cast, which is why the
+    // runtime `enabled` guard exists rather than relying on the type.
+    const item = { apiVersion: "v1", kind: "Pod", metadata: { namespace: "ns" } } as unknown as KubeObjectBase;
+
+    renderHook(() => useResourceEvents(item));
+
+    expect(pollMock).toHaveBeenCalledWith(
+      k8sEventConfig,
+      "ns",
+      expect.objectContaining({ fieldSelector: undefined, enabled: false })
+    );
+  });
+
+  it("defaults the namespace to an empty string when the item has none", () => {
+    const item = { apiVersion: "v1", kind: "Pod", metadata: { uid: "u1" } } as unknown as KubeObjectBase;
+
+    renderHook(() => useResourceEvents(item));
+
+    expect(pollMock).toHaveBeenCalledWith(k8sEventConfig, "", expect.objectContaining({ enabled: true }));
+  });
+
+  it("returns the underlying poll result unchanged", () => {
+    const pollResult = { data: { array: [{ reason: "Started" }] } };
+    pollMock.mockReturnValue(pollResult);
+
+    const item = { apiVersion: "v1", kind: "Pod", metadata: { uid: "u1", namespace: "ns" } } as KubeObjectBase;
+    const { result } = renderHook(() => useResourceEvents(item));
+
+    expect(result.current).toBe(pollResult);
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useResourceEvents.ts
+++ b/apps/client/src/modules/k8s/hooks/useResourceEvents.ts
@@ -1,0 +1,26 @@
+import { k8sEventConfig } from "@my-project/shared";
+import type { KubeObjectBase, Event as K8sEvent } from "@my-project/shared";
+import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
+import { useK8sResourceListPoll } from "./useK8sResourceListPoll";
+import { involvedObjectFieldSelector } from "../utils/involvedObjectFieldSelector";
+import { EVENTS_POLL_INTERVAL_MS, RESOURCE_EVENTS_FETCH_LIMIT } from "../constants/event";
+
+/**
+ * Polls a single resource's own core/v1 Events, scoped server-side by an
+ * involvedObject field selector (uid, or kind+name+namespace fallback). When the
+ * object carries nothing identifying (no uid and no name) we can't build a
+ * selector, so the fetch is skipped rather than pulling the whole namespace and
+ * mislabeling unrelated events as the resource's own.
+ *
+ * Shared by `ResourceEventsTab` (detail tab) and `CompactEventsCard` (sidebar)
+ * so the limit/poll-interval/guard stay defined in one place.
+ */
+export function useResourceEvents(item: KubeObjectBase): UseWatchListResult<K8sEvent> {
+  const fieldSelector = involvedObjectFieldSelector(item);
+  return useK8sResourceListPoll<K8sEvent>(k8sEventConfig, item.metadata?.namespace ?? "", {
+    fieldSelector,
+    limit: RESOURCE_EVENTS_FETCH_LIMIT,
+    refetchInterval: EVENTS_POLL_INTERVAL_MS,
+    enabled: !!fieldSelector,
+  });
+}

--- a/apps/client/src/modules/k8s/pages/overview/components/RecentEventsCard.tsx
+++ b/apps/client/src/modules/k8s/pages/overview/components/RecentEventsCard.tsx
@@ -5,22 +5,12 @@ import { Skeleton } from "@/core/components/ui/skeleton";
 import { Tooltip } from "@/core/components/ui/tooltip";
 import { formatRelativeTime } from "@/core/utils/date-humanize/utils";
 import { PATH_K8S_EVENTS_FULL } from "@/modules/k8s/constants/paths";
-import { EVENT_TONE } from "@/modules/k8s/constants/event";
+import { eventToneClass } from "@/modules/k8s/constants/event";
+import { getEventTimestamp, sortLatestEvents } from "@/modules/k8s/utils/event";
 import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
 import type { OverviewEvent } from "../types";
 
 const MAX_EVENTS = 25;
-
-function eventTimestamp(event: OverviewEvent): string | undefined {
-  return event.lastTimestamp ?? event.eventTime ?? event.metadata?.creationTimestamp;
-}
-
-function eventTime(event: OverviewEvent): number {
-  const raw = eventTimestamp(event);
-  if (!raw) return 0;
-  const time = new Date(raw).getTime();
-  return Number.isFinite(time) ? time : 0;
-}
 
 interface RecentEventsCardProps {
   clusterName: string;
@@ -28,10 +18,7 @@ interface RecentEventsCardProps {
 }
 
 export function RecentEventsCard({ clusterName, result }: RecentEventsCardProps) {
-  const sorted = useMemo(
-    () => [...result.data.array].sort((a, b) => eventTime(b) - eventTime(a)).slice(0, MAX_EVENTS),
-    [result.data.array]
-  );
+  const sorted = useMemo(() => sortLatestEvents(result.data.array, MAX_EVENTS), [result.data.array]);
 
   return (
     <Card>
@@ -57,16 +44,14 @@ export function RecentEventsCard({ clusterName, result }: RecentEventsCardProps)
         ) : (
           <ul className="max-h-80 space-y-2.5 overflow-y-auto pr-1">
             {sorted.map((event, index) => {
-              const timestamp = eventTimestamp(event);
+              const timestamp = getEventTimestamp(event);
               return (
                 <li
                   key={event.metadata?.uid ?? `${timestamp ?? "event"}-${index}`}
                   className="flex items-start gap-2 text-xs"
                 >
                   <span
-                    className={`mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full ${
-                      EVENT_TONE[event.type ?? ""] ?? "bg-muted-foreground"
-                    }`}
+                    className={`mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full ${eventToneClass(event.type)}`}
                     aria-hidden
                   />
                   <div className="min-w-0 flex-1">

--- a/apps/client/src/modules/k8s/pages/overview/hooks/useClusterOverview.ts
+++ b/apps/client/src/modules/k8s/pages/overview/hooks/useClusterOverview.ts
@@ -17,6 +17,8 @@ import {
 import { useTRPCClient } from "@/core/providers/trpc";
 import type { UseWatchListResult } from "@/k8s/api/hooks/useWatch/types";
 import { useK8sResourceList } from "@/modules/k8s/hooks/useK8sResourceList";
+import { useK8sResourceListPoll } from "@/modules/k8s/hooks/useK8sResourceListPoll";
+import { EVENTS_POLL_INTERVAL_MS, OVERVIEW_EVENTS_FETCH_LIMIT } from "@/modules/k8s/constants/event";
 import type { WatchStatus } from "@/modules/k8s/components/WatchConnectionIndicator";
 import type { OverviewEvent } from "../types";
 import type { WorkloadKind } from "../utils/workload";
@@ -46,7 +48,13 @@ export function useClusterOverview(): ClusterOverview {
   const nodes = useK8sResourceList<K8sNode>(k8sNodeConfig, "");
   const pods = useK8sResourceList<Pod>(k8sPodConfig, "");
   const namespaces = useK8sResourceList<Namespace>(k8sNamespaceConfig, "");
-  const events = useK8sResourceList<OverviewEvent>(k8sEventConfig, "");
+  // Recent events: poll a bounded, cluster-wide page instead of watching every
+  // event in the cluster (the card only renders the latest 25). One-shot the
+  // events rather than streaming them.
+  const events = useK8sResourceListPoll<OverviewEvent>(k8sEventConfig, "", {
+    limit: OVERVIEW_EVENTS_FETCH_LIMIT,
+    refetchInterval: EVENTS_POLL_INTERVAL_MS,
+  });
 
   const deployments = useK8sResourceList<KubeObjectBase>(k8sDeploymentConfig, "");
   const statefulsets = useK8sResourceList<KubeObjectBase>(k8sStatefulSetConfig, "");

--- a/apps/client/src/modules/k8s/pages/overview/types.ts
+++ b/apps/client/src/modules/k8s/pages/overview/types.ts
@@ -1,16 +1,4 @@
-import type { KubeObjectBase } from "@my-project/shared";
+import type { Event as K8sEvent } from "@my-project/shared";
 
-/** The shared `Event` schema is `.passthrough()`, so we type only the fields the overview renders. */
-export interface OverviewEvent extends KubeObjectBase {
-  type?: string;
-  reason?: string;
-  message?: string;
-  lastTimestamp?: string;
-  eventTime?: string;
-  involvedObject?: {
-    kind?: string;
-    namespace?: string;
-    name?: string;
-    uid?: string;
-  };
-}
+/** Cluster-overview "Recent events" item — the shared core/v1 `Event` type. */
+export type OverviewEvent = K8sEvent;

--- a/apps/client/src/modules/k8s/pages/pods/detail/components/PodOverviewSidebar.tsx
+++ b/apps/client/src/modules/k8s/pages/pods/detail/components/PodOverviewSidebar.tsx
@@ -1,91 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/core/components/ui/card";
 import { Badge } from "@/core/components/ui/badge";
-import { Tooltip } from "@/core/components/ui/tooltip";
-import { useK8sResourceList } from "../../../../hooks/useK8sResourceList";
-import { formatRelativeTime } from "@/core/utils/date-humanize/utils";
-import { k8sEventConfig } from "@my-project/shared";
-import type { KubeObjectBase, Pod } from "@my-project/shared";
-import { EVENT_TONE } from "../../../../constants/event";
-
-interface K8sEvent extends KubeObjectBase {
-  type?: string;
-  reason?: string;
-  message?: string;
-  count?: number;
-  lastTimestamp?: string;
-  eventTime?: string;
-  firstTimestamp?: string;
-  involvedObject?: {
-    kind?: string;
-    namespace?: string;
-    name?: string;
-    uid?: string;
-  };
-}
-
-function CompactEventsCard({ pod }: { pod: Pod }) {
-  const ns = pod.metadata?.namespace ?? "";
-  const result = useK8sResourceList<K8sEvent>(k8sEventConfig, ns);
-  const events = result.data.array;
-
-  const filtered = events
-    .filter(
-      (e) =>
-        e.involvedObject?.uid === pod.metadata?.uid ||
-        (e.involvedObject?.kind === "Pod" &&
-          e.involvedObject?.name === pod.metadata?.name &&
-          e.involvedObject?.namespace === ns)
-    )
-    .sort((a, b) => {
-      const ta = new Date(a.lastTimestamp ?? a.eventTime ?? a.metadata?.creationTimestamp ?? 0).getTime();
-      const tb = new Date(b.lastTimestamp ?? b.eventTime ?? b.metadata?.creationTimestamp ?? 0).getTime();
-      return tb - ta;
-    })
-    .slice(0, 5);
-
-  return (
-    <Card>
-      <CardHeader className="p-3 pb-1">
-        <CardTitle className="flex items-baseline justify-between text-sm font-semibold">
-          <span>Events</span>
-          <span className="text-muted-foreground text-xs">recent</span>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="p-3 pt-1">
-        {filtered.length === 0 ? (
-          <div className="text-muted-foreground text-xs">No events for this pod.</div>
-        ) : (
-          <ul className="space-y-2">
-            {filtered.map((e, i) => {
-              const ts = e.lastTimestamp ?? e.eventTime ?? e.metadata?.creationTimestamp;
-              return (
-                <li key={i} className="flex items-start gap-2 text-xs">
-                  <span
-                    className={`mt-1 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full ${
-                      EVENT_TONE[e.type ?? ""] ?? "bg-muted-foreground"
-                    }`}
-                    aria-hidden
-                  />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline justify-between gap-2">
-                      <span className="text-foreground truncate font-mono">{e.reason ?? "—"}</span>
-                      <span className="text-muted-foreground flex-shrink-0">{formatRelativeTime(ts)}</span>
-                    </div>
-                    {e.message && (
-                      <Tooltip title={e.message}>
-                        <span className="text-muted-foreground line-clamp-2 block">{e.message}</span>
-                      </Tooltip>
-                    )}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
+import type { Pod } from "@my-project/shared";
+import { CompactEventsCard } from "../../../../components/workload/CompactEventsCard";
 
 function PodPortsCard({ pod }: { pod: Pod }) {
   const containers = pod.spec?.containers ?? [];
@@ -153,7 +69,7 @@ function MetadataListCard({ title, entries }: { title: string; entries: Record<s
 export function PodOverviewSidebar({ pod }: { pod: Pod }) {
   return (
     <div className="flex flex-col gap-3">
-      <CompactEventsCard pod={pod} />
+      <CompactEventsCard item={pod} />
       <PodPortsCard pod={pod} />
       <MetadataListCard title="Labels" entries={pod.metadata?.labels ?? {}} />
       <MetadataListCard title="Annotations" entries={pod.metadata?.annotations ?? {}} />

--- a/apps/client/src/modules/k8s/utils/event/index.ts
+++ b/apps/client/src/modules/k8s/utils/event/index.ts
@@ -1,0 +1,31 @@
+import type { Event as K8sEvent } from "@my-project/shared";
+
+/**
+ * Best available timestamp string for ordering/displaying a core/v1 Event:
+ * `lastTimestamp` (legacy), then `eventTime` (newer API servers), then the
+ * object's `creationTimestamp`. `undefined` when the event carries none.
+ */
+export function getEventTimestamp(event: K8sEvent): string | undefined {
+  return event.lastTimestamp ?? event.eventTime ?? event.metadata?.creationTimestamp;
+}
+
+/**
+ * Numeric epoch (ms) for sorting events newest-first. Returns 0 when the event
+ * has no timestamp or the value is unparseable, so a malformed event sorts last
+ * instead of poisoning the comparator with `NaN`.
+ */
+export function getEventTime(event: K8sEvent): number {
+  const raw = getEventTimestamp(event);
+  if (!raw) return 0;
+  const time = new Date(raw).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+/**
+ * Newest-first copy of `events`, capped at `limit`. Copies before sorting because
+ * callers pass memoized arrays and `Array.prototype.sort` mutates in place;
+ * orders by `getEventTime` (lastTimestamp→eventTime→creationTimestamp, NaN-safe).
+ */
+export function sortLatestEvents<T extends K8sEvent>(events: T[], limit: number): T[] {
+  return [...events].sort((a, b) => getEventTime(b) - getEventTime(a)).slice(0, limit);
+}

--- a/apps/client/src/modules/k8s/utils/involvedObjectFieldSelector/index.test.ts
+++ b/apps/client/src/modules/k8s/utils/involvedObjectFieldSelector/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { involvedObjectFieldSelector } from "./index";
+
+describe("involvedObjectFieldSelector", () => {
+  it("prefers uid when present", () => {
+    expect(involvedObjectFieldSelector({ kind: "Pod", metadata: { uid: "u-1", name: "p", namespace: "ns" } })).toBe(
+      "involvedObject.uid=u-1"
+    );
+  });
+
+  it("falls back to kind+name+namespace when uid is missing", () => {
+    expect(involvedObjectFieldSelector({ kind: "Pod", metadata: { name: "p", namespace: "ns" } })).toBe(
+      "involvedObject.kind=Pod,involvedObject.name=p,involvedObject.namespace=ns"
+    );
+  });
+
+  it("omits kind and namespace when only a name is known", () => {
+    expect(involvedObjectFieldSelector({ metadata: { name: "p" } })).toBe("involvedObject.name=p");
+  });
+
+  it("returns undefined when nothing identifying is present", () => {
+    expect(involvedObjectFieldSelector({ metadata: {} })).toBeUndefined();
+    expect(involvedObjectFieldSelector({})).toBeUndefined();
+  });
+});

--- a/apps/client/src/modules/k8s/utils/involvedObjectFieldSelector/index.ts
+++ b/apps/client/src/modules/k8s/utils/involvedObjectFieldSelector/index.ts
@@ -1,0 +1,37 @@
+interface InvolvedObjectInput {
+  kind?: string;
+  metadata?: {
+    uid?: string;
+    name?: string;
+    namespace?: string;
+  };
+}
+
+/**
+ * Builds a Kubernetes core/v1 Events `fieldSelector` that scopes a LIST to a
+ * single resource. Prefers `involvedObject.uid` (exact); falls back to
+ * kind+name+namespace. Returns `undefined` when the object carries nothing
+ * identifying; callers (see `useResourceEvents`) then disable the fetch rather
+ * than pulling — and mislabeling — the whole namespace's events.
+ */
+export function involvedObjectFieldSelector(item: InvolvedObjectInput): string | undefined {
+  const uid = item.metadata?.uid;
+  if (uid) {
+    return `involvedObject.uid=${uid}`;
+  }
+
+  const name = item.metadata?.name;
+  if (!name) {
+    return undefined;
+  }
+
+  const parts: string[] = [];
+  if (item.kind) {
+    parts.push(`involvedObject.kind=${item.kind}`);
+  }
+  parts.push(`involvedObject.name=${name}`);
+  if (item.metadata?.namespace) {
+    parts.push(`involvedObject.namespace=${item.metadata.namespace}`);
+  }
+  return parts.join(",");
+}

--- a/packages/shared/src/models/k8s/groups/Core/Event/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Core/Event/schema.ts
@@ -12,6 +12,8 @@ export const eventSchema = kubeObjectBaseSchema
     count: z.number().optional(),
     firstTimestamp: z.string().optional(),
     lastTimestamp: z.string().optional(),
+    // core/v1 Event also carries eventTime (MicroTime) on newer API servers.
+    eventTime: z.string().optional(),
     involvedObject: z
       .object({
         kind: z.string().optional(),

--- a/packages/trpc/src/clients/k8s/index.test.ts
+++ b/packages/trpc/src/clients/k8s/index.test.ts
@@ -400,38 +400,64 @@ describe("K8sClient", () => {
     });
   });
 
+  const rsConfig = {
+    group: "apps",
+    version: "v1",
+    apiVersion: "apps/v1",
+    kind: "ReplicaSet",
+    singularName: "replicaset",
+    pluralName: "replicasets",
+  };
+
+  const makeRsKubeConfigWithServer = function () {
+    return {
+      loadFromDefault: vi.fn(),
+      loadFromCluster: vi.fn(),
+      getCurrentCluster: vi.fn().mockReturnValue({ name: "test-cluster", server: "https://k8s.example.com" }),
+      getCurrentContext: vi.fn().mockReturnValue("test-context"),
+      getCurrentUser: vi.fn().mockReturnValue({}),
+      setCurrentContext: vi.fn(),
+      applyToHTTPSOptions: vi.fn(),
+      users: [],
+      contexts: [],
+      clusters: [],
+      currentContext: "test-context",
+    } as unknown as KubeConfig;
+  };
+
+  describe("listResource", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("appends fieldSelector to the query string on listResource", async () => {
+      vi.mocked(KubeConfig).mockImplementationOnce(makeRsKubeConfigWithServer);
+      const fetchMock = vi.mocked(fetchModule);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({ items: [], metadata: {} }),
+      } as never);
+
+      const client = new K8sClient(validSession);
+      await client.listResource(rsConfig, "ns", undefined, {
+        fieldSelector: "involvedObject.uid=abc",
+        limit: 100,
+      });
+
+      const url = fetchMock.mock.calls[0]![0] as string;
+      expect(url).toContain("fieldSelector=involvedObject.uid%3Dabc");
+      expect(url).toContain("limit=100");
+    });
+  });
+
   describe("listAllResources — continue-token pagination", () => {
-    const rsConfig = {
-      group: "apps",
-      version: "v1",
-      apiVersion: "apps/v1",
-      kind: "ReplicaSet",
-      singularName: "replicaset",
-      pluralName: "replicasets",
-    };
-
-    const makeKubeConfigWithServer = function () {
-      return {
-        loadFromDefault: vi.fn(),
-        loadFromCluster: vi.fn(),
-        getCurrentCluster: vi.fn().mockReturnValue({ name: "test-cluster", server: "https://k8s.example.com" }),
-        getCurrentContext: vi.fn().mockReturnValue("test-context"),
-        getCurrentUser: vi.fn().mockReturnValue({}),
-        setCurrentContext: vi.fn(),
-        applyToHTTPSOptions: vi.fn(),
-        users: [],
-        contexts: [],
-        clusters: [],
-        currentContext: "test-context",
-      } as unknown as KubeConfig;
-    };
-
     beforeEach(() => {
       vi.clearAllMocks();
     });
 
     it("follows the continue token until the API server stops returning one", async () => {
-      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      vi.mocked(KubeConfig).mockImplementationOnce(makeRsKubeConfigWithServer);
       const fetchMock = vi.mocked(fetchModule);
       fetchMock
         .mockResolvedValueOnce({
@@ -463,7 +489,7 @@ describe("K8sClient", () => {
     });
 
     it("forwards labelSelector on every page", async () => {
-      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      vi.mocked(KubeConfig).mockImplementationOnce(makeRsKubeConfigWithServer);
       const fetchMock = vi.mocked(fetchModule);
       fetchMock
         .mockResolvedValueOnce({
@@ -486,7 +512,7 @@ describe("K8sClient", () => {
 
     it("returns an empty list without throwing when the API server returns items: null", async () => {
       // Some non-conformant API servers / alpha resources return null instead of [].
-      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      vi.mocked(KubeConfig).mockImplementationOnce(makeRsKubeConfigWithServer);
       const fetchMock = vi.mocked(fetchModule);
       fetchMock.mockResolvedValueOnce({
         ok: true,
@@ -501,7 +527,7 @@ describe("K8sClient", () => {
     });
 
     it("caps at maxPages to prevent unbounded loops on a misbehaving server", async () => {
-      vi.mocked(KubeConfig).mockImplementationOnce(makeKubeConfigWithServer);
+      vi.mocked(KubeConfig).mockImplementationOnce(makeRsKubeConfigWithServer);
       const fetchMock = vi.mocked(fetchModule);
       fetchMock.mockResolvedValue({
         ok: true,

--- a/packages/trpc/src/clients/k8s/index.ts
+++ b/packages/trpc/src/clients/k8s/index.ts
@@ -180,7 +180,7 @@ export class K8sClient {
     resourceConfig: K8sResourceConfig,
     namespace?: string,
     labelSelector?: string,
-    options?: { limit?: number; continueToken?: string }
+    options?: { limit?: number; continueToken?: string; fieldSelector?: string }
   ): Promise<KubeObjectListBase<KubeObjectBase>> {
     if (!this.KubeConfig) {
       throw new Error("KubeConfig is not initialized");
@@ -191,6 +191,9 @@ export class K8sClient {
 
     if (labelSelector) {
       queryParams.append("labelSelector", labelSelector);
+    }
+    if (options?.fieldSelector) {
+      queryParams.append("fieldSelector", options.fieldSelector);
     }
     if (options?.limit && options.limit > 0) {
       queryParams.append("limit", String(options.limit));

--- a/packages/trpc/src/routers/k8s/procedures/basic/list/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/basic/list/index.test.ts
@@ -69,7 +69,10 @@ describe("k8sListProcedure", () => {
     const caller = createCaller(mockContext);
     const result = await caller.k8s.list(input);
 
-    expect(mockK8sClientInstance.listResource).toHaveBeenCalledWith(input.resourceConfig, input.namespace, "");
+    expect(mockK8sClientInstance.listResource).toHaveBeenCalledWith(input.resourceConfig, input.namespace, "", {
+      limit: undefined,
+      fieldSelector: undefined,
+    });
     expect(result).toEqual(mockResponse);
   });
 
@@ -186,5 +189,111 @@ describe("k8sListProcedure", () => {
     expect(meta.creationTimestamp).toBe("2024-01-01T10:00:00Z");
     expect(meta.labels).toEqual(mockResponse.items[0].metadata.labels);
     expect(meta.annotations).toEqual(mockResponse.items[0].metadata.annotations);
+  });
+
+  it("forwards limit and fieldSelector to listResource", async () => {
+    const input = {
+      clusterName: "test-cluster",
+      namespace: "test-namespace",
+      resourceConfig: {
+        group: "",
+        version: "v1",
+        pluralName: "events",
+        kind: "Event",
+        singularName: "event",
+        apiVersion: "v1",
+      },
+      labels: {},
+      limit: 100,
+      fieldSelector: "involvedObject.uid=abc",
+    };
+
+    mockK8sClientInstance.listResource.mockResolvedValueOnce({
+      apiVersion: "v1",
+      kind: "EventList",
+      metadata: { resourceVersion: "1" },
+      items: [],
+    });
+
+    const caller = createCaller(mockContext);
+    await caller.k8s.list(input);
+
+    expect(mockK8sClientInstance.listResource).toHaveBeenCalledWith(input.resourceConfig, input.namespace, "", {
+      limit: 100,
+      fieldSelector: "involvedObject.uid=abc",
+    });
+  });
+
+  it("accepts and forwards a compound kind+name+namespace fieldSelector (the no-uid fallback)", async () => {
+    const compound = "involvedObject.kind=Pod,involvedObject.name=my-pod,involvedObject.namespace=ns";
+    const input = {
+      clusterName: "test-cluster",
+      namespace: "test-namespace",
+      resourceConfig: {
+        group: "",
+        version: "v1",
+        pluralName: "events",
+        kind: "Event",
+        singularName: "event",
+        apiVersion: "v1",
+      },
+      labels: {},
+      fieldSelector: compound,
+    };
+
+    mockK8sClientInstance.listResource.mockResolvedValueOnce({
+      apiVersion: "v1",
+      kind: "EventList",
+      metadata: { resourceVersion: "1" },
+      items: [],
+    });
+
+    const caller = createCaller(mockContext);
+    await caller.k8s.list(input);
+
+    expect(mockK8sClientInstance.listResource).toHaveBeenCalledWith(input.resourceConfig, input.namespace, "", {
+      limit: undefined,
+      fieldSelector: compound,
+    });
+  });
+
+  it("rejects limit values outside the allowed range", async () => {
+    const base = {
+      clusterName: "test-cluster",
+      namespace: "test-namespace",
+      resourceConfig: {
+        group: "",
+        version: "v1",
+        pluralName: "events",
+        kind: "Event",
+        singularName: "event",
+        apiVersion: "v1",
+      },
+      labels: {},
+    };
+    const caller = createCaller(mockContext);
+    await expect(caller.k8s.list({ ...base, limit: 0 })).rejects.toThrowError();
+    await expect(caller.k8s.list({ ...base, limit: 1001 })).rejects.toThrowError();
+    await expect(caller.k8s.list({ ...base, limit: 1.5 })).rejects.toThrowError();
+  });
+
+  it("rejects a malformed fieldSelector", async () => {
+    const base = {
+      clusterName: "test-cluster",
+      namespace: "test-namespace",
+      resourceConfig: {
+        group: "",
+        version: "v1",
+        pluralName: "events",
+        kind: "Event",
+        singularName: "event",
+        apiVersion: "v1",
+      },
+      labels: {},
+    };
+    const caller = createCaller(mockContext);
+    // No operator / illegal characters / whitespace must be rejected.
+    await expect(caller.k8s.list({ ...base, fieldSelector: "not a selector" })).rejects.toThrowError();
+    await expect(caller.k8s.list({ ...base, fieldSelector: "x".repeat(513) })).rejects.toThrowError();
   });
 });

--- a/packages/trpc/src/routers/k8s/procedures/basic/list/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/basic/list/index.ts
@@ -7,6 +7,12 @@ import { k8sResourceConfigSchema } from "@my-project/shared";
 import { handleK8sError } from "../../../utils/handleK8sError/index.js";
 import { K8sClient } from "../../../../../clients/k8s/index.js";
 
+// Forwarded verbatim to the K8s API server, so constrain to the field-selector
+// grammar (comma-separated key(=|==|!=)value pairs). Project convention: regex-
+// constrained Zod for filter strings sent to backends (cf. tektonInputSchemas.celFilter).
+const K8S_FIELD_SELECTOR_REGEX =
+  /^[A-Za-z0-9_.]+(?:==|!=|=)[A-Za-z0-9_./-]*(?:,[A-Za-z0-9_.]+(?:==|!=|=)[A-Za-z0-9_./-]*)*$/;
+
 // Explicit properties so `trpc-to-openapi` emits typed schemas; downstream
 // oapi-codegen clients otherwise drop every extra key on decode.
 const k8sItemMetadataSchema = z
@@ -45,6 +51,8 @@ export const k8sListProcedure = protectedProcedure
       namespace: z.string().optional(),
       resourceConfig: k8sResourceConfigSchema,
       labels: z.record(z.string()).optional().default({}),
+      limit: z.number().int().positive().max(1000).optional(),
+      fieldSelector: z.string().max(512).regex(K8S_FIELD_SELECTOR_REGEX, "Invalid fieldSelector").optional(),
     })
   )
   .output(k8sListOutputSchema)
@@ -56,9 +64,12 @@ export const k8sListProcedure = protectedProcedure
         throw new TRPCError(ERROR_K8S_CLIENT_NOT_INITIALIZED);
       }
 
-      const { namespace, resourceConfig, labels } = input;
+      const { namespace, resourceConfig, labels, limit, fieldSelector } = input;
 
-      return await k8sClient.listResource(resourceConfig, namespace, createLabelSelectorString(labels));
+      return await k8sClient.listResource(resourceConfig, namespace, createLabelSelectorString(labels), {
+        limit,
+        fieldSelector,
+      });
     } catch (error) {
       throw handleK8sError(error);
     }


### PR DESCRIPTION
The overview "Recent events" card and per-resource Events views fetched and streamed every event in the cluster (or the whole namespace), making them slow to load. Bound and scope those fetches.

- K8sClient.listResource: add fieldSelector support (limit was already there).
- k8s.list tRPC procedure: accept Zod-validated limit + fieldSelector inputs; fieldSelector is regex-constrained to the Kubernetes field-selector grammar.
- Add useK8sResourceListPoll: a bounded, no-WebSocket list hook (limit / fieldSelector / refetchInterval) returning the same UseWatchListResult shape as the watch hook, so consumers swap in without other changes.
- Add involvedObjectFieldSelector util (involvedObject.uid=..., with a kind+name+namespace fallback).
- Overview "Recent events" card now polls a bounded 100-event list every 30s instead of opening a cluster-wide events watch.
- ResourceEventsTab, the workload CompactEventsCard, and the Pod overview sidebar now fetch only the resource's own events via a server-side involvedObject.uid field selector instead of the whole namespace.
