### PR TITLE
EPMDEDP-16788: feat: add permission-aware Custom Resources catalog for users 

### DIFF
--- a/apps/client/src/k8s/api/hooks/useWatch/query-keys/index.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/query-keys/index.ts
@@ -62,6 +62,12 @@ export function getK8sDeploymentRevisionsQueryCacheKey(clusterName: string, name
   return ["k8s:deploymentRevisions", clusterName, namespace, name];
 }
 
+export function getK8sAccessibleCustomResourcesQueryCacheKey(clusterName: string, namespace: string): string[] {
+  // Namespace is part of the key: the SelfSubjectRulesReview behind this query is
+  // namespace-scoped, so switching the default namespace must refetch the catalog.
+  return ["k8s:accessibleCustomResources", clusterName, namespace];
+}
+
 export function getK8sListPollQueryCacheKey(
   clusterName: string,
   namespace: string | undefined,

--- a/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.test.ts
+++ b/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.test.ts
@@ -32,11 +32,11 @@ const crds = [
 ];
 
 const mocked = {
-  ret: { data: { array: crds as never[], map: new Map() }, error: null, isReady: true, isLoading: false },
+  ret: { data: { array: crds as never[] }, error: null, isLoading: false },
 };
 
-vi.mock("@/modules/k8s/hooks/useCRDList", () => ({
-  useCRDList: vi.fn(() => mocked.ret),
+vi.mock("@/modules/k8s/hooks/useCRDCatalog", () => ({
+  useCRDCatalog: vi.fn(() => mocked.ret),
 }));
 
 import { useCRSidebarItems } from "./useCRSidebarItems";
@@ -54,16 +54,15 @@ describe("useCRSidebarItems", () => {
     expect(pr.route.params).toMatchObject({ group: "tekton.dev", version: "v1", plural: "pipelineruns" });
   });
 
-  it("returns empty array on watch error", () => {
+  it("returns empty array on catalog error", () => {
     mocked.ret = {
-      data: { array: [], map: new Map() },
+      data: { array: [] },
       error: new Error("boom"),
-      isReady: true,
       isLoading: false,
     } as never;
     const { result } = renderHook(() => useCRSidebarItems("c1"));
     expect(result.current).toEqual([]);
-    mocked.ret = { data: { array: crds as never[], map: new Map() }, error: null, isReady: true, isLoading: false };
+    mocked.ret = { data: { array: crds as never[] }, error: null, isLoading: false };
   });
 
   it("returns stable identity across renders when CRD data is unchanged", () => {
@@ -84,9 +83,8 @@ describe("useCRSidebarItems", () => {
       },
     };
     mocked.ret = {
-      data: { array: [...crds, crdWithEmptyGroup] as never[], map: new Map() },
+      data: { array: [...crds, crdWithEmptyGroup] as never[] },
       error: null,
-      isReady: true,
       isLoading: false,
     } as never;
 
@@ -96,7 +94,7 @@ describe("useCRSidebarItems", () => {
     expect(allChildren.every((c) => c.title !== "Broken")).toBe(true);
 
     // Restore original mock
-    mocked.ret = { data: { array: crds as never[], map: new Map() }, error: null, isReady: true, isLoading: false };
+    mocked.ret = { data: { array: crds as never[] }, error: null, isLoading: false };
   });
 
   it("does NOT emit a subgroup with an empty title when multiple CRDs have empty spec.group", () => {
@@ -122,9 +120,8 @@ describe("useCRSidebarItems", () => {
       },
     };
     mocked.ret = {
-      data: { array: [...crds, emptyGroup1, emptyGroup2] as never[], map: new Map() },
+      data: { array: [...crds, emptyGroup1, emptyGroup2] as never[] },
       error: null,
-      isReady: true,
       isLoading: false,
     } as never;
 
@@ -135,7 +132,7 @@ describe("useCRSidebarItems", () => {
     expect(result.current).toHaveLength(2);
 
     // Restore original mock
-    mocked.ret = { data: { array: crds as never[], map: new Map() }, error: null, isReady: true, isLoading: false };
+    mocked.ret = { data: { array: crds as never[] }, error: null, isLoading: false };
   });
 
   describe("isActiveFn matches list and detail paths", () => {

--- a/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.ts
+++ b/apps/client/src/modules/k8s/components/K8sSidebar/useCRSidebarItems.ts
@@ -1,13 +1,13 @@
 import { useMemo } from "react";
 import { Puzzle } from "lucide-react";
-import { useCRDList } from "@/modules/k8s/hooks/useCRDList";
+import { useCRDCatalog } from "@/modules/k8s/hooks/useCRDCatalog";
 import { storageVersionName, escapeRe } from "@/modules/k8s/registry/dynamic/crdUtils";
 import { PATH_K8S_CR_LIST_FULL } from "@/modules/k8s/constants/paths";
 import type { NavCollapsibleSubGroupItem, SimpleNavItem } from "@/core/components/sidebar/types";
 import type { CRDObject } from "@my-project/shared";
 
 export function useCRSidebarItems(clusterName: string): NavCollapsibleSubGroupItem[] {
-  const { data, error } = useCRDList();
+  const { data, error } = useCRDCatalog();
   return useMemo(() => {
     if (error || !data.array.length) return [];
 

--- a/apps/client/src/modules/k8s/constants/nav.ts
+++ b/apps/client/src/modules/k8s/constants/nav.ts
@@ -53,15 +53,15 @@ export function createK8sNavigationConfig(
     if (group === "CustomResources") {
       // The "CRDs" descriptor is sidebarHidden so the parent header doesn't visually
       // duplicate it; the group itself links to the CRDs list page via `defaultRoute`.
-      const mergedChildren = [...groupChildren, ...crSidebarItems];
-      if (mergedChildren.length > 0) {
-        items.push({
-          title: "Custom Resources",
-          icon: groupIconMap.CustomResources ?? Layers,
-          defaultRoute: { to: PATH_K8S_CRDS_FULL, params } as unknown as SimpleNavItem["route"],
-          children: mergedChildren,
-        });
-      }
+      // Always render the group, even with no children yet: the CR items arrive only
+      // after the CRD watch (or the permission-derived catalog) responds, and gating
+      // the header on them makes the whole section pop in seconds after first paint.
+      items.push({
+        title: "Custom Resources",
+        icon: groupIconMap.CustomResources ?? Layers,
+        defaultRoute: { to: PATH_K8S_CRDS_FULL, params } as unknown as SimpleNavItem["route"],
+        children: [...groupChildren, ...crSidebarItems],
+      });
     } else if (groupChildren.length > 0) {
       items.push({ title: group, icon: groupIconMap[group] ?? Layers, children: groupChildren });
     }

--- a/apps/client/src/modules/k8s/hooks/useAccessibleCRCatalog.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useAccessibleCRCatalog.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import type { AccessibleCustomResource } from "@my-project/shared";
+import { createTestQueryClient } from "@/test/utils";
+
+const queryMock = vi.fn();
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({ k8s: { accessibleCustomResources: { query: queryMock } } }),
+}));
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: (sel: (s: { clusterName: string; defaultNamespace: string }) => unknown) =>
+    sel({ clusterName: "test-cluster", defaultNamespace: "edp-delivery" }),
+}));
+
+import { toSyntheticCRD, useAccessibleCRCatalog } from "./useAccessibleCRCatalog";
+
+const entry: AccessibleCustomResource = {
+  group: "v2.edp.epam.com",
+  version: "v1",
+  plural: "codebasebranches",
+  kind: "CodebaseBranch",
+  singular: "codebasebranch",
+  namespaced: true,
+  verbs: ["*"],
+  editable: true,
+};
+
+// Factory so each test gets an isolated cache while the client stays stable
+// across re-renders (a `new QueryClient` inside the component body would reset
+// the cache on every render).
+const createWrapper = () => {
+  const client = createTestQueryClient();
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+};
+
+describe("toSyntheticCRD", () => {
+  it("maps a namespaced catalog entry to a CRDObject with a single served storage version", () => {
+    expect(toSyntheticCRD(entry)).toEqual({
+      apiVersion: "apiextensions.k8s.io/v1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "codebasebranches.v2.edp.epam.com",
+        uid: "codebasebranches.v2.edp.epam.com",
+        resourceVersion: "v1",
+        creationTimestamp: "",
+      },
+      spec: {
+        group: "v2.edp.epam.com",
+        scope: "Namespaced",
+        names: { kind: "CodebaseBranch", plural: "codebasebranches", singular: "codebasebranch" },
+        versions: [{ name: "v1", served: true, storage: true }],
+      },
+    });
+  });
+
+  it("maps a cluster-scoped entry to scope Cluster", () => {
+    expect(toSyntheticCRD({ ...entry, namespaced: false }).spec.scope).toBe("Cluster");
+  });
+});
+
+describe("useAccessibleCRCatalog", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches the catalog for the stored cluster/namespace and maps it to synthetic CRDs", async () => {
+    queryMock.mockResolvedValueOnce([entry]);
+    const { result } = renderHook(() => useAccessibleCRCatalog({ enabled: true }), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+    expect(queryMock).toHaveBeenCalledWith({ clusterName: "test-cluster", namespace: "edp-delivery" });
+    expect(result.current.data[0].metadata.name).toBe("codebasebranches.v2.edp.epam.com");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not fetch when disabled", () => {
+    const { result } = renderHook(() => useAccessibleCRCatalog({ enabled: false }), { wrapper: createWrapper() });
+
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("surfaces the query error with an empty data array", async () => {
+    queryMock.mockRejectedValueOnce(new Error("SSRR failed"));
+    const { result } = renderHook(() => useAccessibleCRCatalog({ enabled: true }), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("SSRR failed");
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useAccessibleCRCatalog.ts
+++ b/apps/client/src/modules/k8s/hooks/useAccessibleCRCatalog.ts
@@ -1,0 +1,75 @@
+import { useQuery } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
+import type { AccessibleCustomResource, CRDObject } from "@my-project/shared";
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import { getK8sAccessibleCustomResourcesQueryCacheKey } from "@/k8s/api/hooks/useWatch/query-keys";
+
+/**
+ * Maps a permission-derived catalog entry to a SYNTHETIC CRDObject so every existing
+ * CRD consumer (useCRDByGVR, buildCRDescriptor, CR list/detail views, sidebar) works
+ * unchanged. The synthetic object intentionally carries no schema or
+ * additionalPrinterColumns — catalog-path users get the default Name/Age columns.
+ * Admins keep the full CRD watch with real printer columns.
+ */
+export function toSyntheticCRD(cr: AccessibleCustomResource): CRDObject {
+  return {
+    apiVersion: "apiextensions.k8s.io/v1",
+    kind: "CustomResourceDefinition",
+    metadata: {
+      name: `${cr.plural}.${cr.group}`,
+      uid: `${cr.plural}.${cr.group}`,
+      // Real CRDs bump resourceVersion whenever spec.versions changes, which is what
+      // busts version-sensitive descriptor memos downstream (useCRList and friends).
+      // The synthetic object has no API server to do that, so encode the served
+      // version here — a catalog refetch that changes the served version for the
+      // same GVR must invalidate the descriptor instead of hitting a removed API
+      // version.
+      resourceVersion: cr.version,
+      creationTimestamp: "",
+    },
+    spec: {
+      group: cr.group,
+      scope: cr.namespaced ? "Namespaced" : "Cluster",
+      names: { kind: cr.kind, plural: cr.plural, singular: cr.singular },
+      versions: [{ name: cr.version, served: true, storage: true }],
+    },
+  };
+}
+
+// Stable fallback so useCRDCatalog's memo deps don't churn on every render
+// while the query has no data yet.
+const EMPTY_CATALOG: CRDObject[] = [];
+
+/**
+ * Fetches the SelfSubjectRulesReview ∩ discovery catalog and returns it as synthetic
+ * CRDObjects. Cached per (cluster, namespace); switching the default namespace
+ * refetches transparently. `enabled` is driven by useCRDCatalog — the catalog is
+ * fetched only when the cluster-scoped CRD watch is forbidden.
+ */
+export function useAccessibleCRCatalog({ enabled }: { enabled: boolean }): {
+  data: CRDObject[];
+  isLoading: boolean;
+  error: Error | null;
+} {
+  const trpc = useTRPCClient();
+  const { clusterName, defaultNamespace: namespace } = useClusterStore(
+    useShallow((state) => ({
+      clusterName: state.clusterName,
+      defaultNamespace: state.defaultNamespace,
+    }))
+  );
+
+  const query = useQuery({
+    queryKey: getK8sAccessibleCustomResourcesQueryCacheKey(clusterName, namespace),
+    queryFn: async () => {
+      const list = await trpc.k8s.accessibleCustomResources.query({ clusterName, namespace });
+      return list.map(toSyntheticCRD);
+    },
+    enabled: enabled && !!clusterName && !!namespace,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  return { data: query.data ?? EMPTY_CATALOG, isLoading: query.isLoading, error: query.error };
+}

--- a/apps/client/src/modules/k8s/hooks/useCRDByGVR.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDByGVR.test.ts
@@ -11,11 +11,10 @@ const fakeCrd = {
   },
 };
 
-vi.mock("./useCRDList", () => ({
-  useCRDList: vi.fn(() => ({
-    data: { array: [fakeCrd], map: new Map([[fakeCrd.metadata.name, fakeCrd]]) },
+vi.mock("./useCRDCatalog", () => ({
+  useCRDCatalog: vi.fn(() => ({
+    data: { array: [fakeCrd] },
     isLoading: false,
-    isReady: true,
     error: null,
   })),
 }));
@@ -34,7 +33,7 @@ describe("useCRDByGVR", () => {
   });
 
   it("does NOT match a version that is served: false (deprecated)", async () => {
-    const { useCRDList } = await import("./useCRDList");
+    const { useCRDCatalog } = await import("./useCRDCatalog");
     const deprecatedCrd = {
       ...fakeCrd,
       spec: {
@@ -42,10 +41,9 @@ describe("useCRDByGVR", () => {
         versions: [{ name: "v1beta1", storage: false, served: false }],
       },
     };
-    (useCRDList as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce({
-      data: { array: [deprecatedCrd], map: new Map() },
+    (useCRDCatalog as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      data: { array: [deprecatedCrd] },
       isLoading: false,
-      isReady: true,
       error: null,
     });
     const { result } = renderHook(() => useCRDByGVR("tekton.dev", "v1beta1", "pipelineruns"));

--- a/apps/client/src/modules/k8s/hooks/useCRDByGVR.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDByGVR.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useCRDList } from "./useCRDList";
+import { useCRDCatalog } from "./useCRDCatalog";
 import type { CRDObject } from "@my-project/shared";
 
 export interface UseCRDByGVRResult {
@@ -9,7 +9,7 @@ export interface UseCRDByGVRResult {
 }
 
 export function useCRDByGVR(group: string, version: string, plural: string): UseCRDByGVRResult {
-  const watch = useCRDList();
+  const watch = useCRDCatalog();
   const crd = useMemo(
     () =>
       watch.data.array.find(

--- a/apps/client/src/modules/k8s/hooks/useCRDCatalog.test.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDCatalog.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { CRDObject } from "@my-project/shared";
+
+const watchMock = vi.fn();
+const catalogMock = vi.fn();
+vi.mock("./useCRDList", () => ({ useCRDList: () => watchMock() }));
+vi.mock("./useAccessibleCRCatalog", () => ({
+  useAccessibleCRCatalog: (opts: { enabled: boolean }) => catalogMock(opts),
+}));
+
+import { useCRDCatalog } from "./useCRDCatalog";
+
+const watchCrd = { metadata: { name: "from-watch" } } as CRDObject;
+const catalogCrd = { metadata: { name: "from-catalog" } } as CRDObject;
+
+const forbiddenError = Object.assign(new Error("FORBIDDEN"), { data: { code: "FORBIDDEN" } });
+const serverError = Object.assign(new Error("boom"), { data: { code: "INTERNAL_SERVER_ERROR" } });
+
+const watchResult = (overrides: object) => ({
+  data: { array: [], map: new Map() },
+  isLoading: false,
+  isReady: true,
+  error: null,
+  ...overrides,
+});
+
+const catalogResult = (overrides: object) => ({ data: [], isLoading: false, error: null, ...overrides });
+
+describe("useCRDCatalog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    catalogMock.mockReturnValue(catalogResult({}));
+  });
+
+  it("uses the CRD watch and keeps the catalog disabled when the watch succeeds (admin path)", () => {
+    watchMock.mockReturnValue(watchResult({ data: { array: [watchCrd], map: new Map() } }));
+
+    const { result } = renderHook(() => useCRDCatalog());
+
+    expect(catalogMock).toHaveBeenCalledWith({ enabled: false });
+    expect(result.current).toEqual({ data: { array: [watchCrd] }, isLoading: false, error: null });
+  });
+
+  it("falls back to the accessible-CR catalog when the watch is FORBIDDEN", () => {
+    watchMock.mockReturnValue(watchResult({ error: forbiddenError }));
+    catalogMock.mockReturnValue(catalogResult({ data: [catalogCrd] }));
+
+    const { result } = renderHook(() => useCRDCatalog());
+
+    expect(catalogMock).toHaveBeenCalledWith({ enabled: true });
+    expect(result.current).toEqual({ data: { array: [catalogCrd] }, isLoading: false, error: null });
+  });
+
+  it("does NOT fall back on a non-FORBIDDEN watch error and propagates it (transient outage)", () => {
+    watchMock.mockReturnValue(watchResult({ error: serverError }));
+
+    const { result } = renderHook(() => useCRDCatalog());
+
+    expect(catalogMock).toHaveBeenCalledWith({ enabled: false });
+    expect(result.current.error).toBe(serverError);
+    expect(result.current.data.array).toEqual([]);
+  });
+
+  it("surfaces the catalog error when both the watch and the fallback fail", () => {
+    const catalogError = new Error("catalog failed");
+    watchMock.mockReturnValue(watchResult({ error: forbiddenError }));
+    catalogMock.mockReturnValue(catalogResult({ error: catalogError }));
+
+    const { result } = renderHook(() => useCRDCatalog());
+
+    expect(result.current.error).toBe(catalogError);
+  });
+
+  it("reports loading while the CRD watch is still pending", () => {
+    watchMock.mockReturnValue(watchResult({ isLoading: true }));
+
+    const { result } = renderHook(() => useCRDCatalog());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("reports loading while the fallback catalog is fetching", () => {
+    watchMock.mockReturnValue(watchResult({ error: forbiddenError }));
+    catalogMock.mockReturnValue(catalogResult({ isLoading: true }));
+
+    const { result } = renderHook(() => useCRDCatalog());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns a stable identity across renders when inputs are unchanged", () => {
+    const stableWatch = watchResult({ data: { array: [watchCrd], map: new Map() } });
+    watchMock.mockReturnValue(stableWatch);
+
+    const { result, rerender } = renderHook(() => useCRDCatalog());
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/apps/client/src/modules/k8s/hooks/useCRDCatalog.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDCatalog.ts
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import type { CRDObject } from "@my-project/shared";
+import { useCRDList } from "./useCRDList";
+import { useAccessibleCRCatalog } from "./useAccessibleCRCatalog";
+
+export interface UseCRDCatalogResult {
+  /**
+   * Intentionally narrower than the watch result: no `map` — this is a catalog,
+   * not a watch, and neither consumer (sidebar, useCRDByGVR) needs the map.
+   */
+  data: { array: CRDObject[] };
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Single source of truth for the CRD catalog, RBAC-adaptive:
+ *  - admins who can list CRDs cluster-wide  → live CRD watch (full spec, printer columns)
+ *  - restricted users (CRD list FORBIDDEN)  → SelfSubjectRulesReview ∩ discovery
+ *    catalog rendered as synthetic CRDObjects
+ *
+ * Returns the same shape useCRDList consumers already use, so useCRSidebarItems and
+ * useCRDByGVR swap to it with a one-line change.
+ */
+export function useCRDCatalog(): UseCRDCatalogResult {
+  const watch = useCRDList();
+  // FORBIDDEN is the precise fallback signal: the cluster-scoped CRD watch 403s for
+  // users without cluster-wide CRD list rights (handleK8sError maps 403 → FORBIDDEN).
+  // Any other failure (timeout, 5xx) keeps the normal error path — falling back there
+  // would render a restricted catalog for admins during a transient outage.
+  const forbidden = watch.error?.data?.code === "FORBIDDEN";
+  const catalog = useAccessibleCRCatalog({ enabled: forbidden });
+
+  const array = forbidden ? catalog.data : watch.data.array;
+  const error = forbidden ? catalog.error : watch.error;
+  const isLoading = watch.isLoading || (forbidden && catalog.isLoading);
+
+  return useMemo(() => ({ data: { array }, isLoading, error }), [array, isLoading, error]);
+}

--- a/apps/client/src/modules/k8s/hooks/useCRDList.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRDList.ts
@@ -2,9 +2,9 @@ import { k8sCustomResourceDefinitionConfig, type CRDObject } from "@my-project/s
 import { useWatchList } from "@/k8s/api/hooks/useWatch/useWatchList";
 
 /**
- * Watches every CRD in the cluster. Used by the CR sidebar hook and by
- * useCRDByGVR. Both callers MUST NOT pass labels — the watch-sharing
- * invariant requires identical TanStack Query keys.
+ * Watches every CRD in the cluster. Consumed only through useCRDCatalog (which
+ * serves the CR sidebar hook and useCRDByGVR). Callers MUST NOT pass labels —
+ * the watch-sharing invariant requires identical TanStack Query keys.
  */
 export function useCRDList() {
   return useWatchList<CRDObject>({ resourceConfig: k8sCustomResourceDefinitionConfig });

--- a/packages/shared/src/models/k8s/common/constants.ts
+++ b/packages/shared/src/models/k8s/common/constants.ts
@@ -36,6 +36,49 @@ export const defaultPermissionsToCheck = [
   k8sOperation.delete,
 ] as const;
 
+/**
+ * API groups that are built in or aggregated (not CRD-backed). Excluded from the
+ * permission-derived "Custom Resources" catalog so it lists only custom resources,
+ * matching the admin CRD-watch behaviour.
+ */
+export const BUILTIN_API_GROUPS = new Set<string>([
+  "", // core
+  "apps",
+  "batch",
+  "autoscaling",
+  "policy",
+  "extensions",
+  "networking.k8s.io",
+  "discovery.k8s.io",
+  "coordination.k8s.io",
+  "node.k8s.io",
+  "events.k8s.io",
+  "certificates.k8s.io",
+  "rbac.authorization.k8s.io",
+  "scheduling.k8s.io",
+  "storage.k8s.io",
+  "admissionregistration.k8s.io",
+  "apiextensions.k8s.io",
+  "apiregistration.k8s.io",
+  "authentication.k8s.io",
+  "authorization.k8s.io",
+  "flowcontrol.apiserver.k8s.io",
+  "internal.apiserver.k8s.io",
+  "metrics.k8s.io",
+  "resource.k8s.io",
+  "storagemigration.k8s.io",
+]);
+
+/** RBAC verbs that imply the user can MODIFY a resource (drives AccessibleCustomResource.editable). */
+export const CR_WRITE_VERBS = new Set<string>([
+  rbacOperation.create,
+  rbacOperation.update,
+  rbacOperation.patch,
+  rbacOperation.delete,
+  rbacOperation.deletecollection,
+  "*",
+]);
+
 export const defaultPermissions = {
   [k8sOperation.create]: {
     allowed: false,

--- a/packages/shared/src/models/k8s/common/types.ts
+++ b/packages/shared/src/models/k8s/common/types.ts
@@ -60,3 +60,34 @@ export type DefaultPermissionListCheckResult = Record<
 
 export type K8sOperation = ValueOf<typeof k8sOperation>;
 export type RBACOperation = ValueOf<typeof rbacOperation>;
+
+/**
+ * A custom-resource TYPE the signed-in user can access, derived from
+ * SelfSubjectRulesReview ∩ API discovery. Powers the permission-aware
+ * "Custom Resources" catalog for users who cannot list CRDs cluster-wide.
+ */
+export interface AccessibleCustomResource {
+  /** API group, e.g. "v2.edp.epam.com" */
+  group: string;
+  /**
+   * Served version from discovery, e.g. "v1" — the group's preferred version when
+   * the type is served there, otherwise the highest-priority version serving it.
+   */
+  version: string;
+  /** Resource plural, e.g. "codebasebranches" */
+  plural: string;
+  /** Kind from discovery, e.g. "CodebaseBranch" */
+  kind: string;
+  /** Singular name from discovery; falls back to the lowercase kind when discovery omits it */
+  singular: string;
+  /** Scope from discovery */
+  namespaced: boolean;
+  /** User's RBAC verbs from the rules review, e.g. ["*"] or ["get", "list", "watch"] */
+  verbs: string[];
+  /**
+   * Whether `verbs` includes a write verb (see CR_WRITE_VERBS). Informational —
+   * the client gates editing with per-resource SelfSubjectAccessReview
+   * (usePermissions), which stays the authoritative source.
+   */
+  editable: boolean;
+}

--- a/packages/trpc/src/routers/k8s/index.ts
+++ b/packages/trpc/src/routers/k8s/index.ts
@@ -6,6 +6,7 @@ import { k8sGetProcedure } from "./procedures/basic/get/index.js";
 import { k8sGetKubeConfig } from "./procedures/kubeconfig/index.js";
 import { k8sListProcedure } from "./procedures/basic/list/index.js";
 import { k8sGetResourcePermissions } from "./procedures/permissions/index.js";
+import { k8sAccessibleCustomResourcesProcedure } from "./procedures/accessibleCustomResources/index.js";
 import { k8sUpdateItemProcedure } from "./procedures/basic/update/index.js";
 import { k8sScaleWorkloadProcedure } from "./procedures/workloads/scale/index.js";
 import { k8sRestartWorkloadProcedure } from "./procedures/workloads/restart/index.js";
@@ -51,6 +52,7 @@ export const k8sRouter = t.router({
   rollbackDeployment: k8sRollbackDeploymentProcedure,
   apiVersions: k8sGetApiVersions,
   itemPermissions: k8sGetResourcePermissions,
+  accessibleCustomResources: k8sAccessibleCustomResourcesProcedure,
   kubeconfig: k8sGetKubeConfig,
   clusterDetails: k8sGetClusterDetails,
   podLogs: k8sPodLogsProcedure,

--- a/packages/trpc/src/routers/k8s/procedures/accessibleCustomResources/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/accessibleCustomResources/index.test.ts
@@ -1,0 +1,304 @@
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { K8sClient } from "../../../../clients/k8s/index.js";
+import type { V1ResourceRule } from "@kubernetes/client-node";
+
+// Mock K8sClient at module level
+vi.mock("../../../../clients/k8s/index.js", () => {
+  return {
+    K8sClient: vi.fn(),
+  };
+});
+
+const input = { clusterName: "test-cluster", namespace: "edp-delivery" };
+
+const ssrrResponse = (resourceRules: V1ResourceRule[], extra: { evaluationError?: string } = {}) => ({
+  status: {
+    incomplete: true,
+    resourceRules,
+    nonResourceRules: [],
+    ...extra,
+  },
+});
+
+const apiGroupList = {
+  groups: [
+    {
+      name: "v2.edp.epam.com",
+      preferredVersion: { groupVersion: "v2.edp.epam.com/v1", version: "v1" },
+      versions: [{ groupVersion: "v2.edp.epam.com/v1", version: "v1" }],
+    },
+    {
+      name: "v1.edp.epam.com",
+      preferredVersion: { groupVersion: "v1.edp.epam.com/v1alpha1", version: "v1alpha1" },
+      versions: [{ groupVersion: "v1.edp.epam.com/v1alpha1", version: "v1alpha1" }],
+    },
+  ],
+};
+
+const v2ResourceList = {
+  resources: [
+    { name: "codebasebranches", singularName: "codebasebranch", namespaced: true, kind: "CodebaseBranch" },
+    { name: "codebasebranches/status", singularName: "", namespaced: true, kind: "CodebaseBranch" },
+    { name: "stages", singularName: "", namespaced: true, kind: "Stage" },
+  ],
+};
+
+const v1ResourceList = {
+  resources: [
+    { name: "clusterkeycloaks", singularName: "clusterkeycloak", namespaced: false, kind: "ClusterKeycloak" },
+  ],
+};
+
+describe("k8sAccessibleCustomResourcesProcedure", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+
+  let mockAuthApi: {
+    createSelfSubjectRulesReview: Mock;
+  };
+
+  let mockKubeConfig: {
+    makeApiClient: Mock;
+  };
+
+  let mockFetchApiPath: Mock;
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+
+    mockAuthApi = {
+      createSelfSubjectRulesReview: vi.fn(),
+    };
+
+    mockKubeConfig = {
+      makeApiClient: vi.fn().mockReturnValue(mockAuthApi),
+    };
+
+    mockFetchApiPath = vi.fn().mockImplementation((path: string) => {
+      if (path === "/apis") return Promise.resolve(apiGroupList);
+      if (path === "/apis/v2.edp.epam.com/v1") return Promise.resolve(v2ResourceList);
+      if (path === "/apis/v1.edp.epam.com/v1alpha1") return Promise.resolve(v1ResourceList);
+      return Promise.reject(new Error(`Unexpected discovery path: ${path}`));
+    });
+
+    // Mock K8sClient constructor to return an object with KubeConfig + fetchApiPath
+    (K8sClient as unknown as Mock).mockImplementation(function () {
+      return { KubeConfig: mockKubeConfig, fetchApiPath: mockFetchApiPath };
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("intersects SSRR rules with discovery and returns the catalog sorted by group then kind", async () => {
+    mockAuthApi.createSelfSubjectRulesReview.mockResolvedValue(
+      ssrrResponse([
+        { apiGroups: ["v2.edp.epam.com"], resources: ["codebasebranches"], verbs: ["*"] },
+        { apiGroups: ["v2.edp.epam.com"], resources: ["stages"], verbs: ["get", "list", "watch"] },
+        { apiGroups: ["v1.edp.epam.com"], resources: ["clusterkeycloaks"], verbs: ["get", "list", "watch"] },
+        // Built-in group rule must be ignored entirely.
+        { apiGroups: ["apps"], resources: ["deployments"], verbs: ["*"] },
+      ])
+    );
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.accessibleCustomResources(input);
+
+    expect(mockAuthApi.createSelfSubjectRulesReview).toHaveBeenCalledWith({
+      body: {
+        apiVersion: "authorization.k8s.io/v1",
+        kind: "SelfSubjectRulesReview",
+        spec: { namespace: "edp-delivery" },
+      },
+    });
+
+    expect(result).toEqual([
+      {
+        group: "v1.edp.epam.com",
+        version: "v1alpha1",
+        plural: "clusterkeycloaks",
+        kind: "ClusterKeycloak",
+        singular: "clusterkeycloak",
+        namespaced: false,
+        verbs: ["get", "list", "watch"],
+        editable: false,
+      },
+      {
+        group: "v2.edp.epam.com",
+        version: "v1",
+        plural: "codebasebranches",
+        kind: "CodebaseBranch",
+        singular: "codebasebranch",
+        namespaced: true,
+        verbs: ["*"],
+        editable: true,
+      },
+      {
+        group: "v2.edp.epam.com",
+        version: "v1",
+        plural: "stages",
+        kind: "Stage",
+        // Discovery returned an empty singularName — falls back to lowercase kind.
+        singular: "stage",
+        namespaced: true,
+        verbs: ["get", "list", "watch"],
+        editable: false,
+      },
+    ]);
+  });
+
+  it("expands a per-group resources wildcard against discovery, merging explicit verbs", async () => {
+    mockAuthApi.createSelfSubjectRulesReview.mockResolvedValue(
+      ssrrResponse([
+        { apiGroups: ["v2.edp.epam.com"], resources: ["*"], verbs: ["get", "list"] },
+        { apiGroups: ["v2.edp.epam.com"], resources: ["codebasebranches"], verbs: ["update"] },
+      ])
+    );
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.accessibleCustomResources(input);
+
+    // Subresource codebasebranches/status must not appear.
+    expect(result.map((r) => r.plural)).toEqual(["codebasebranches", "stages"]);
+    const codebaseBranches = result.find((r) => r.plural === "codebasebranches")!;
+    expect(codebaseBranches.verbs.sort()).toEqual(["get", "list", "update"]);
+    expect(codebaseBranches.editable).toBe(true);
+    const stages = result.find((r) => r.plural === "stages")!;
+    expect(stages.verbs.sort()).toEqual(["get", "list"]);
+    expect(stages.editable).toBe(false);
+  });
+
+  it("catalogs a plural served only in a non-preferred version, preferring the preferred one otherwise", async () => {
+    const multiVersionGroupList = {
+      groups: [
+        {
+          name: "tekton.dev",
+          preferredVersion: { groupVersion: "tekton.dev/v1", version: "v1" },
+          versions: [
+            { groupVersion: "tekton.dev/v1", version: "v1" },
+            { groupVersion: "tekton.dev/v1beta1", version: "v1beta1" },
+          ],
+        },
+      ],
+    };
+    mockFetchApiPath.mockImplementation((path: string) => {
+      if (path === "/apis") return Promise.resolve(multiVersionGroupList);
+      if (path === "/apis/tekton.dev/v1")
+        return Promise.resolve({
+          resources: [{ name: "pipelineruns", singularName: "pipelinerun", namespaced: true, kind: "PipelineRun" }],
+        });
+      if (path === "/apis/tekton.dev/v1beta1")
+        return Promise.resolve({
+          resources: [
+            // Served in both versions — must be cataloged once, at the preferred version.
+            { name: "pipelineruns", singularName: "pipelinerun", namespaced: true, kind: "PipelineRun" },
+            // Served ONLY at v1beta1 — the RBAC grant is real, so it must still appear.
+            { name: "clustertasks", singularName: "clustertask", namespaced: false, kind: "ClusterTask" },
+          ],
+        });
+      return Promise.reject(new Error(`Unexpected discovery path: ${path}`));
+    });
+    mockAuthApi.createSelfSubjectRulesReview.mockResolvedValue(
+      ssrrResponse([{ apiGroups: ["tekton.dev"], resources: ["pipelineruns", "clustertasks"], verbs: ["get", "list"] }])
+    );
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.accessibleCustomResources(input);
+
+    expect(result.map((r) => `${r.plural}@${r.version}`)).toEqual(["clustertasks@v1beta1", "pipelineruns@v1"]);
+  });
+
+  it("returns an empty catalog instead of failing when /apis responds without a groups field", async () => {
+    mockAuthApi.createSelfSubjectRulesReview.mockResolvedValue(
+      ssrrResponse([{ apiGroups: ["v2.edp.epam.com"], resources: ["stages"], verbs: ["get", "list"] }])
+    );
+    mockFetchApiPath.mockImplementation((path: string) => {
+      if (path === "/apis") return Promise.resolve({});
+      return Promise.reject(new Error(`Unexpected discovery path: ${path}`));
+    });
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.k8s.accessibleCustomResources(input)).resolves.toEqual([]);
+  });
+
+  it("drops stale rules: unknown groups and plurals not served in any version of the group", async () => {
+    mockAuthApi.createSelfSubjectRulesReview.mockResolvedValue(
+      ssrrResponse([
+        { apiGroups: ["gone.example.com"], resources: ["ghosts"], verbs: ["*"] },
+        { apiGroups: ["v2.edp.epam.com"], resources: ["removedthings"], verbs: ["*"] },
+      ])
+    );
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.accessibleCustomResources(input);
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips a group whose discovery call fails and still returns the rest", async () => {
+    mockAuthApi.createSelfSubjectRulesReview.mockResolvedValue(
+      ssrrResponse([
+        { apiGroups: ["v2.edp.epam.com"], resources: ["stages"], verbs: ["get", "list"] },
+        { apiGroups: ["v1.edp.epam.com"], resources: ["clusterkeycloaks"], verbs: ["get"] },
+      ])
+    );
+    mockFetchApiPath.mockImplementation((path: string) => {
+      if (path === "/apis") return Promise.resolve(apiGroupList);
+      if (path === "/apis/v2.edp.epam.com/v1") return Promise.reject(new Error("boom"));
+      if (path === "/apis/v1.edp.epam.com/v1alpha1") return Promise.resolve(v1ResourceList);
+      return Promise.reject(new Error(`Unexpected discovery path: ${path}`));
+    });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.accessibleCustomResources(input);
+
+    expect(result.map((r) => r.plural)).toEqual(["clusterkeycloaks"]);
+  });
+
+  it("returns [] without calling discovery when no catalog-eligible rules exist", async () => {
+    mockAuthApi.createSelfSubjectRulesReview.mockResolvedValue(
+      ssrrResponse([{ apiGroups: ["apps"], resources: ["deployments"], verbs: ["*"] }])
+    );
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.accessibleCustomResources(input);
+
+    expect(result).toEqual([]);
+    expect(mockFetchApiPath).not.toHaveBeenCalled();
+  });
+
+  it("logs the SSRR evaluationError but still returns the rules-derived catalog", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockAuthApi.createSelfSubjectRulesReview.mockResolvedValue(
+      ssrrResponse([{ apiGroups: ["v2.edp.epam.com"], resources: ["stages"], verbs: ["get", "list"] }], {
+        evaluationError: "webhook authorizer does not support user rule resolution",
+      })
+    );
+
+    const caller = createCaller(mockContext);
+    const result = await caller.k8s.accessibleCustomResources(input);
+
+    expect(result.map((r) => r.plural)).toEqual(["stages"]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("webhook authorizer does not support"));
+    warnSpy.mockRestore();
+  });
+
+  it("throws when the SelfSubjectRulesReview call fails", async () => {
+    mockAuthApi.createSelfSubjectRulesReview.mockRejectedValueOnce(new Error("Kubernetes API unavailable"));
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.k8s.accessibleCustomResources(input)).rejects.toThrow("Kubernetes API unavailable");
+  });
+
+  it("throws a validation error for missing input fields", async () => {
+    const caller = createCaller(mockContext);
+
+    await expect(
+      caller.k8s.accessibleCustomResources({ clusterName: "test-cluster" } as unknown as typeof input)
+    ).rejects.toThrow();
+  });
+});

--- a/packages/trpc/src/routers/k8s/procedures/accessibleCustomResources/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/accessibleCustomResources/index.ts
@@ -1,0 +1,144 @@
+import {
+  AuthorizationV1Api,
+  type V1APIGroup,
+  type V1APIGroupList,
+  type V1APIResourceList,
+} from "@kubernetes/client-node";
+import { z } from "zod";
+import { CR_WRITE_VERBS, type AccessibleCustomResource } from "@my-project/shared";
+import { protectedProcedure } from "../../../../procedures/protected/index.js";
+import { getInitializedK8sClient } from "../../utils/getInitializedK8sClient/index.js";
+import { rethrowOrHandleK8sError } from "../../utils/handleK8sError/index.js";
+import { mapRulesToCatalog, WILDCARD_RESOURCE } from "./mapRulesToCatalog.js";
+
+/**
+ * Intersect one group's RBAC plurals with its discovery documents. Preferred
+ * version first: when a plural is served in several versions, the catalog
+ * reports the preferred one. The remaining served versions are still scanned
+ * because a type may be served ONLY there (e.g. a resource that never graduated
+ * past v1beta1 while the group's preferred version moved to v1) — the RBAC
+ * grant for it is real, and the admin CRD-watch path shows it.
+ */
+async function catalogGroup(
+  k8sClient: ReturnType<typeof getInitializedK8sClient>,
+  group: string,
+  meta: V1APIGroup,
+  plurals: Map<string, string[]>
+): Promise<AccessibleCustomResource[]> {
+  const versions = Array.from(
+    new Set([meta.preferredVersion?.version, ...(meta.versions ?? []).map((v) => v.version)])
+  ).filter((version): version is string => !!version);
+
+  const docs = await Promise.all(
+    versions.map(async (version) => {
+      try {
+        return { version, list: await k8sClient.fetchApiPath<V1APIResourceList>(`/apis/${group}/${version}`) };
+      } catch {
+        return null; // one version's discovery failed — skip it
+      }
+    })
+  );
+
+  const wildcardVerbs = plurals.get(WILDCARD_RESOURCE);
+  const cataloged = new Set<string>();
+  const entries: AccessibleCustomResource[] = [];
+  for (const doc of docs) {
+    if (!doc) continue;
+    for (const served of doc.list.resources ?? []) {
+      if (served.name.includes("/")) continue; // subresource
+      if (cataloged.has(served.name)) continue; // already matched at a higher-priority version
+      const explicitVerbs = plurals.get(served.name);
+      // A type makes it into the catalog only when RBAC names it explicitly
+      // or grants the whole group via resources:["*"]; plurals not served in
+      // ANY of the group's versions are dropped (stale rules).
+      if (!explicitVerbs && !wildcardVerbs) continue;
+      cataloged.add(served.name);
+      const verbs = Array.from(new Set([...(explicitVerbs ?? []), ...(wildcardVerbs ?? [])]));
+      entries.push({
+        group,
+        version: doc.version,
+        plural: served.name,
+        kind: served.kind,
+        // K8s convention: when discovery omits the singular (common for CRDs),
+        // it defaults to the lowercase kind — same fallback buildCRDescriptor uses.
+        singular: served.singularName || served.kind.toLowerCase(),
+        namespaced: served.namespaced,
+        verbs,
+        editable: verbs.some((verb) => CR_WRITE_VERBS.has(verb)),
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Permission-aware catalog of custom-resource TYPES for users who cannot list
+ * CRDs cluster-wide: one SelfSubjectRulesReview for the namespace, intersected
+ * with API discovery (/apis + /apis/<group>/<version> per served version of each
+ * accessible group). Read-only; per-resource editing stays gated by
+ * SelfSubjectAccessReview.
+ */
+export const k8sAccessibleCustomResourcesProcedure = protectedProcedure
+  .input(
+    z.object({
+      // Cache-key disambiguation only — like every k8s procedure, the server acts
+      // on the session's current cluster context.
+      clusterName: z.string(),
+      namespace: z.string(),
+    })
+  )
+  .query(async ({ input, ctx }): Promise<AccessibleCustomResource[]> => {
+    try {
+      const { namespace } = input;
+      const k8sClient = getInitializedK8sClient(ctx);
+      const authApi = k8sClient.KubeConfig.makeApiClient(AuthorizationV1Api);
+
+      // 1) One SelfSubjectRulesReview = the user's entire effective RBAC for this namespace.
+      const review = await authApi.createSelfSubjectRulesReview({
+        body: {
+          apiVersion: "authorization.k8s.io/v1",
+          kind: "SelfSubjectRulesReview",
+          spec: { namespace },
+        },
+      });
+      const status = review.status;
+      // `incomplete: true` is expected on clusters with an external-authz webhook
+      // (it cannot enumerate); the rules that ARE returned come straight from RBAC
+      // and are trusted as-is. Never fail open to the full cluster catalog here.
+      if (status?.evaluationError) {
+        console.warn(`[accessibleCustomResources] SSRR evaluationError (ns=${namespace}): ${status.evaluationError}`);
+      }
+
+      const byGroup = mapRulesToCatalog(status?.resourceRules ?? []);
+      if (byGroup.size === 0) return [];
+
+      // 2) Discovery for ONLY the candidate groups (bounded): one /apis + one
+      //    /apis/<group>/<version> per served version of each candidate group.
+      const apiGroupList = await k8sClient.fetchApiPath<V1APIGroupList>("/apis");
+      // fetchApiPath blind-casts the body, so a degraded /apis response without
+      // `groups` must degrade to an empty catalog, not a 500.
+      const groupMeta = new Map((apiGroupList.groups ?? []).map((group) => [group.name, group]));
+
+      const result: AccessibleCustomResource[] = [];
+      await Promise.all(
+        Array.from(byGroup.entries()).map(async ([group, plurals]) => {
+          const meta = groupMeta.get(group);
+          if (!meta) return; // stale RBAC rule — group no longer served
+          try {
+            result.push(...(await catalogGroup(k8sClient, group, meta, plurals)));
+          } catch (error) {
+            // One broken group must not fail the whole request.
+            console.warn(`[accessibleCustomResources] skipping group ${group} (ns=${namespace}): ${String(error)}`);
+          }
+        })
+      );
+
+      // Kind uniqueness within a group is conventional, not enforced — plural breaks ties.
+      result.sort(
+        (a, b) => a.group.localeCompare(b.group) || a.kind.localeCompare(b.kind) || a.plural.localeCompare(b.plural)
+      );
+      return result;
+    } catch (error) {
+      throw rethrowOrHandleK8sError(error);
+    }
+  });

--- a/packages/trpc/src/routers/k8s/procedures/accessibleCustomResources/mapRulesToCatalog.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/accessibleCustomResources/mapRulesToCatalog.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { V1ResourceRule } from "@kubernetes/client-node";
+import { mapRulesToCatalog, WILDCARD_RESOURCE } from "./mapRulesToCatalog.js";
+
+const rule = (overrides: Partial<V1ResourceRule>): V1ResourceRule => ({
+  verbs: ["get", "list", "watch"],
+  ...overrides,
+});
+
+describe("mapRulesToCatalog", () => {
+  it("groups custom-resource rules by group and plural with their verbs", () => {
+    const result = mapRulesToCatalog([
+      rule({ apiGroups: ["v2.edp.epam.com"], resources: ["codebasebranches"], verbs: ["*"] }),
+      rule({
+        apiGroups: ["v2.edp.epam.com"],
+        resources: ["stages", "cdpipelines"],
+        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"],
+      }),
+      rule({ apiGroups: ["v1.edp.epam.com"], resources: ["clusterkeycloaks"] }),
+    ]);
+
+    expect(Array.from(result.keys()).sort()).toEqual(["v1.edp.epam.com", "v2.edp.epam.com"]);
+    const v2 = result.get("v2.edp.epam.com")!;
+    expect(v2.get("codebasebranches")).toEqual(["*"]);
+    expect(v2.get("stages")).toEqual(["get", "list", "watch", "create", "update", "patch", "delete"]);
+    expect(v2.get("cdpipelines")).toEqual(["get", "list", "watch", "create", "update", "patch", "delete"]);
+    expect(result.get("v1.edp.epam.com")!.get("clusterkeycloaks")).toEqual(["get", "list", "watch"]);
+  });
+
+  it("excludes the core group and built-in/aggregated groups", () => {
+    const result = mapRulesToCatalog([
+      rule({ apiGroups: [""], resources: ["pods"] }),
+      rule({ apiGroups: ["apps"], resources: ["deployments"] }),
+      rule({ apiGroups: ["authorization.k8s.io"], resources: ["selfsubjectrulesreviews"], verbs: ["create"] }),
+      rule({ apiGroups: ["metrics.k8s.io"], resources: ["pods"] }),
+    ]);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("excludes wildcard apiGroups entirely", () => {
+    const result = mapRulesToCatalog([rule({ apiGroups: ["*"], resources: ["codebasebranches"] })]);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("excludes the wildcard group but keeps specific groups from the same rule", () => {
+    const result = mapRulesToCatalog([
+      rule({ apiGroups: ["*", "v2.edp.epam.com"], resources: ["codebasebranches"], verbs: ["get"] }),
+    ]);
+
+    expect(Array.from(result.keys())).toEqual(["v2.edp.epam.com"]);
+    expect(result.get("v2.edp.epam.com")!.get("codebasebranches")).toEqual(["get"]);
+  });
+
+  it("keeps a per-group resources wildcard under the sentinel key", () => {
+    const result = mapRulesToCatalog([
+      rule({ apiGroups: ["v2.edp.epam.com"], resources: ["*"], verbs: ["get", "list"] }),
+    ]);
+
+    expect(result.get("v2.edp.epam.com")!.get(WILDCARD_RESOURCE)).toEqual(["get", "list"]);
+  });
+
+  it("excludes subresources", () => {
+    const result = mapRulesToCatalog([
+      rule({ apiGroups: ["v2.edp.epam.com"], resources: ["codebases/status", "pods/log"] }),
+    ]);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("excludes instance-scoped grants (resourceNames non-empty)", () => {
+    const result = mapRulesToCatalog([
+      rule({ apiGroups: ["v2.edp.epam.com"], resources: ["codebasebranches"], resourceNames: ["main"] }),
+    ]);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("merges and dedupes verbs from multiple rules for the same group/plural", () => {
+    const result = mapRulesToCatalog([
+      rule({ apiGroups: ["v2.edp.epam.com"], resources: ["stages"], verbs: ["get", "list"] }),
+      rule({ apiGroups: ["v2.edp.epam.com"], resources: ["stages"], verbs: ["list", "update"] }),
+    ]);
+
+    expect(result.get("v2.edp.epam.com")!.get("stages")).toEqual(["get", "list", "update"]);
+  });
+
+  it("tolerates rules with missing optional fields", () => {
+    const result = mapRulesToCatalog([
+      { verbs: ["get"] },
+      { verbs: ["get"], apiGroups: ["v2.edp.epam.com"] },
+      { verbs: [], apiGroups: ["v2.edp.epam.com"], resources: ["stages"] },
+    ]);
+
+    expect(result.get("v2.edp.epam.com")!.get("stages")).toEqual([]);
+  });
+
+  it("returns an empty map for no rules", () => {
+    expect(mapRulesToCatalog([]).size).toBe(0);
+  });
+});

--- a/packages/trpc/src/routers/k8s/procedures/accessibleCustomResources/mapRulesToCatalog.ts
+++ b/packages/trpc/src/routers/k8s/procedures/accessibleCustomResources/mapRulesToCatalog.ts
@@ -1,0 +1,55 @@
+import { BUILTIN_API_GROUPS } from "@my-project/shared";
+import type { V1ResourceRule } from "@kubernetes/client-node";
+
+/**
+ * Sentinel plural key for a per-group `resources: ["*"]` grant. "*" is not a legal
+ * resource name, so it can never collide with a real plural. The procedure expands
+ * it against the group's discovery documents (the per-version calls it already makes).
+ */
+export const WILDCARD_RESOURCE = "*";
+
+/**
+ * Collapse SelfSubjectRulesReview resourceRules into group → plural → verbs[],
+ * applying the catalog filters:
+ *  - drop the core group ("") and built-in/aggregated groups (BUILTIN_API_GROUPS)
+ *  - drop wildcard apiGroups ("*") — expanding them needs discovery across every
+ *    group on the cluster. Users with apiGroups:["*"] AND resources:["*"] can list
+ *    CRDs cluster-wide and take the CRD-watch path anyway. Known false negative:
+ *    a grant of apiGroups:["*"] with specific resource names (rare, but legal
+ *    RBAC) cannot list CRDs, and those types won't appear in the catalog unless
+ *    another rule names their group explicitly
+ *  - keep a per-group resources wildcard under the WILDCARD_RESOURCE sentinel key —
+ *    unlike a cluster-wide wildcard it expands with the per-version discovery calls
+ *    catalogGroup already makes for the group
+ *  - drop subresources (resource name contains "/", e.g. "pods/log")
+ *  - drop instance-scoped grants (rule.resourceNames non-empty) — listing the type
+ *    would 403 for everything but those named objects, misleading in a list view
+ */
+export function mapRulesToCatalog(rules: V1ResourceRule[]): Map<string, Map<string, string[]>> {
+  const byGroup = new Map<string, Map<string, Set<string>>>();
+  for (const rule of rules) {
+    if (rule.resourceNames && rule.resourceNames.length > 0) continue;
+    const apiGroups = rule.apiGroups ?? [];
+    const resources = rule.resources ?? [];
+    const verbs = rule.verbs ?? [];
+    for (const group of apiGroups) {
+      if (group === "*" || BUILTIN_API_GROUPS.has(group)) continue;
+      for (const resource of resources) {
+        if (resource !== WILDCARD_RESOURCE && resource.includes("/")) continue;
+        const plurals = byGroup.get(group) ?? new Map<string, Set<string>>();
+        const set = plurals.get(resource) ?? new Set<string>();
+        verbs.forEach((v) => set.add(v));
+        plurals.set(resource, set);
+        byGroup.set(group, plurals);
+      }
+    }
+  }
+  // Freeze Sets → string[] for a stable return type.
+  const out = new Map<string, Map<string, string[]>>();
+  for (const [group, plurals] of byGroup) {
+    const m = new Map<string, string[]>();
+    for (const [plural, set] of plurals) m.set(plural, Array.from(set));
+    out.set(group, m);
+  }
+  return out;
+}


### PR DESCRIPTION
Users whose RBAC does not allow listing CRDs cluster-wide previously saw an empty Custom Resources section because the sidebar and CR views depended entirely on the cluster-scoped CRD watch.

- derive an accessible-CR catalog on the server from SelfSubjectRulesReview intersected with API discovery, scanning every served version of each candidate group (preferred version first) so types served only in non-preferred versions are not dropped
- exclude built-in/aggregated groups, subresources, and instance-scoped grants; degrade per group on discovery failures instead of failing the whole request
- fall back transparently on the client: useCRDCatalog serves the live CRD watch for admins and synthetic CRD objects from the catalog when the watch is FORBIDDEN, so existing consumers (sidebar, CR list/detail) work unchanged
- cache the catalog per cluster and namespace; encode the served version into the synthetic object so descriptor memos invalidate when the catalog reports a new version
