### PR TITLE
EPMDEDP-16047: fix: make sidebar pin keys param-aware and restore icons for pinned pages

### DIFF
--- a/apps/client/src/core/components/sidebar/SidebarCollapsibleSubGroupMenuItem.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarCollapsibleSubGroupMenuItem.tsx
@@ -4,12 +4,49 @@ import { Link, useLocation } from "@tanstack/react-router";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/core/components/ui/collapsible";
 import { SidebarMenuSubButton, SidebarMenuSubItem } from "../ui/sidebar";
 import { cn } from "@/core/utils/classname";
-import type { NavCollapsibleSubGroupItem } from "./types";
+import { usePinToggle } from "./usePinToggle";
+import { SidebarPinAction } from "./SidebarPinAction";
+import type { NavCollapsibleSubGroupItem, SimpleNavItem } from "./types";
 
 interface Props {
   subGroup: NavCollapsibleSubGroupItem;
   parentGroupId?: string;
   onNavigate?: (groupId?: string) => void;
+}
+
+interface CollapsibleChildRowProps {
+  child: SimpleNavItem;
+  parentGroupId?: string;
+  onNavigate?: (groupId?: string) => void;
+}
+
+/**
+ * Individual child row inside a collapsible sub-group.
+ * Extracted to keep hook calls at the top level of a single component instance.
+ */
+function CollapsibleChildRow({ child, parentGroupId, onNavigate }: CollapsibleChildRowProps) {
+  const { pathname } = useLocation();
+  const { pinned, handlePin } = usePinToggle(child);
+
+  return (
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton asChild size="sm">
+        <Link
+          to={child.route.to}
+          params={child.route.params}
+          onClick={() => onNavigate?.(parentGroupId)}
+          activeOptions={{ exact: true, includeSearch: false }}
+          activeProps={{ className: "bg-accent text-accent-foreground" }}
+          title={child.title}
+          className={cn("min-w-0", child.isActiveFn?.(pathname) && "bg-accent text-accent-foreground")}
+        >
+          {child.icon && <child.icon className="size-4 shrink-0" />}
+          <span className="min-w-0 flex-1 truncate">{child.title}</span>
+        </Link>
+      </SidebarMenuSubButton>
+      <SidebarPinAction scope="menu-sub-item" title={child.title} pinned={pinned} onToggle={handlePin} />
+    </SidebarMenuSubItem>
+  );
 }
 
 export function SidebarCollapsibleSubGroupMenuItem({ subGroup, parentGroupId, onNavigate }: Props) {
@@ -44,22 +81,7 @@ export function SidebarCollapsibleSubGroupMenuItem({ subGroup, parentGroupId, on
       </CollapsibleTrigger>
       <CollapsibleContent>
         {subGroup.children.map((child) => (
-          <SidebarMenuSubItem key={child.title}>
-            <SidebarMenuSubButton asChild size="sm">
-              <Link
-                to={child.route.to}
-                params={child.route.params}
-                onClick={() => onNavigate?.(parentGroupId)}
-                activeOptions={{ exact: true, includeSearch: false }}
-                activeProps={{ className: "bg-accent text-accent-foreground" }}
-                title={child.title}
-                className={cn("min-w-0", child.isActiveFn?.(pathname) && "bg-accent text-accent-foreground")}
-              >
-                {child.icon && <child.icon className="size-4 shrink-0" />}
-                <span className="min-w-0 flex-1 truncate">{child.title}</span>
-              </Link>
-            </SidebarMenuSubButton>
-          </SidebarMenuSubItem>
+          <CollapsibleChildRow key={child.title} child={child} parentGroupId={parentGroupId} onNavigate={onNavigate} />
         ))}
       </CollapsibleContent>
     </Collapsible>

--- a/apps/client/src/core/components/sidebar/SidebarMenuItem.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarMenuItem.tsx
@@ -1,10 +1,9 @@
 import { useCallback } from "react";
 import { Link, useLocation } from "@tanstack/react-router";
-import { Pin, PinOff } from "lucide-react";
-import { SidebarMenuAction, SidebarMenuSubButton, SidebarMenuSubItem } from "../ui/sidebar";
-import { usePinnedItems } from "@/core/hooks/usePinnedItems";
+import { SidebarMenuSubButton, SidebarMenuSubItem } from "../ui/sidebar";
 import { cn } from "@/core/utils/classname";
-import { createPinConfig } from "./utils";
+import { usePinToggle } from "./usePinToggle";
+import { SidebarPinAction } from "./SidebarPinAction";
 import type { SimpleNavItem } from "./types";
 
 interface SidebarMenuItemProps {
@@ -18,23 +17,12 @@ interface SidebarMenuItemProps {
  */
 export const SidebarMenuItem = ({ item, parentGroupId, onNavigate }: SidebarMenuItemProps) => {
   const { pathname } = useLocation();
-  const { isPinned, togglePin } = usePinnedItems();
+  const { pinned, handlePin } = usePinToggle(item);
   const isActiveFnMatch = item.isActiveFn?.(pathname) ?? false;
-  const pinConfig = createPinConfig(item.title, item.route);
-  const pinned = isPinned(pinConfig.key);
 
   const handleClick = useCallback(() => {
     onNavigate?.(parentGroupId);
   }, [onNavigate, parentGroupId]);
-
-  const handlePin = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      togglePin(pinConfig);
-    },
-    [togglePin, pinConfig]
-  );
 
   return (
     <SidebarMenuSubItem>
@@ -52,13 +40,7 @@ export const SidebarMenuItem = ({ item, parentGroupId, onNavigate }: SidebarMenu
           <span>{item.title}</span>
         </Link>
       </SidebarMenuSubButton>
-      <SidebarMenuAction
-        showOnHover
-        onClick={handlePin}
-        aria-label={pinned ? `Unpin ${item.title}` : `Pin ${item.title}`}
-      >
-        {pinned ? <Pin className="size-3 fill-current text-blue-600" /> : <PinOff className="size-3" />}
-      </SidebarMenuAction>
+      <SidebarPinAction scope="menu-sub-item" title={item.title} pinned={pinned} onToggle={handlePin} />
     </SidebarMenuSubItem>
   );
 };

--- a/apps/client/src/core/components/sidebar/SidebarMenuItemWithHover.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarMenuItemWithHover.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from "react";
 import { Link, useLocation, useMatches } from "@tanstack/react-router";
-import { ChevronRight, Pin, PinOff } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { SidebarMenuAction, SidebarMenuButton, SidebarMenuItem, SidebarMenuSub } from "../ui/sidebar";
+import { SidebarPinAction } from "./SidebarPinAction";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 import { cn } from "../../utils/classname";
 import { SidebarMenuContent } from "./SidebarMenuContent";
@@ -128,13 +129,7 @@ export function SidebarMenuItemWithHover({
             )}
           </Link>
         </SidebarMenuButton>
-        <SidebarMenuAction
-          showOnHover
-          onClick={handlePin}
-          aria-label={pinned ? `Unpin ${simpleItem.title}` : `Pin ${simpleItem.title}`}
-        >
-          {pinned ? <Pin className="size-3 fill-current text-blue-600" /> : <PinOff className="size-3" />}
-        </SidebarMenuAction>
+        <SidebarPinAction scope="menu-item" title={simpleItem.title} pinned={pinned} onToggle={handlePin} />
       </SidebarMenuItem>
     );
   }

--- a/apps/client/src/core/components/sidebar/SidebarPinAction.test.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarPinAction.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SidebarProvider } from "../ui/sidebar";
+import { SidebarPinAction } from "./SidebarPinAction";
+
+function wrap(ui: React.ReactNode) {
+  return <SidebarProvider>{ui}</SidebarProvider>;
+}
+
+describe("SidebarPinAction", () => {
+  it("renders a Pin icon when pinned", () => {
+    render(wrap(<SidebarPinAction scope="menu-item" title="Pods" pinned={true} onToggle={vi.fn()} />));
+    // When pinned the aria-label is "Unpin <title>"
+    expect(screen.getByRole("button", { name: "Unpin Pods" })).toBeInTheDocument();
+  });
+
+  it("renders a PinOff icon when not pinned", () => {
+    render(wrap(<SidebarPinAction scope="menu-item" title="Pods" pinned={false} onToggle={vi.fn()} />));
+    expect(screen.getByRole("button", { name: "Pin Pods" })).toBeInTheDocument();
+  });
+
+  it("fires onToggle when clicked", () => {
+    const onToggle = vi.fn();
+    render(wrap(<SidebarPinAction scope="menu-sub-item" title="Services" pinned={false} onToggle={onToggle} />));
+    fireEvent.click(screen.getByRole("button", { name: "Pin Services" }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses 'Unpin' aria-label when pinned", () => {
+    render(wrap(<SidebarPinAction scope="menu-sub-item" title="Deployments" pinned={true} onToggle={vi.fn()} />));
+    expect(screen.getByRole("button", { name: "Unpin Deployments" })).toBeInTheDocument();
+  });
+
+  it("applies menu-sub-item reveal classes when unpinned with scope menu-sub-item", () => {
+    render(wrap(<SidebarPinAction scope="menu-sub-item" title="ConfigMaps" pinned={false} onToggle={vi.fn()} />));
+    const btn = screen.getByRole("button", { name: "Pin ConfigMaps" });
+    expect(btn.className).toMatch(/md:opacity-0/);
+    expect(btn.className).toMatch(/group-hover\/menu-sub-item:opacity-100/);
+    expect(btn.className).toMatch(/group-focus-within\/menu-sub-item:opacity-100/);
+    expect(btn.className).toMatch(/data-\[state=open\]:opacity-100/);
+  });
+
+  it("applies menu-item reveal classes when unpinned with scope menu-item", () => {
+    render(wrap(<SidebarPinAction scope="menu-item" title="Namespaces" pinned={false} onToggle={vi.fn()} />));
+    const btn = screen.getByRole("button", { name: "Pin Namespaces" });
+    expect(btn.className).toMatch(/md:opacity-0/);
+    expect(btn.className).toMatch(/group-hover\/menu-item:opacity-100/);
+    expect(btn.className).toMatch(/group-focus-within\/menu-item:opacity-100/);
+    expect(btn.className).toMatch(/data-\[state=open\]:opacity-100/);
+  });
+
+  it("does NOT apply reveal classes when pinned (always visible)", () => {
+    render(wrap(<SidebarPinAction scope="menu-item" title="Pods" pinned={true} onToggle={vi.fn()} />));
+    const btn = screen.getByRole("button", { name: "Unpin Pods" });
+    expect(btn.className).not.toMatch(/md:opacity-0/);
+  });
+});

--- a/apps/client/src/core/components/sidebar/SidebarPinAction.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarPinAction.tsx
@@ -1,0 +1,61 @@
+import { Pin, PinOff } from "lucide-react";
+import { SidebarMenuAction } from "../ui/sidebar";
+import { cn } from "@/core/utils/classname";
+
+/**
+ * Unified pin/unpin action button for sidebar rows.
+ *
+ * Wraps `SidebarMenuAction` to add two row-specific behaviors:
+ *
+ * 1. 12px icons — overrides the base `[&>svg]:size-4` with `[&>svg]:size-3`.
+ *
+ * 2. Scope-aware hover reveal — the base `showOnHover` is hard-coded to the
+ *    `group/menu-item` container, which reveals every sibling pin when a row
+ *    lives in `group/menu-sub-item`. This applies reveal classes matched to the
+ *    row's actual container via a static lookup keyed by `scope`.
+ */
+
+export type PinScope = "menu-item" | "menu-sub-item";
+
+interface SidebarPinActionProps {
+  title: string;
+  pinned: boolean;
+  /** Click handler; preventDefault / stopPropagation belong in the call site. */
+  onToggle: (e: React.MouseEvent) => void;
+  /**
+   * Which group container the row lives in — selects the matching hover-reveal scope.
+   * - "menu-item"     → `SidebarMenuItem`      (`group/menu-item`)
+   * - "menu-sub-item" → `SidebarMenuSubItem`   (`group/menu-sub-item`)
+   */
+  scope: PinScope;
+  className?: string;
+}
+
+/**
+ * Scope-keyed reveal classes. Values are complete Tailwind class strings so the
+ * scanner can extract them — never computed from the `scope` variable at runtime.
+ */
+const REVEAL_CLASSES: Record<PinScope, string> = {
+  "menu-item":
+    "md:opacity-0 group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100 data-[state=open]:opacity-100",
+  "menu-sub-item":
+    "md:opacity-0 group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:opacity-100 data-[state=open]:opacity-100",
+};
+
+export function SidebarPinAction({ title, pinned, onToggle, scope, className }: SidebarPinActionProps) {
+  return (
+    <SidebarMenuAction
+      onClick={onToggle}
+      aria-label={pinned ? `Unpin ${title}` : `Pin ${title}`}
+      className={cn(
+        // Force 12px icons over the base [&>svg]:size-4.
+        "[&>svg]:size-3",
+        // Unpinned pins reveal only on row hover/focus; pinned pins stay visible.
+        !pinned && REVEAL_CLASSES[scope],
+        className
+      )}
+    >
+      {pinned ? <Pin className="fill-current text-blue-600" /> : <PinOff />}
+    </SidebarMenuAction>
+  );
+}

--- a/apps/client/src/core/components/sidebar/SidebarPinnedSection/index.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarPinnedSection/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { ChevronDown, PinOff, Pin as PinIcon, Box } from "lucide-react";
+import { ChevronDown, Pin as PinIcon, Box } from "lucide-react";
 import { PAGE_ICONS } from "@/core/constants/page-icons";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../../ui/collapsible";
 import {
@@ -9,12 +9,13 @@ import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuButton,
-  SidebarMenuAction,
   useSidebar,
 } from "../../ui/sidebar";
 import { usePinnedItems } from "@/core/hooks/usePinnedItems";
 import type { PinnedPage } from "@/core/hooks/usePinnedItems";
+import { getK8sPinnedPageIcon } from "@/modules/k8s/utils/pinned-icon";
 import { cn } from "@/core/utils/classname";
+import { SidebarPinAction } from "../SidebarPinAction";
 
 export function SidebarPinnedSection() {
   const [open, setOpen] = useState(true);
@@ -66,9 +67,11 @@ function PinnedPageItem({ page, onUnpin }: PinnedPageItemProps) {
     [onUnpin]
   );
 
-  // Get icon from iconType, fallback to type (for backwards compatibility), or Box
+  // Get icon from iconType, fallback to type (for backwards compatibility),
+  // then to the K8s registry resolver (K8s routes are param-identified and
+  // can't live in the static PAGE_ICONS map), or Box as the last resort.
   const iconKey = page.iconType || page.type;
-  const Icon = (iconKey && PAGE_ICONS[iconKey as keyof typeof PAGE_ICONS]) || Box;
+  const Icon = (iconKey && PAGE_ICONS[iconKey as keyof typeof PAGE_ICONS]) || getK8sPinnedPageIcon(page) || Box;
 
   return (
     <SidebarMenuItem>
@@ -90,9 +93,8 @@ function PinnedPageItem({ page, onUnpin }: PinnedPageItemProps) {
           )}
         </Link>
       </SidebarMenuButton>
-      <SidebarMenuAction showOnHover onClick={handleUnpin} aria-label={`Unpin ${page.label}`}>
-        <PinOff className="size-3" />
-      </SidebarMenuAction>
+      {/* Entries here are pinned by definition, so pinned={true} keeps the filled pin always visible. */}
+      <SidebarPinAction scope="menu-item" title={page.label} pinned={true} onToggle={handleUnpin} />
     </SidebarMenuItem>
   );
 }

--- a/apps/client/src/core/components/sidebar/SidebarSubGroupMenuItem.tsx
+++ b/apps/client/src/core/components/sidebar/SidebarSubGroupMenuItem.tsx
@@ -1,9 +1,8 @@
 import { useCallback } from "react";
 import { Link } from "@tanstack/react-router";
-import { Pin, PinOff } from "lucide-react";
-import { SidebarMenuAction, SidebarMenuSubButton, SidebarMenuSubItem } from "../ui/sidebar";
-import { usePinnedItems } from "@/core/hooks/usePinnedItems";
-import { createPinConfig } from "./utils";
+import { SidebarMenuSubButton, SidebarMenuSubItem } from "../ui/sidebar";
+import { usePinToggle } from "./usePinToggle";
+import { SidebarPinAction } from "./SidebarPinAction";
 import type { NavSubGroupItem } from "./types";
 
 interface SidebarSubGroupMenuItemProps {
@@ -22,22 +21,11 @@ interface SubGroupItemProps {
  * Component for rendering an individual item within a sub-group
  */
 const SubGroupItem = ({ item, parentGroupId, onNavigate }: SubGroupItemProps) => {
-  const { isPinned, togglePin } = usePinnedItems();
-  const pinConfig = createPinConfig(item.title, item.route);
-  const pinned = isPinned(pinConfig.key);
+  const { pinned, handlePin } = usePinToggle(item);
 
   const handleClick = useCallback(() => {
     onNavigate?.(parentGroupId);
   }, [onNavigate, parentGroupId]);
-
-  const handlePin = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      togglePin(pinConfig);
-    },
-    [togglePin, pinConfig]
-  );
 
   return (
     <SidebarMenuSubItem>
@@ -55,13 +43,7 @@ const SubGroupItem = ({ item, parentGroupId, onNavigate }: SubGroupItemProps) =>
           <span>{item.title}</span>
         </Link>
       </SidebarMenuSubButton>
-      <SidebarMenuAction
-        className="group-focus-within/menu-sub-item:opacity-100 group-hover/menu-sub-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0"
-        onClick={handlePin}
-        aria-label={pinned ? `Unpin ${item.title}` : `Pin ${item.title}`}
-      >
-        {pinned ? <Pin className="size-3 fill-current text-blue-600" /> : <PinOff className="size-3" />}
-      </SidebarMenuAction>
+      <SidebarPinAction scope="menu-sub-item" title={item.title} pinned={pinned} onToggle={handlePin} />
     </SidebarMenuSubItem>
   );
 };

--- a/apps/client/src/core/components/sidebar/navigationConfig.test.ts
+++ b/apps/client/src/core/components/sidebar/navigationConfig.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { PATH_TO_ICON_TYPE } from "@/core/constants/page-icons";
+import { createNavigationConfig } from "./navigationConfig";
+
+describe("navigationConfig icon coverage", () => {
+  // Drift guard: pinned items resolve their icon via PATH_TO_ICON_TYPE, which is
+  // maintained separately from the nav config. A nav route missing from the map
+  // silently renders the generic Box icon when pinned, so fail loudly instead.
+  it("every KRCI nav route has a PATH_TO_ICON_TYPE entry so pinned items keep their icons", () => {
+    const items = createNavigationConfig("test-cluster", "test-namespace");
+
+    // Recursive walk so nav items at any nesting depth (groups, sub-groups,
+    // collapsible sub-groups) are covered — a fixed-depth loop would silently
+    // skip routes if a deeper level is ever added.
+    interface NavNode {
+      route?: { to?: string };
+      children?: NavNode[];
+    }
+
+    const routes: string[] = [];
+    const collectRoutes = (nodes: NavNode[]) => {
+      for (const node of nodes) {
+        if (node.route?.to) routes.push(node.route.to);
+        if (node.children?.length) collectRoutes(node.children);
+      }
+    };
+    collectRoutes(items as NavNode[]);
+
+    expect(routes.length).toBeGreaterThan(0);
+
+    const missing = routes.filter((to) => !PATH_TO_ICON_TYPE[to]);
+    expect(missing).toEqual([]);
+  });
+});

--- a/apps/client/src/core/components/sidebar/usePinToggle.ts
+++ b/apps/client/src/core/components/sidebar/usePinToggle.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import { usePinnedItems } from "@/core/hooks/usePinnedItems";
+import { createPinConfig } from "./utils";
+import type { SimpleNavItem } from "./types";
+
+/**
+ * Shared pin/unpin state for a sidebar nav row: builds the pin config from the
+ * item, reads its pinned state, and exposes a click handler that swallows the
+ * navigation event before toggling.
+ */
+export function usePinToggle(item: Pick<SimpleNavItem, "title" | "route">) {
+  const { isPinned, togglePin } = usePinnedItems();
+  const pinConfig = createPinConfig(item.title, item.route);
+  const pinned = isPinned(pinConfig.key);
+
+  const handlePin = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      togglePin(pinConfig);
+    },
+    [togglePin, pinConfig]
+  );
+
+  return { pinned, handlePin };
+}

--- a/apps/client/src/core/components/sidebar/utils.test.ts
+++ b/apps/client/src/core/components/sidebar/utils.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { createPinConfig } from "./utils";
+
+// createPinConfig delegates key construction to buildPinKey; the deeper
+// key-format tests live in pinKey.test.ts. Here we verify the full shape of
+// the returned PinnedPage and the cluster-agnostic key behaviour.
+
+describe("createPinConfig", () => {
+  describe("KRCI route with only clusterName param — backward-compatible key format", () => {
+    it("produces a key without a query suffix", () => {
+      const config = createPinConfig("Pipelines", {
+        to: "/c/$clusterName/cicd/pipelines",
+        params: { clusterName: "dev" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      expect(config.key).toBe("page:/c/$clusterName/cicd/pipelines");
+    });
+
+    it("sets label, route.to, and route.params correctly", () => {
+      const config = createPinConfig("Pipelines", {
+        to: "/c/$clusterName/cicd/pipelines",
+        params: { clusterName: "dev" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      expect(config.label).toBe("Pipelines");
+      expect(config.route.to).toBe("/c/$clusterName/cicd/pipelines");
+      expect(config.route.params).toEqual({ clusterName: "dev" });
+    });
+
+    it("derives iconType from the path", () => {
+      const config = createPinConfig("Pipelines", {
+        to: "/c/$clusterName/cicd/pipelines",
+        params: { clusterName: "dev" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      expect(config.iconType).toBe("pipelines");
+      expect(config.type).toBe("pipelines");
+    });
+  });
+
+  describe("generic K8s list route parameterised by kind", () => {
+    it("produces distinct keys for Deployments and StatefulSets", () => {
+      const deployments = createPinConfig("Deployments", {
+        to: "/c/$clusterName/k8s/$kind",
+        params: { clusterName: "dev", kind: "deployments" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      const statefulsets = createPinConfig("StatefulSets", {
+        to: "/c/$clusterName/k8s/$kind",
+        params: { clusterName: "dev", kind: "statefulsets" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      expect(deployments.key).not.toBe(statefulsets.key);
+    });
+
+    it("embeds the kind in the key query suffix", () => {
+      const config = createPinConfig("DaemonSets", {
+        to: "/c/$clusterName/k8s/$kind",
+        params: { clusterName: "dev", kind: "daemonsets" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      expect(config.key).toBe("page:/c/$clusterName/k8s/$kind?kind=daemonsets");
+    });
+
+    it("key is identical for the same kind across different clusters", () => {
+      const clusterA = createPinConfig("Jobs", {
+        to: "/c/$clusterName/k8s/$kind",
+        params: { clusterName: "cluster-a", kind: "jobs" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      const clusterB = createPinConfig("Jobs", {
+        to: "/c/$clusterName/k8s/$kind",
+        params: { clusterName: "cluster-b", kind: "jobs" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      expect(clusterA.key).toBe(clusterB.key);
+    });
+  });
+
+  describe("CR list route parameterised by group, version, plural", () => {
+    it("produces a key with params sorted deterministically", () => {
+      const config = createPinConfig("My CRs", {
+        to: "/c/$clusterName/k8s/cr/$group/$version/$plural",
+        params: { clusterName: "dev", group: "apps", version: "v1", plural: "mycrds" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      // params sorted: group, plural, version (alphabetical, clusterName excluded)
+      expect(config.key).toBe(
+        "page:/c/$clusterName/k8s/cr/$group/$version/$plural?group=apps&plural=mycrds&version=v1"
+      );
+    });
+
+    it("produces the same key regardless of param object insertion order", () => {
+      const a = createPinConfig("My CRs", {
+        to: "/c/$clusterName/k8s/cr/$group/$version/$plural",
+        params: { plural: "mycrds", clusterName: "dev", version: "v1", group: "apps" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      const b = createPinConfig("My CRs", {
+        to: "/c/$clusterName/k8s/cr/$group/$version/$plural",
+        params: { version: "v1", group: "apps", clusterName: "dev", plural: "mycrds" },
+      } as Parameters<typeof createPinConfig>[1]);
+
+      expect(a.key).toBe(b.key);
+    });
+  });
+});

--- a/apps/client/src/core/components/sidebar/utils.ts
+++ b/apps/client/src/core/components/sidebar/utils.ts
@@ -1,4 +1,5 @@
 import { getIconTypeFromPath } from "@/core/constants/page-icons";
+import { buildPinKey } from "@/core/utils/pinKey";
 import type { PinnedPage } from "@/core/hooks/usePinnedItems";
 import type { RouteParams } from "@/core/router/types";
 import type { NavGroupItem } from "./types";
@@ -23,20 +24,30 @@ export function isNavGroupActiveForPathname(item: NavGroupItem, pathname: string
 /**
  * Helper to create a pin config from route and title.
  * Derives the icon type from the route path.
+ *
+ * The pin key is cluster-agnostic: `clusterName` is excluded from the key so
+ * that a page pinned on one cluster remains pinned when switching clusters.
+ * All other route params are included, sorted by key name, to disambiguate
+ * pages that share the same route template (e.g. generic K8s list pages
+ * parameterised by `kind`, or CR list pages parameterised by group/version/plural).
+ *
+ * Key format:
+ *   - No identifying params: `page:<path>`
+ *   - With identifying params: `page:<path>?<k1>=<v1>&<k2>=<v2>`
  */
 export function createPinConfig(title: string, route: RouteParams): PinnedPage {
   const path = route.to ?? "/";
-  const params = route.params ?? {};
+  const params = (route.params ?? {}) as Record<string, string>;
   const iconType = getIconTypeFromPath(path);
 
   return {
-    key: `page:${path}`,
+    key: buildPinKey(path, params),
     label: title,
     type: iconType as PinnedPage["type"],
     iconType,
     route: {
       to: path,
-      params: params as Record<string, string>,
+      params,
     },
   };
 }

--- a/apps/client/src/core/constants/page-icons.ts
+++ b/apps/client/src/core/constants/page-icons.ts
@@ -8,8 +8,11 @@ import {
   CloudUpload,
   Code,
   Database,
+  FileCode,
   FileText,
+  Funnel,
   GitBranch,
+  Globe,
   Layers,
   Link2,
   PanelsTopLeft,
@@ -18,6 +21,8 @@ import {
   Shield,
   ShieldAlert,
   ShieldCheck,
+  Webhook,
+  Zap,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
@@ -35,6 +40,14 @@ export const PAGE_ICONS = {
   pipelineruns: Activity,
   pipelines: Bot,
   tasks: CheckCircle,
+
+  // CI/CD Webhook Triggers (icons mirror navigationConfig.ts entries)
+  "event-listeners": Webhook,
+  triggers: Zap,
+  "trigger-templates": FileCode,
+  "trigger-bindings": Link2,
+  interceptors: Funnel,
+  "cluster-interceptors": Globe,
 
   // Observability
   "pipeline-metrics": Activity,
@@ -115,57 +128,65 @@ export const PATH_TO_ICON_TYPE: Record<string, PageIconType> = {
   "/c/$clusterName/cicd/pipelines": "pipelines",
   "/c/$clusterName/cicd/tasks": "tasks",
 
+  // CI/CD Webhook Triggers
+  "/c/$clusterName/cicd/webhook-triggers/event-listeners": "event-listeners",
+  "/c/$clusterName/cicd/webhook-triggers/triggers": "triggers",
+  "/c/$clusterName/cicd/webhook-triggers/trigger-templates": "trigger-templates",
+  "/c/$clusterName/cicd/webhook-triggers/trigger-bindings": "trigger-bindings",
+  "/c/$clusterName/cicd/webhook-triggers/interceptors": "interceptors",
+  "/c/$clusterName/cicd/webhook-triggers/cluster-interceptors": "cluster-interceptors",
+
   // Observability
-  "/c/$clusterName/observability/pipeline-metrics": "pipeline-metrics",
+  "/c/$clusterName/observability/pipeline-metrics/$namespace": "pipeline-metrics",
 
   // Security - SCA
   "/c/$clusterName/security/sca/$namespace": "sca",
-  "/c/$clusterName/security/sca-projects/$namespace": "sca-projects",
+  "/c/$clusterName/security/sca/projects/$namespace": "sca-projects",
 
   // Security - SAST
-  "/c/$clusterName/security/sast/$namespace": "sast",
+  "/c/$clusterName/security/sast/projects/$namespace": "sast",
 
   // Security - Container Scanning
-  "/c/$clusterName/security/trivy/overview/$namespace": "trivy-overview",
-  "/c/$clusterName/security/trivy/vulnerabilities/$namespace": "trivy-vulnerabilities",
-  "/c/$clusterName/security/trivy/exposed-secrets/$namespace": "trivy-exposed-secrets",
+  "/c/$clusterName/security/trivy": "trivy-overview",
+  "/c/$clusterName/security/trivy/vulnerabilities": "trivy-vulnerabilities",
+  "/c/$clusterName/security/container/exposed-secrets": "trivy-exposed-secrets",
 
   // Security - Namespace Security
-  "/c/$clusterName/security/trivy/config-audits/$namespace": "trivy-config-audits",
-  "/c/$clusterName/security/trivy/rbac-assessments/$namespace": "trivy-rbac-assessments",
-  "/c/$clusterName/security/trivy/infra-assessments/$namespace": "trivy-infra-assessments",
+  "/c/$clusterName/security/namespace/config-audits": "trivy-config-audits",
+  "/c/$clusterName/security/namespace/rbac-assessments": "trivy-rbac-assessments",
+  "/c/$clusterName/security/namespace/infra-assessments": "trivy-infra-assessments",
 
   // Security - Cluster Security
-  "/c/$clusterName/security/trivy/compliance/$namespace": "trivy-compliance",
-  "/c/$clusterName/security/trivy/cluster-config-audits/$namespace": "trivy-cluster-config-audits",
-  "/c/$clusterName/security/trivy/cluster-rbac-assessments/$namespace": "trivy-cluster-rbac-assessments",
-  "/c/$clusterName/security/trivy/cluster-infra-assessments/$namespace": "trivy-cluster-infra-assessments",
-  "/c/$clusterName/security/trivy/cluster-vulnerabilities/$namespace": "trivy-cluster-vulnerabilities",
+  "/c/$clusterName/security/cluster/compliance": "trivy-compliance",
+  "/c/$clusterName/security/cluster/config-audits": "trivy-cluster-config-audits",
+  "/c/$clusterName/security/cluster/rbac-assessments": "trivy-cluster-rbac-assessments",
+  "/c/$clusterName/security/cluster/infra-assessments": "trivy-cluster-infra-assessments",
+  "/c/$clusterName/security/cluster/vulnerabilities": "trivy-cluster-vulnerabilities",
 
   // Configuration - Quick Access
-  "/c/$clusterName/configuration/quicklinks/$namespace": "config-quicklinks",
+  "/c/$clusterName/configuration/quicklinks": "config-quicklinks",
 
   // Configuration - Artifacts Storage
-  "/c/$clusterName/configuration/nexus/$namespace": "config-nexus",
-  "/c/$clusterName/configuration/registry/$namespace": "config-registry",
+  "/c/$clusterName/configuration/nexus": "config-nexus",
+  "/c/$clusterName/configuration/registry": "config-registry",
 
   // Configuration - Deployment
-  "/c/$clusterName/configuration/clusters/$namespace": "config-clusters",
-  "/c/$clusterName/configuration/gitops/$namespace": "config-gitops",
-  "/c/$clusterName/configuration/argocd/$namespace": "config-argocd",
+  "/c/$clusterName/configuration/clusters": "config-clusters",
+  "/c/$clusterName/configuration/gitops": "config-gitops",
+  "/c/$clusterName/configuration/argocd": "config-argocd",
 
   // Configuration - Security
-  "/c/$clusterName/configuration/defectdojo/$namespace": "config-defectdojo",
-  "/c/$clusterName/configuration/dependency-track/$namespace": "config-dependency-track",
+  "/c/$clusterName/configuration/defectdojo": "config-defectdojo",
+  "/c/$clusterName/configuration/dependency-track": "config-dependency-track",
 
   // Configuration - Code Quality
-  "/c/$clusterName/configuration/sonar/$namespace": "config-sonar",
+  "/c/$clusterName/configuration/sonar": "config-sonar",
 
   // Configuration - VCS
-  "/c/$clusterName/configuration/gitservers/$namespace": "config-gitservers",
+  "/c/$clusterName/configuration/gitservers": "config-gitservers",
 
   // Configuration - Management Tool
-  "/c/$clusterName/configuration/jira/$namespace": "config-jira",
+  "/c/$clusterName/configuration/jira": "config-jira",
 };
 
 /**

--- a/apps/client/src/core/hooks/usePinnedItems.test.ts
+++ b/apps/client/src/core/hooks/usePinnedItems.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import { migratePinnedItems } from "./usePinnedItems";
+import type { PinnedPage } from "./usePinnedItems";
+
+// Helpers ----------------------------------------------------------------
+
+function makeItem(
+  overrides: Partial<PinnedPage> & { routeTo: string; routeParams?: Record<string, string> }
+): PinnedPage {
+  const { routeTo, routeParams = {}, ...rest } = overrides;
+  return {
+    key: `page:${routeTo}`,
+    label: "Test",
+    type: "pipelines",
+    route: { to: routeTo, params: routeParams },
+    ...rest,
+  };
+}
+
+// ------------------------------------------------------------------------
+
+describe("migratePinnedItems", () => {
+  describe("iconType backfill", () => {
+    it("leaves items that already have iconType unchanged (key recompute still runs)", () => {
+      const item: PinnedPage = {
+        key: "page:/c/$clusterName/cicd/pipelines",
+        label: "Pipelines",
+        type: "pipelines",
+        iconType: "pipelines",
+        route: { to: "/c/$clusterName/cicd/pipelines", params: { clusterName: "dev" } },
+      };
+      const result = migratePinnedItems([item]);
+      expect(result).toHaveLength(1);
+      expect(result[0].iconType).toBe("pipelines");
+    });
+
+    it("backfills iconType from the pathToIconType map when missing", () => {
+      const item = makeItem({
+        routeTo: "/c/$clusterName/cicd/pipelines",
+        routeParams: { clusterName: "dev" },
+        iconType: undefined,
+        type: "pipelines",
+      });
+      const result = migratePinnedItems([item]);
+      expect(result[0].iconType).toBe("pipelines");
+    });
+
+    it("backfills iconType from item.type for detail-page types", () => {
+      const item = makeItem({
+        routeTo: "/c/$clusterName/projects/my-app",
+        routeParams: { clusterName: "dev" },
+        iconType: undefined,
+        type: "project",
+      });
+      const result = migratePinnedItems([item]);
+      expect(result[0].iconType).toBe("project");
+    });
+
+    it("does not crash when iconType cannot be derived", () => {
+      const item = makeItem({
+        routeTo: "/c/$clusterName/some/unknown/path",
+        routeParams: { clusterName: "dev" },
+        iconType: undefined,
+        type: "pipelines",
+      });
+      const result = migratePinnedItems([item]);
+      expect(result).toHaveLength(1);
+      expect(result[0].iconType).toBeUndefined();
+    });
+  });
+
+  describe("key recomputation", () => {
+    it("keeps old key intact for routes with only clusterName param (backward compatible)", () => {
+      const item: PinnedPage = {
+        key: "page:/c/$clusterName/cicd/pipelines",
+        label: "Pipelines",
+        type: "pipelines",
+        iconType: "pipelines",
+        route: { to: "/c/$clusterName/cicd/pipelines", params: { clusterName: "dev" } },
+      };
+      const result = migratePinnedItems([item]);
+      expect(result[0].key).toBe("page:/c/$clusterName/cicd/pipelines");
+    });
+
+    it("rewrites old collision key to param-aware key for generic K8s list items", () => {
+      // Old format: all K8s kinds shared `page:/c/$clusterName/k8s/$kind`
+      const item: PinnedPage = {
+        key: "page:/c/$clusterName/k8s/$kind", // old colliding key
+        label: "Deployments",
+        type: "deployments",
+        iconType: "deployments",
+        route: { to: "/c/$clusterName/k8s/$kind", params: { clusterName: "dev", kind: "deployments" } },
+      };
+      const result = migratePinnedItems([item]);
+      expect(result[0].key).toBe("page:/c/$clusterName/k8s/$kind?kind=deployments");
+    });
+
+    it("rewrites keys for CR list items with group, version, plural params", () => {
+      const item: PinnedPage = {
+        key: "page:/c/$clusterName/k8s/cr/$group/$version/$plural", // old colliding key
+        label: "My CRs",
+        type: "pipelines",
+        iconType: "pipelines",
+        route: {
+          to: "/c/$clusterName/k8s/cr/$group/$version/$plural",
+          params: { clusterName: "dev", group: "apps", version: "v1", plural: "mycrds" },
+        },
+      };
+      const result = migratePinnedItems([item]);
+      expect(result[0].key).toBe(
+        "page:/c/$clusterName/k8s/cr/$group/$version/$plural?group=apps&plural=mycrds&version=v1"
+      );
+    });
+
+    it("is idempotent — already-migrated items are returned unchanged", () => {
+      const item: PinnedPage = {
+        key: "page:/c/$clusterName/k8s/$kind?kind=deployments",
+        label: "Deployments",
+        type: "deployments",
+        iconType: "deployments",
+        route: { to: "/c/$clusterName/k8s/$kind", params: { clusterName: "dev", kind: "deployments" } },
+      };
+      const first = migratePinnedItems([item]);
+      const second = migratePinnedItems(first);
+      expect(second[0].key).toBe("page:/c/$clusterName/k8s/$kind?kind=deployments");
+      expect(second).toHaveLength(1);
+    });
+  });
+
+  describe("collision deduplication", () => {
+    it("preserves both items when old keys collided but params differ (distinct new keys after migration)", () => {
+      // Two items stored under the same old key but with different kind params.
+      const deployments: PinnedPage = {
+        key: "page:/c/$clusterName/k8s/$kind",
+        label: "Deployments",
+        type: "deployments",
+        iconType: "deployments",
+        route: { to: "/c/$clusterName/k8s/$kind", params: { clusterName: "dev", kind: "deployments" } },
+      };
+      const statefulsets: PinnedPage = {
+        key: "page:/c/$clusterName/k8s/$kind",
+        label: "StatefulSets",
+        type: "deployments",
+        iconType: "deployments",
+        route: { to: "/c/$clusterName/k8s/$kind", params: { clusterName: "dev", kind: "statefulsets" } },
+      };
+      const result = migratePinnedItems([deployments, statefulsets]);
+
+      // Both get distinct keys after migration, so no deduplication needed here —
+      // but let's verify both survive with correct keys.
+      expect(result).toHaveLength(2);
+      expect(result[0].key).toBe("page:/c/$clusterName/k8s/$kind?kind=deployments");
+      expect(result[1].key).toBe("page:/c/$clusterName/k8s/$kind?kind=statefulsets");
+    });
+
+    it("dedupes when two entries genuinely resolve to the same new key, keeping first", () => {
+      // Edge case: truly identical routes stored twice (same kind, same path).
+      const first: PinnedPage = {
+        key: "page:/c/$clusterName/k8s/$kind",
+        label: "Deployments First",
+        type: "deployments",
+        iconType: "deployments",
+        route: { to: "/c/$clusterName/k8s/$kind", params: { clusterName: "dev", kind: "deployments" } },
+      };
+      const duplicate: PinnedPage = {
+        key: "page:/c/$clusterName/k8s/$kind",
+        label: "Deployments Duplicate",
+        type: "deployments",
+        iconType: "deployments",
+        route: { to: "/c/$clusterName/k8s/$kind", params: { clusterName: "dev", kind: "deployments" } },
+      };
+      const result = migratePinnedItems([first, duplicate]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].label).toBe("Deployments First");
+    });
+
+    it("preserves items with genuinely different keys alongside deduplicated ones", () => {
+      const pipelines: PinnedPage = {
+        key: "page:/c/$clusterName/cicd/pipelines",
+        label: "Pipelines",
+        type: "pipelines",
+        iconType: "pipelines",
+        route: { to: "/c/$clusterName/cicd/pipelines", params: { clusterName: "dev" } },
+      };
+      const deployments: PinnedPage = {
+        key: "page:/c/$clusterName/k8s/$kind",
+        label: "Deployments",
+        type: "deployments",
+        iconType: "deployments",
+        route: { to: "/c/$clusterName/k8s/$kind", params: { clusterName: "dev", kind: "deployments" } },
+      };
+      const result = migratePinnedItems([pipelines, deployments]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].key).toBe("page:/c/$clusterName/cicd/pipelines");
+      expect(result[1].key).toBe("page:/c/$clusterName/k8s/$kind?kind=deployments");
+    });
+  });
+
+  describe("empty and single-item inputs", () => {
+    it("returns an empty array for empty input", () => {
+      expect(migratePinnedItems([])).toEqual([]);
+    });
+
+    it("returns a single-item array for a single already-correct item", () => {
+      const item: PinnedPage = {
+        key: "page:/c/$clusterName/cicd/pipelines",
+        label: "Pipelines",
+        type: "pipelines",
+        iconType: "pipelines",
+        route: { to: "/c/$clusterName/cicd/pipelines", params: { clusterName: "dev" } },
+      };
+      const result = migratePinnedItems([item]);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("iconType backfill for newly mapped paths", () => {
+    it("heals items pinned before their route had an icon mapping (e.g. Trigger Bindings)", () => {
+      const item = makeItem({
+        routeTo: "/c/$clusterName/cicd/webhook-triggers/trigger-bindings",
+        routeParams: { clusterName: "dev" },
+        label: "Trigger Bindings",
+        type: undefined as unknown as PinnedPage["type"],
+      });
+
+      const [migrated] = migratePinnedItems([item]);
+
+      expect(migrated.iconType).toBe("trigger-bindings");
+      expect(migrated.type).toBe("trigger-bindings");
+      expect(migrated.key).toBe("page:/c/$clusterName/cicd/webhook-triggers/trigger-bindings");
+    });
+  });
+});

--- a/apps/client/src/core/hooks/usePinnedItems.ts
+++ b/apps/client/src/core/hooks/usePinnedItems.ts
@@ -1,7 +1,9 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { LOCAL_STORAGE_SERVICE } from "@/core/services/local-storage";
 import { LS_KEY_SIDEBAR_PINNED_ITEMS } from "@/core/services/local-storage/keys";
+import { PATH_TO_ICON_TYPE } from "@/core/constants/page-icons";
 import type { PageIconType } from "@/core/constants/page-icons";
+import { buildPinKey } from "@/core/utils/pinKey";
 
 export type PinnedPageType =
   | "project"
@@ -15,6 +17,12 @@ export type PinnedPageType =
   | "pipeline"
   | "pipelineRun"
   | "tasks"
+  | "event-listeners"
+  | "triggers"
+  | "trigger-templates"
+  | "trigger-bindings"
+  | "interceptors"
+  | "cluster-interceptors"
   | "projects"
   | "deployments"
   | "pipeline-metrics"
@@ -45,7 +53,18 @@ export type PinnedPageType =
   | "config-jira";
 
 export interface PinnedPage {
-  /** Unique key in the format `"type:namespace/name"` (or `"type:namespace/parent/name"` for stages). */
+  /**
+   * Unique, cluster-agnostic key for this pinned page.
+   *
+   * Format:
+   *   - No identifying params (or only `clusterName`):
+   *     `page:<routePath>`
+   *     e.g. `page:/c/$clusterName/cicd/pipelines`
+   *   - With identifying params (sorted by key name):
+   *     `page:<routePath>?<k1>=<v1>&<k2>=<v2>`
+   *     e.g. `page:/c/$clusterName/k8s/$kind?kind=deployments`
+   *     e.g. `page:/c/$clusterName/k8s/cr/$group/$version/$plural?group=apps&plural=mycrds&version=v1`
+   */
   key: string;
   label: string;
   type: PinnedPageType;
@@ -58,39 +77,49 @@ export interface PinnedPage {
 }
 
 /**
- * Migrate old pinned items to add iconType field.
- * Maps route paths to correct icon types.
+ * Normalize stored pinned items to the current format in a single pass:
+ *  1. iconType backfill — items stored without an `iconType` get it derived
+ *     from their route path or type.
+ *  2. Key recomputation — each key is rebuilt from the item's stored `route`
+ *     via `buildPinKey`, so items sharing a generic route template (e.g. K8s
+ *     list pages under `page:/c/$clusterName/k8s/$kind`) get distinct,
+ *     param-aware keys.
+ *
+ * Duplicate keys are then removed (first occurrence wins).
+ *
+ * Returns the normalized array; the caller decides whether to persist it.
  */
-function migratePinnedItems(items: PinnedPage[]): PinnedPage[] {
-  const pathToIconType: Record<string, PageIconType> = {
-    "/c/$clusterName/overview/$namespace": "overview",
-    "/c/$clusterName/projects": "projects",
-    "/c/$clusterName/cdpipelines": "deployments",
-    "/c/$clusterName/cicd/pipelineruns": "pipelineruns",
-    "/c/$clusterName/cicd/pipelines": "pipelines",
-    "/c/$clusterName/cicd/tasks": "tasks",
-    "/c/$clusterName/observability/pipeline-metrics": "pipeline-metrics",
-    "/c/$clusterName/security/sca/$namespace": "sca",
-    "/c/$clusterName/security/sca-projects/$namespace": "sca-projects",
-    "/c/$clusterName/security/sast/$namespace": "sast",
-  };
+export function migratePinnedItems(items: PinnedPage[]): PinnedPage[] {
+  // Step 1: backfill iconType and recompute keys from stored route.
+  const withIconAndKey = items.map((item): PinnedPage => {
+    // Recompute the key from the item's stored route so that old single-format
+    // keys (e.g. `page:/c/$clusterName/k8s/$kind`) become param-aware.
+    const recomputedKey = buildPinKey(item.route.to, item.route.params);
 
-  return items.map((item) => {
-    // If iconType already exists, keep as is
-    if (item.iconType) return item;
-
-    // Derive iconType from route path
-    const iconType = pathToIconType[item.route.to];
-    if (iconType) {
-      return { ...item, iconType, type: iconType as PinnedPageType };
+    // First resolve any iconType backfill; the key update is applied once below.
+    let updated = item;
+    if (!item.iconType) {
+      // Derive iconType from the route path via the canonical map (shared with createPinConfig).
+      const iconType = PATH_TO_ICON_TYPE[item.route.to];
+      if (iconType) {
+        updated = { ...item, iconType, type: iconType as PinnedPageType };
+      } else if (["project", "deployment", "stage", "sca-project", "sast-project"].includes(item.type)) {
+        // For detail pages (project, deployment, stage, etc.) iconType matches type.
+        updated = { ...item, iconType: item.type as PageIconType };
+      }
     }
 
-    // For detail pages (project, deployment, stage), iconType matches type
-    if (["project", "deployment", "stage", "sca-project", "sast-project"].includes(item.type)) {
-      return { ...item, iconType: item.type as PageIconType };
-    }
+    // Apply the recomputed key in a single place, preserving the original
+    // reference when nothing changed so callers can detect no-ops by identity.
+    return recomputedKey !== updated.key ? { ...updated, key: recomputedKey } : updated;
+  });
 
-    return item;
+  // Step 2: dedupe by key, keeping first occurrence.
+  const seen = new Set<string>();
+  return withIconAndKey.filter((item) => {
+    if (seen.has(item.key)) return false;
+    seen.add(item.key);
+    return true;
   });
 }
 
@@ -98,8 +127,15 @@ let listeners: Array<() => void> = [];
 const rawSnapshot = LOCAL_STORAGE_SERVICE.getItem(LS_KEY_SIDEBAR_PINNED_ITEMS) ?? [];
 let cachedSnapshot: PinnedPage[] = migratePinnedItems(rawSnapshot);
 
-// Save migrated items back to localStorage only if migration actually occurred
-const needsMigration = rawSnapshot.some((item: PinnedPage) => !item.iconType);
+// Persist migrated items back to localStorage only when something actually changed:
+// either an iconType was backfilled, a key was recomputed, or a duplicate was removed.
+// `migratePinnedItems` returns the original element reference for items it leaves
+// untouched and a fresh object only for items it changes, so reference inequality
+// detects any modification without recomputing keys a second time. A length change
+// means a duplicate was dropped; index comparison is only valid once lengths match.
+const needsMigration =
+  cachedSnapshot.length !== rawSnapshot.length || cachedSnapshot.some((item, i) => item !== rawSnapshot[i]);
+
 if (needsMigration && cachedSnapshot.length > 0) {
   LOCAL_STORAGE_SERVICE.setItem(LS_KEY_SIDEBAR_PINNED_ITEMS, cachedSnapshot);
 }
@@ -130,7 +166,10 @@ function getSnapshot(): PinnedPage[] {
 export function usePinnedItems() {
   const pinnedPages = useSyncExternalStore(subscribe, getSnapshot);
 
-  const isPinned = useCallback((key: string) => pinnedPages.some((p) => p.key === key), [pinnedPages]);
+  // Index keys into a Set so each row's lookup is O(1); the sidebar calls isPinned
+  // once per row, so a linear scan here would be O(rows × pins) on every render.
+  const pinnedKeys = useMemo(() => new Set(pinnedPages.map((p) => p.key)), [pinnedPages]);
+  const isPinned = useCallback((key: string) => pinnedKeys.has(key), [pinnedKeys]);
 
   const togglePin = useCallback((page: PinnedPage) => {
     const current: PinnedPage[] = LOCAL_STORAGE_SERVICE.getItem(LS_KEY_SIDEBAR_PINNED_ITEMS) ?? [];

--- a/apps/client/src/core/utils/pinKey/index.test.ts
+++ b/apps/client/src/core/utils/pinKey/index.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { buildPinKey } from "./index";
+
+describe("buildPinKey", () => {
+  describe("routes whose only param is clusterName", () => {
+    it("produces a key identical to the old page:<path> format", () => {
+      expect(buildPinKey("/c/$clusterName/cicd/pipelines", { clusterName: "dev" })).toBe(
+        "page:/c/$clusterName/cicd/pipelines"
+      );
+    });
+
+    it("produces the same key regardless of clusterName value", () => {
+      const a = buildPinKey("/c/$clusterName/cicd/pipelines", { clusterName: "prod" });
+      const b = buildPinKey("/c/$clusterName/cicd/pipelines", { clusterName: "dev" });
+      expect(a).toBe(b);
+    });
+
+    it("produces a key without a query suffix when params is empty", () => {
+      expect(buildPinKey("/c/$clusterName/cicd/pipelines", {})).toBe("page:/c/$clusterName/cicd/pipelines");
+    });
+
+    it("produces a key without a query suffix when params is omitted", () => {
+      expect(buildPinKey("/c/$clusterName/cicd/pipelines")).toBe("page:/c/$clusterName/cicd/pipelines");
+    });
+  });
+
+  describe("generic K8s list route parameterised by kind", () => {
+    it("produces distinct keys for different kinds", () => {
+      const deployments = buildPinKey("/c/$clusterName/k8s/$kind", {
+        clusterName: "dev",
+        kind: "deployments",
+      });
+      const statefulsets = buildPinKey("/c/$clusterName/k8s/$kind", {
+        clusterName: "dev",
+        kind: "statefulsets",
+      });
+      expect(deployments).not.toBe(statefulsets);
+    });
+
+    it("includes kind in the query suffix", () => {
+      expect(buildPinKey("/c/$clusterName/k8s/$kind", { clusterName: "dev", kind: "deployments" })).toBe(
+        "page:/c/$clusterName/k8s/$kind?kind=deployments"
+      );
+    });
+
+    it("is cluster-agnostic — same kind on different clusters yields identical key", () => {
+      const a = buildPinKey("/c/$clusterName/k8s/$kind", { clusterName: "cluster-a", kind: "jobs" });
+      const b = buildPinKey("/c/$clusterName/k8s/$kind", { clusterName: "cluster-b", kind: "jobs" });
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("CR list route parameterised by group, version, plural", () => {
+    it("includes all identifying params sorted by key name", () => {
+      expect(
+        buildPinKey("/c/$clusterName/k8s/cr/$group/$version/$plural", {
+          clusterName: "dev",
+          group: "apps",
+          version: "v1",
+          plural: "mycrds",
+        })
+      ).toBe("page:/c/$clusterName/k8s/cr/$group/$version/$plural?group=apps&plural=mycrds&version=v1");
+    });
+
+    it("produces the same key regardless of param insertion order", () => {
+      // params supplied in a different order — result must be identical
+      const a = buildPinKey("/c/$clusterName/k8s/cr/$group/$version/$plural", {
+        plural: "mycrds",
+        clusterName: "dev",
+        version: "v1",
+        group: "apps",
+      });
+      const b = buildPinKey("/c/$clusterName/k8s/cr/$group/$version/$plural", {
+        version: "v1",
+        group: "apps",
+        clusterName: "dev",
+        plural: "mycrds",
+      });
+      expect(a).toBe(b);
+    });
+
+    it("produces distinct keys for different group/version/plural combinations", () => {
+      const cr1 = buildPinKey("/c/$clusterName/k8s/cr/$group/$version/$plural", {
+        clusterName: "dev",
+        group: "apps",
+        version: "v1",
+        plural: "widgets",
+      });
+      const cr2 = buildPinKey("/c/$clusterName/k8s/cr/$group/$version/$plural", {
+        clusterName: "dev",
+        group: "apps",
+        version: "v1",
+        plural: "gadgets",
+      });
+      expect(cr1).not.toBe(cr2);
+    });
+  });
+});

--- a/apps/client/src/core/utils/pinKey/index.ts
+++ b/apps/client/src/core/utils/pinKey/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Builds a stable, cluster-agnostic pin key for a sidebar page.
+ *
+ * Format:
+ *   - No identifying params (or only `clusterName`): `page:<path>`
+ *   - With identifying params:                        `page:<path>?<k1>=<v1>&<k2>=<v2>`
+ *
+ * `clusterName` is always excluded so that pins are cluster-agnostic (a page
+ * pinned on cluster "dev" stays pinned when the user switches to "prod").
+ * Remaining params are sorted by key name to ensure deterministic output
+ * regardless of object insertion order. Keys and values are percent-encoded
+ * so distinct param sets can never serialize to the same key (e.g. a value
+ * containing `&` or `=`). Current K8s params are DNS-constrained, so encoding
+ * is an identity transform for every key that exists today.
+ *
+ * Examples:
+ *   buildPinKey("/c/$clusterName/cicd/pipelines", { clusterName: "dev" })
+ *   → "page:/c/$clusterName/cicd/pipelines"
+ *
+ *   buildPinKey("/c/$clusterName/k8s/$kind", { clusterName: "dev", kind: "deployments" })
+ *   → "page:/c/$clusterName/k8s/$kind?kind=deployments"
+ *
+ *   buildPinKey("/c/$clusterName/k8s/cr/$group/$version/$plural", { clusterName: "dev", group: "apps", plural: "mycrds", version: "v1" })
+ *   → "page:/c/$clusterName/k8s/cr/$group/$version/$plural?group=apps&plural=mycrds&version=v1"
+ */
+export function buildPinKey(path: string, params: Record<string, string> = {}): string {
+  const identifying = Object.entries(params)
+    .filter(([key]) => key !== "clusterName")
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  if (identifying.length === 0) {
+    return `page:${path}`;
+  }
+
+  const query = identifying.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&");
+  return `page:${path}?${query}`;
+}

--- a/apps/client/src/modules/k8s/constants/nav.ts
+++ b/apps/client/src/modules/k8s/constants/nav.ts
@@ -5,7 +5,7 @@ import { listRouteSlug } from "../registry/resolve";
 import type { SidebarGroup as RegistrySidebarGroup } from "../registry/types";
 import { PATH_K8S_CRDS_FULL, PATH_K8S_EVENTS_FULL, PATH_K8S_LIST_FULL, PATH_K8S_OVERVIEW_FULL } from "./paths";
 
-const groupIconMap: Record<RegistrySidebarGroup, typeof Layers> = {
+export const groupIconMap: Record<RegistrySidebarGroup, typeof Layers> = {
   Workloads: Layers,
   Network: Globe,
   Storage: HardDrive,

--- a/apps/client/src/modules/k8s/utils/pinned-icon.test.ts
+++ b/apps/client/src/modules/k8s/utils/pinned-icon.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { Bell, PanelsTopLeft, Puzzle } from "lucide-react";
+import { resourceRegistry } from "../registry";
+import { groupIconMap } from "../constants/nav";
+import { getK8sPinnedPageIcon } from "./pinned-icon";
+
+const page = (to: string, params: Record<string, string> = {}) => ({ route: { to, params } });
+
+describe("getK8sPinnedPageIcon", () => {
+  it("resolves generic-template kinds from the kind param", () => {
+    const descriptor = resourceRegistry.deployments;
+    const expected = descriptor.sidebarIcon ?? groupIconMap[descriptor.sidebarGroup];
+
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/k8s/$kind", { clusterName: "dev", kind: "deployments" }))).toBe(
+      expected
+    );
+  });
+
+  it("resolves dedicated list routes from the path slug", () => {
+    const descriptor = resourceRegistry.pods;
+    const expected = descriptor.sidebarIcon ?? groupIconMap[descriptor.sidebarGroup];
+
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/k8s/pods", { clusterName: "dev" }))).toBe(expected);
+  });
+
+  it("maps overview, events, and custom-resource routes to their static icons", () => {
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/k8s/overview"))).toBe(PanelsTopLeft);
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/k8s/events"))).toBe(Bell);
+    expect(
+      getK8sPinnedPageIcon(
+        page("/c/$clusterName/k8s/cr/$group/$version/$plural", { group: "g", version: "v1", plural: "things" })
+      )
+    ).toBe(Puzzle);
+  });
+
+  it("returns undefined for non-K8s routes so callers fall back to PAGE_ICONS", () => {
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/cicd/pipelines"))).toBeUndefined();
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/projects"))).toBeUndefined();
+  });
+
+  it("ignores a /k8s/ segment outside the K8s route prefix", () => {
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/cicd/k8s/pods"))).toBeUndefined();
+    expect(getK8sPinnedPageIcon(page("/other/k8s/pods"))).toBeUndefined();
+  });
+
+  it("returns undefined for unknown or missing kinds", () => {
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/k8s/$kind", { kind: "nonexistent" }))).toBeUndefined();
+    expect(getK8sPinnedPageIcon(page("/c/$clusterName/k8s/$kind"))).toBeUndefined();
+  });
+});

--- a/apps/client/src/modules/k8s/utils/pinned-icon.ts
+++ b/apps/client/src/modules/k8s/utils/pinned-icon.ts
@@ -1,0 +1,39 @@
+import { Bell, PanelsTopLeft, Puzzle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { PinnedPage } from "@/core/hooks/usePinnedItems";
+import { resourceRegistry } from "../registry";
+import { resolveDescriptor } from "../registry/resolve";
+import { groupIconMap } from "../constants/nav";
+
+/**
+ * Resolves the icon for a pinned K8s-mode page at render time.
+ *
+ * K8s list pages mostly share one generic route template (`/k8s/$kind`), so the
+ * static PATH_TO_ICON_TYPE map used for KRCI pins cannot distinguish them — the
+ * identity lives in route params, not the path. This resolver derives the kind
+ * from the stored route (the `kind` param for the generic template, the path
+ * slug for dedicated routes like `/k8s/pods`) and reuses the same registry
+ * icons the K8s sidebar renders, so pinned entries match their nav items.
+ *
+ * Returns undefined for non-K8s routes and unknown kinds so the caller can fall
+ * through to the static PAGE_ICONS registry / generic Box fallback.
+ */
+export function getK8sPinnedPageIcon(page: Pick<PinnedPage, "route">): LucideIcon | undefined {
+  // Anchored to the K8s route prefix so a `/k8s/` segment elsewhere in a
+  // non-K8s path can never trigger registry resolution.
+  const slugMatch = page.route.to.match(/^\/c\/\$clusterName\/k8s\/([^/]+)/);
+  if (!slugMatch) return undefined;
+  const slug = slugMatch[1];
+
+  if (slug === "overview") return PanelsTopLeft;
+  if (slug === "events") return Bell;
+  // Generic custom-resource routes (`/k8s/cr/$group/$version/$plural`).
+  if (slug === "cr") return Puzzle;
+
+  const kind = slug === "$kind" ? page.route.params.kind : slug;
+  if (!kind) return undefined;
+
+  const descriptor = resolveDescriptor(resourceRegistry, kind);
+  if (!descriptor) return undefined;
+  return descriptor.sidebarIcon ?? groupIconMap[descriptor.sidebarGroup];
+}


### PR DESCRIPTION
Generic K8s list pages share one route template, so every kind resolved to the same pin key — pinning one page toggled them all. Pin keys are now cluster-agnostic and include identifying route params, keeping a page pinned across cluster switches while distinguishing pages on shared templates.

- migrate stored pins in place: recompute keys, backfill icon types, drop duplicate entries
- unify the pin button into one component with correct hover-reveal scope per row container, consistent 12px icons, and an always-visible state for pinned entries
- resolve pinned K8s page icons from the resource registry since param-identified routes cannot live in the static path-to-icon map
- align the path-to-icon map with the actual route tree (webhook triggers, security, configuration) so pinned items stop falling back to the generic Box icon
- add unit tests, including a drift guard that fails when a nav route lacks an icon mapping

