### PR TITLE
EPMDEDP-16788: fix: align K8s mode list pages with KRCI list layout

### DIFF
--- a/apps/client/src/modules/k8s/components/BatchDeleteDialog/index.tsx
+++ b/apps/client/src/modules/k8s/components/BatchDeleteDialog/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { Trash } from "lucide-react";
 import { Button } from "@/core/components/ui/button";
 import {
   Dialog,
@@ -18,18 +17,27 @@ import type { K8sResourceConfig, KubeObjectBase } from "@my-project/shared";
 interface Props<T extends KubeObjectBase> {
   items: T[];
   config: K8sResourceConfig;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onDeleted?: () => void;
 }
 
-export function BatchDeleteAction<T extends KubeObjectBase>({ items, config, onDeleted }: Props<T>) {
-  const [open, setOpen] = useState(false);
+export function BatchDeleteDialog<T extends KubeObjectBase>({
+  items,
+  config,
+  open,
+  onOpenChange,
+  onDeleted,
+}: Props<T>) {
   const [busy, setBusy] = useState(false);
   const trpc = useTRPCClient();
   const { clusterName } = useClusterStore(useShallow((s) => ({ clusterName: s.clusterName })));
 
-  if (items.length === 0) return null;
-
   const handleConfirm = async () => {
+    // The items list is live: the watch stream can drain it to empty while the
+    // dialog is open (e.g. another actor deleted the selected resources).
+    if (items.length === 0) return;
+
     setBusy(true);
     const results = await Promise.allSettled(
       items.map((item) =>
@@ -42,7 +50,7 @@ export function BatchDeleteAction<T extends KubeObjectBase>({ items, config, onD
       )
     );
     setBusy(false);
-    setOpen(false);
+    onOpenChange(false);
 
     const failures = results
       .map((r, i) => ({ result: r, item: items[i] }))
@@ -65,38 +73,33 @@ export function BatchDeleteAction<T extends KubeObjectBase>({ items, config, onD
   };
 
   return (
-    <>
-      <Button variant="outline" size="sm" onClick={() => setOpen(true)} disabled={busy}>
-        <Trash size={14} className="mr-1.5" /> Delete {items.length}
-      </Button>
-      <Dialog open={open} onOpenChange={(v) => !busy && setOpen(v)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              Delete {items.length} {config.pluralName}?
-            </DialogTitle>
-          </DialogHeader>
-          <DialogBody>
-            <p className="text-sm">This will delete the following resources:</p>
-            <ul className="mt-2 max-h-64 overflow-y-auto font-mono text-sm">
-              {items.map((i) => (
-                <li key={i.metadata?.uid}>
-                  {i.metadata?.namespace ? `${i.metadata.namespace}/` : ""}
-                  {i.metadata?.name}
-                </li>
-              ))}
-            </ul>
-          </DialogBody>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setOpen(false)} disabled={busy}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleConfirm} disabled={busy}>
-              {busy ? "Deleting…" : "Delete"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+    <Dialog open={open} onOpenChange={(v) => !busy && onOpenChange(v)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Delete {items.length} {config.pluralName}?
+          </DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <p className="text-sm">This will delete the following resources:</p>
+          <ul className="mt-2 max-h-64 overflow-y-auto font-mono text-sm">
+            {items.map((i) => (
+              <li key={i.metadata?.uid}>
+                {i.metadata?.namespace ? `${i.metadata.namespace}/` : ""}
+                {i.metadata?.name}
+              </li>
+            ))}
+          </ul>
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleConfirm} disabled={busy || items.length === 0}>
+            {busy ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/client/src/modules/k8s/components/ResourceTable/index.tsx
+++ b/apps/client/src/modules/k8s/components/ResourceTable/index.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { Box } from "lucide-react";
+import { Box, Trash } from "lucide-react";
 import { Button } from "@/core/components/ui/button";
 import { DataTable } from "@/core/components/Table";
 import { EmptyList } from "@/core/components/EmptyList";
@@ -15,7 +15,7 @@ import {
 import type { TableProps } from "@/core/components/Table/types";
 import type { KubeObjectBase } from "@my-project/shared";
 import type { ResourceDescriptor } from "../../registry/types";
-import { BatchDeleteAction } from "../BatchDeleteAction";
+import { BatchDeleteDialog } from "../BatchDeleteDialog";
 
 interface Props<T extends KubeObjectBase> {
   items: T[];
@@ -121,15 +121,16 @@ export function ResourceTable<T extends KubeObjectBase>({
 }: Props<T>) {
   const clusterName = useClusterStore((s) => s.clusterName) ?? "";
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const columns = useMemo(
     () => descriptor.columns((data) => <NameLink item={data} descriptor={descriptor} clusterName={clusterName} />),
     [descriptor, clusterName]
   );
 
-  const isRowSelected = (item: KubeObjectBase) => selected.has(item.metadata?.uid ?? "");
+  const isRowSelected = useCallback((item: KubeObjectBase) => selected.has(item.metadata?.uid ?? ""), [selected]);
 
-  const handleSelectRow = (_e: React.MouseEvent<HTMLButtonElement>, item: KubeObjectBase) => {
+  const handleSelectRow = useCallback((_e: React.MouseEvent<HTMLButtonElement>, item: KubeObjectBase) => {
     const uid = item.metadata?.uid ?? "";
     setSelected((prev) => {
       const next = new Set(prev);
@@ -137,9 +138,9 @@ export function ResourceTable<T extends KubeObjectBase>({
       else next.add(uid);
       return next;
     });
-  };
+  }, []);
 
-  const handleSelectAll = (_e: React.ChangeEvent<HTMLInputElement>, paginatedItems: KubeObjectBase[]) => {
+  const handleSelectAll = useCallback((_e: React.ChangeEvent<HTMLInputElement>, paginatedItems: KubeObjectBase[]) => {
     setSelected((prev) => {
       const next = new Set(prev);
       const allSelected = paginatedItems.every((i) => next.has(i.metadata?.uid ?? ""));
@@ -150,9 +151,28 @@ export function ResourceTable<T extends KubeObjectBase>({
       }
       return next;
     });
-  };
+  }, []);
 
-  const selectedItems = (items as KubeObjectBase[]).filter((i) => selected.has(i.metadata?.uid ?? ""));
+  const selectedUids = useMemo(() => Array.from(selected), [selected]);
+
+  const selectedItems = useMemo(
+    () => (items as KubeObjectBase[]).filter((i) => selected.has(i.metadata?.uid ?? "")),
+    [items, selected]
+  );
+
+  const renderSelectionInfo = useCallback(
+    (selectionLength: number) => (
+      <div className="flex items-center gap-2">
+        <div className="min-w-38">
+          <p>{selectionLength} item(s) selected</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => setDeleteDialogOpen(true)}>
+          <Trash size={14} className="mr-1.5" /> Delete {selectionLength}
+        </Button>
+      </div>
+    ),
+    []
+  );
 
   const emptyDescription = descriptor.config.clusterScoped
     ? `There are no ${descriptor.label} in the cluster`
@@ -162,16 +182,6 @@ export function ResourceTable<T extends KubeObjectBase>({
 
   return (
     <>
-      {selected.size > 0 && (
-        <div className="bg-muted/30 flex items-center gap-2 border-b px-4 py-2">
-          <span className="text-muted-foreground text-sm">{selected.size} selected</span>
-          <BatchDeleteAction
-            items={selectedItems}
-            config={descriptor.config}
-            onDeleted={() => setSelected(new Set())}
-          />
-        </div>
-      )}
       <DataTable<KubeObjectBase>
         id={tableId ?? `k8s-${descriptor.config.pluralName}`}
         data={items as KubeObjectBase[]}
@@ -180,7 +190,6 @@ export function ResourceTable<T extends KubeObjectBase>({
         blockerError={error}
         filterFunction={filterFunction}
         slots={slots}
-        outlined={!slots}
         sort={
           descriptor.defaultSort
             ? {
@@ -190,10 +199,11 @@ export function ResourceTable<T extends KubeObjectBase>({
             : undefined
         }
         selection={{
-          selected: Array.from(selected),
+          selected: selectedUids,
           isRowSelected,
           handleSelectRow,
           handleSelectAll,
+          renderSelectionInfo,
         }}
         emptyListComponent={
           <EmptyList
@@ -203,6 +213,18 @@ export function ResourceTable<T extends KubeObjectBase>({
           />
         }
       />
+      {/* Mounted outside DataTable: the selection banner unmounts as soon as the
+          watch stream drains selected items from the data, which would otherwise
+          kill an in-flight deletion dialog. */}
+      {deleteDialogOpen && (
+        <BatchDeleteDialog
+          items={selectedItems}
+          config={descriptor.config}
+          open={deleteDialogOpen}
+          onOpenChange={setDeleteDialogOpen}
+          onDeleted={() => setSelected(new Set())}
+        />
+      )}
     </>
   );
 }

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/view.test.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/view.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@tanstack/react-router", async () => {
   };
 });
 
-// Mock ResourceTable to avoid deep tree (DataTable, BatchDeleteAction, etc.)
+// Mock ResourceTable to avoid deep tree (DataTable, BatchDeleteDialog, etc.)
 // but still render items and column labels so we can assert on them.
 vi.mock("@/modules/k8s/components/ResourceTable", () => ({
   ResourceTable: ({

--- a/apps/client/src/modules/k8s/pages/nodes/list/page.tsx
+++ b/apps/client/src/modules/k8s/pages/nodes/list/page.tsx
@@ -53,7 +53,6 @@ function K8sNodesListContent() {
           blockerError={(result.error as Error) ?? null}
           filterFunction={filterFunction}
           slots={tableSlots}
-          outlined={false}
           emptyListComponent={
             <EmptyList
               icon={<Box width={64} height={64} className="text-muted-foreground" />}

--- a/apps/client/src/modules/k8s/pages/pods/list/page.tsx
+++ b/apps/client/src/modules/k8s/pages/pods/list/page.tsx
@@ -60,7 +60,6 @@ function K8sPodsListContent() {
           blockerError={(result.error as Error) ?? null}
           filterFunction={filterFunction}
           slots={tableSlots}
-          outlined={false}
           emptyListComponent={
             <EmptyList
               icon={<Box width={64} height={64} className="text-muted-foreground" />}


### PR DESCRIPTION
- Render all K8s resource list tables as outlined cards matching the Projects page chrome, so the search/filter section gets the same padding in both modes
- Move the batch-delete selection banner into the table's selection-info slot, consistent with the Projects list pattern
- Convert the batch-delete action into a controlled dialog mounted outside the table, so an in-flight deletion survives the watch stream draining selected items from the list
- Guard batch delete against confirming an empty selection and memoize selection handlers to keep table memoization effective on streaming list updates
