### PR TITLE
EPMDEDP-17124: fix: populate Deployed version dropdown on CD promotion stages in multi-pipeline clusters

### DIFF
--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/components/columns/DeployedVersionConfiguration.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/components/columns/DeployedVersionConfiguration.tsx
@@ -45,9 +45,13 @@ export const DeployedVersionConfigurationColumn = ({
     (s) => (s.values as Record<string, unknown>)[fieldName] as string | undefined
   );
 
+  // Render options when EITHER stream is available. The input stream supplies the deployable
+  // tags ([LATEST] + history); the current stage's own verified stream only adds the optional
+  // [STABLE] entry. Requiring both (the previous behaviour) blanked the whole dropdown whenever
+  // the stage's own verified stream was missing, even though deployable tags were available.
   const imageStreamTagsOptions: SelectOption<string>[] = React.useMemo(
     () =>
-      appCodebaseImageStream && appCodebaseVerifiedImageStream
+      appCodebaseImageStream || appCodebaseVerifiedImageStream
         ? createImageStreamTags(appCodebaseImageStream, appCodebaseVerifiedImageStream)
         : [],
     [appCodebaseImageStream, appCodebaseVerifiedImageStream]

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/components/columns/DeployedVersionConfigurationHead.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/components/columns/DeployedVersionConfigurationHead.tsx
@@ -14,7 +14,11 @@ import {
   useStageListWatch,
 } from "@/modules/platform/cdpipelines/pages/stage-details/hooks";
 import { routeStageDetails } from "@/modules/platform/cdpipelines/pages/stage-details/route";
-import { CodebaseImageStream, Stage } from "@my-project/shared";
+import {
+  getVerifiedImageStream,
+  normalizeStreamNameSet,
+  resolveInputImageStream,
+} from "@/modules/platform/cdpipelines/pages/stage-details/utils/resolveStageImageStreams";
 
 export const DeployedVersionConfigurationHeadColumn = () => {
   const params = routeStageDetails.useParams();
@@ -37,6 +41,13 @@ export const DeployedVersionConfigurationHeadColumn = () => {
 
   const buttonsHighlighted = checkHighlightedButtons(values);
 
+  // All image tag field names — derived from the already-merged `values` object so keys from both
+  // active state and defaultValues are covered without a separate dedup step.
+  const allImageTagFields = React.useMemo(
+    () => Object.keys(values).filter((key) => key.includes(IMAGE_TAG_POSTFIX)),
+    [values]
+  );
+
   const isLoading =
     pipelineAppCodebasesWatch.isLoading ||
     imageStreamsWatch.isLoading ||
@@ -44,87 +55,29 @@ export const DeployedVersionConfigurationHeadColumn = () => {
     stageWatch.isLoading ||
     stageListWatch.isLoading;
 
-  // Helper functions for image stream lookups wrapped in useCallback to prevent recreating on every render
-  const findPreviousStage = React.useCallback((stages: Stage[], currentStageOrder: number): Stage | undefined => {
-    return stages.find(({ spec: { order: stageOrder } }) => stageOrder === currentStageOrder - 1);
-  }, []);
-
-  const createDockerStreamSet = React.useCallback((inputDockerStreams: string[] = []): Set<string> => {
-    const normalizedNames = inputDockerStreams.map((el) => el.replaceAll(".", "-"));
-    return new Set<string>(normalizedNames);
-  }, []);
-
-  const getLatestImageStream = React.useCallback(
-    (
-      imageStreams: CodebaseImageStream[],
-      codebaseName: string,
-      stageOrder: number,
-      inputDockerStreamsSet: Set<string>,
-      stages: Stage[],
-      cdPipelineName: string,
-      applicationsToPromote: string[] | null
-    ): CodebaseImageStream | undefined => {
-      const codebaseImageStreams = imageStreams.filter(({ spec: { codebase } }) => codebase === codebaseName);
-      const normalizedAppsToPromote = new Set(applicationsToPromote?.map((el) => el.replaceAll(".", "-")) || []);
-      const isPromote = normalizedAppsToPromote.has(codebaseName);
-
-      if (isPromote) {
-        if (stageOrder === 0) {
-          return codebaseImageStreams.find((el) => inputDockerStreamsSet.has(el.metadata.name));
-        }
-        const previousStage = findPreviousStage(stages, stageOrder);
-        if (!previousStage) return undefined;
-        return codebaseImageStreams.find(
-          ({ spec: { codebase }, metadata: { name } }) =>
-            name === `${cdPipelineName}-${previousStage.spec.name}-${codebase}-verified`
-        );
-      }
-
-      return codebaseImageStreams.find((el) => inputDockerStreamsSet.has(el.metadata.name));
-    },
-    [findPreviousStage]
-  );
-
-  const getVerifiedImageStream = React.useCallback(
-    (
-      imageStreams: CodebaseImageStream[],
-      cdPipelineName: string,
-      stageName: string,
-      codebaseName: string
-    ): CodebaseImageStream | undefined => {
-      return imageStreams.find(
-        ({ metadata: { name } }) => name === `${cdPipelineName}-${stageName}-${codebaseName}-verified`
-      );
-    },
-    []
-  );
-
   const handleClickLatest = React.useCallback(() => {
     if (isLoading || !cdPipelineWatch.data || !stageWatch.data) {
       return;
     }
 
-    const inputDockerStreamsSet = createDockerStreamSet(cdPipelineWatch.data.spec.inputDockerStreams);
-
-    // Get all image tag field names from both state.values and defaultValues
-    const stateKeys = Object.keys(form.state.values).filter((key) => key.includes(IMAGE_TAG_POSTFIX));
-    const defaultKeys = Object.keys(form.options.defaultValues || {}).filter((key) => key.includes(IMAGE_TAG_POSTFIX));
-    const allImageTagFields = Array.from(new Set([...stateKeys, ...defaultKeys]));
+    const inputDockerStreamsSet = normalizeStreamNameSet(cdPipelineWatch.data.spec.inputDockerStreams ?? []);
+    const appsToPromoteSet = normalizeStreamNameSet(cdPipelineWatch.data.spec.applicationsToPromote ?? []);
 
     // Process all image tag fields to set their latest values
     for (const fieldName of allImageTagFields) {
       // Extract app name from field name (remove IMAGE_TAG_POSTFIX)
       const appName = fieldName.replace(IMAGE_TAG_POSTFIX, "");
 
-      const latestImageStream = getLatestImageStream(
-        imageStreamsWatch.data.array,
-        appName,
-        stageWatch.data.spec.order,
+      const appImageStreams = imageStreamsWatch.data.array.filter(({ spec: { codebase } }) => codebase === appName);
+
+      const latestImageStream = resolveInputImageStream({
+        imageStreams: appImageStreams,
+        stageOrder: stageWatch.data.spec.order,
         inputDockerStreamsSet,
-        stageListWatch.data.array,
-        params.cdPipeline,
-        cdPipelineWatch.data.spec.applicationsToPromote ?? null
-      );
+        stages: stageListWatch.data.array,
+        cdPipelineName: params.cdPipeline,
+        isPromote: appsToPromoteSet.has(appName),
+      });
 
       if (!latestImageStream?.spec?.tags?.length) {
         continue;
@@ -143,25 +96,19 @@ export const DeployedVersionConfigurationHeadColumn = () => {
     }
   }, [
     isLoading,
+    allImageTagFields,
     cdPipelineWatch.data,
     stageWatch.data,
     imageStreamsWatch.data.array,
     stageListWatch.data.array,
     params.cdPipeline,
     form,
-    createDockerStreamSet,
-    getLatestImageStream,
   ]);
 
   const handleClickStable = React.useCallback(() => {
     if (isLoading || !stageWatch.data) {
       return;
     }
-
-    // Get all image tag field names from both state.values and defaultValues
-    const stateKeys = Object.keys(form.state.values).filter((key) => key.includes(IMAGE_TAG_POSTFIX));
-    const defaultKeys = Object.keys(form.options.defaultValues || {}).filter((key) => key.includes(IMAGE_TAG_POSTFIX));
-    const allImageTagFields = Array.from(new Set([...stateKeys, ...defaultKeys]));
 
     // Process all image tag fields to set their stable values
     for (const fieldName of allImageTagFields) {
@@ -202,12 +149,12 @@ export const DeployedVersionConfigurationHeadColumn = () => {
     }
   }, [
     isLoading,
+    allImageTagFields,
     stageWatch.data,
     imageStreamsWatch.data.array,
     params.cdPipeline,
     params.stage,
     form,
-    getVerifiedImageStream,
   ]);
 
   return (

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/utils/createImageStreamTags/index.test.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/utils/createImageStreamTags/index.test.ts
@@ -97,6 +97,32 @@ describe("createImageStreamTags", () => {
     expect(result).toEqual([]);
   });
 
+  // Guard-relaxation path: the column now calls this whenever EITHER stream is present (previously
+  // it required both, blanking the dropdown when a stage's own verified stream was missing).
+  it("should return deployable tags when only the input stream is present (verified undefined)", () => {
+    const appStream = createMockImageStream(["tag-1", "tag-2"]);
+
+    const result = createImageStreamTags(appStream, undefined);
+
+    expect(result).toEqual([
+      { label: "[LATEST] - tag-2", value: "latest::tag-2" },
+      { label: "tag-2", value: "tag-2" },
+      { label: "tag-1", value: "tag-1" },
+    ]);
+  });
+
+  it("should return only the STABLE entry when just the verified stream is present (input undefined)", () => {
+    const verifiedStream = createMockImageStream(["stable-1"]);
+
+    const result = createImageStreamTags(undefined, verifiedStream);
+
+    expect(result).toEqual([{ label: "[STABLE] - stable-1", value: "stable::stable-1" }]);
+  });
+
+  it("should return an empty list when both streams are undefined", () => {
+    expect(createImageStreamTags(undefined, undefined)).toEqual([]);
+  });
+
   it("should reverse tag order (newest first)", () => {
     const appStream = createMockImageStream(["old-tag", "middle-tag", "new-tag"]);
     const verifiedStream = createMockImageStream([]);

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/utils/createImageStreamTags/index.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/utils/createImageStreamTags/index.ts
@@ -2,38 +2,21 @@ import { SelectOption } from "@/core/types/forms";
 import { CodebaseImageStream } from "@my-project/shared";
 
 export const createImageStreamTags = (
-  applicationImageStream: CodebaseImageStream,
-  applicationVerifiedImageStream: CodebaseImageStream
+  applicationImageStream: CodebaseImageStream | undefined,
+  applicationVerifiedImageStream: CodebaseImageStream | undefined
 ) => {
-  let base: SelectOption<string>[] =
-    applicationImageStream && applicationImageStream?.spec?.tags
-      ? applicationImageStream?.spec?.tags
-          .map(({ name }) => ({
-            label: name,
-            value: name,
-          }))
-          .reverse()
-      : [];
+  const tags = applicationImageStream?.spec?.tags ?? [];
 
-  if (applicationImageStream?.spec?.tags?.length) {
-    const latestTagValue = applicationImageStream?.spec?.tags.at(-1)?.name;
-    const latest = {
-      label: `[LATEST] - ${latestTagValue}`,
-      value: `latest::${latestTagValue}`,
-    };
+  let base: SelectOption<string>[] = tags.map(({ name }) => ({ label: name, value: name })).reverse();
 
-    base = [latest, ...base];
+  if (tags.length) {
+    const latestTagValue = tags.at(-1)?.name;
+    base = [{ label: `[LATEST] - ${latestTagValue}`, value: `latest::${latestTagValue}` }, ...base];
   }
 
   if (applicationVerifiedImageStream?.spec?.tags?.length) {
-    const latestTagValue = applicationVerifiedImageStream?.spec?.tags.at(-1)?.name;
-
-    const stable = {
-      label: `[STABLE] - ${latestTagValue}`,
-      value: `stable::${latestTagValue}`,
-    };
-
-    base = [stable, ...base];
+    const latestTagValue = applicationVerifiedImageStream.spec.tags.at(-1)?.name;
+    base = [{ label: `[STABLE] - ${latestTagValue}`, value: `stable::${latestTagValue}` }, ...base];
   }
 
   return base;

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/hooks/index.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/hooks/index.ts
@@ -24,6 +24,11 @@ import { useGitServerWatchList } from "@/k8s/api/groups/KRCI/GitServer";
 import { useConfigMapWatchItem } from "@/k8s/api/groups/Core/ConfigMap";
 import { useTriggerTemplateWatchItem } from "@/k8s/api/groups/Tekton/TriggerTemplate";
 import { routeStageDetails } from "../route";
+import {
+  getVerifiedImageStream,
+  normalizeStreamNameSet,
+  resolveInputImageStream,
+} from "../utils/resolveStageImageStreams";
 
 export const useWatchApplicationsPods = () => true; // noop
 
@@ -204,58 +209,6 @@ export interface StageAppCodebasesCombinedDataResult {
   isReady: boolean;
 }
 
-const findPreviousStage = (stages: Stage[], currentStageOrder: number): Stage | undefined => {
-  return stages.find(({ spec: { order: stageOrder } }) => stageOrder === currentStageOrder - 1);
-};
-
-const createDockerStreamSet = (inputDockerStreams: string[] = []): Set<string> => {
-  const normalizedNames = inputDockerStreams.map((el) => el.replaceAll(".", "-"));
-  return new Set<string>(normalizedNames);
-};
-
-const createAppToPromoteSet = (applicationsToPromote: string[] | null = []): Set<string> => {
-  const normalizedNames = applicationsToPromote?.map((el) => el.replaceAll(".", "-")) || [];
-  return new Set<string>(normalizedNames);
-};
-
-const getImageStreamByStageOrder = (
-  imageStreams: CodebaseImageStream[],
-  order: number,
-  inputDockerStreamsSet: Set<string>,
-  stages: Stage[],
-  cdPipelineName: string
-): CodebaseImageStream | undefined => {
-  if (order === 0) {
-    return imageStreams.find((el) => inputDockerStreamsSet.has(el.metadata.name));
-  }
-
-  const previousStage = findPreviousStage(stages, order);
-  if (!previousStage) {
-    return undefined;
-  }
-
-  return imageStreams.find(
-    ({ spec: { codebase }, metadata: { name } }) =>
-      name === `${cdPipelineName}-${previousStage.spec.name}-${codebase}-verified`
-  );
-};
-
-const getImageStreamByToPromoteFlag = (
-  imageStreams: CodebaseImageStream[],
-  inputDockerStreamsSet: Set<string>
-): CodebaseImageStream | undefined => {
-  return imageStreams.find((el) => inputDockerStreamsSet.has(el.metadata.name));
-};
-
-const getVerifiedImageStream = (
-  imageStreams: CodebaseImageStream[],
-  cdPipelineName: string,
-  stageName: string,
-  codebase: string
-): CodebaseImageStream | undefined => {
-  return imageStreams.find(({ metadata: { name } }) => name === `${cdPipelineName}-${stageName}-${codebase}-verified`);
-};
-
 const findArgoApplicationByCodebaseName = (
   argoApplications: Application[],
   appName: string
@@ -304,15 +257,14 @@ const processAppCodebase = (
 
   const application = findArgoApplicationByCodebaseName(argoApplications, appName);
 
-  const appCodebaseImageStream = isPromote
-    ? getImageStreamByStageOrder(
-        appCodebaseImageStreamList,
-        stageOrder,
-        cdPipelineInputDockerStreamsSet,
-        stages,
-        cdPipelineName
-      )
-    : getImageStreamByToPromoteFlag(appCodebaseImageStreamList, cdPipelineInputDockerStreamsSet);
+  const appCodebaseImageStream = resolveInputImageStream({
+    imageStreams: appCodebaseImageStreamList,
+    stageOrder,
+    inputDockerStreamsSet: cdPipelineInputDockerStreamsSet,
+    stages,
+    cdPipelineName,
+    isPromote,
+  });
 
   return {
     appCodebase,
@@ -374,8 +326,8 @@ export const useStageAppCodebasesCombinedData = (): StageAppCodebasesCombinedDat
     );
 
     const cdPipelineApplicationToPromoteListSet = new Set<string>(cdPipeline.spec.applicationsToPromote ?? []);
-    const cdPipelineAppsToPromoteSet = createAppToPromoteSet(cdPipeline.spec.applicationsToPromote ?? null);
-    const cdPipelineInputDockerStreamsSet = createDockerStreamSet(cdPipeline.spec.inputDockerStreams);
+    const cdPipelineAppsToPromoteSet = normalizeStreamNameSet(cdPipeline.spec.applicationsToPromote ?? []);
+    const cdPipelineInputDockerStreamsSet = normalizeStreamNameSet(cdPipeline.spec.inputDockerStreams ?? []);
 
     const stageAppCodebasesCombinedData = stageAppCodebaseList.map((appCodebase: Codebase) =>
       processAppCodebase(appCodebase, {

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/utils/resolveStageImageStreams/index.test.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/utils/resolveStageImageStreams/index.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { CodebaseImageStream, Stage } from "@my-project/shared";
+import { findPreviousStage, getVerifiedImageStream, normalizeStreamNameSet, resolveInputImageStream } from "./index";
+
+const makeStage = (cdPipeline: string, name: string, order: number): Stage =>
+  ({ spec: { cdPipeline, name, order } }) as unknown as Stage;
+
+const makeStream = (name: string, codebase: string, tags: string[] = []): CodebaseImageStream =>
+  ({
+    metadata: { name },
+    spec: { codebase, tags: tags.map((t) => ({ name: t, created: "2026-01-01T00:00:00Z" })) },
+  }) as unknown as CodebaseImageStream;
+
+describe("normalizeStreamNameSet", () => {
+  it("replaces dots with dashes and dedupes", () => {
+    const set = normalizeStreamNameSet(["app.one-main", "app-two-main", "app.one-main"]);
+    expect(set.has("app-one-main")).toBe(true);
+    expect(set.has("app-two-main")).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it("treats undefined as empty", () => {
+    expect(normalizeStreamNameSet(undefined).size).toBe(0);
+  });
+});
+
+describe("findPreviousStage", () => {
+  // Every pipeline's stages share one namespace. The regression: an order-0 stage from a
+  // DIFFERENT pipeline must never be picked as the previous stage just because it matches `order`.
+  const stages = [
+    makeStage("other", "sit", 0), // foreign pipeline, sorts first, same order — the trap
+    makeStage("demo", "dev", 0),
+    makeStage("demo", "qa", 1),
+    makeStage("demo", "prod", 2),
+  ];
+
+  it("returns the previous stage within the same pipeline, ignoring foreign same-order stages", () => {
+    const prev = findPreviousStage(stages, 1, "demo");
+    expect(prev?.spec.cdPipeline).toBe("demo");
+    expect(prev?.spec.name).toBe("dev");
+  });
+
+  it("returns undefined when the pipeline has no stage at order - 1", () => {
+    expect(findPreviousStage(stages, 1, "nonexistent")).toBeUndefined();
+  });
+});
+
+describe("getVerifiedImageStream", () => {
+  it("matches <pipeline>-<stage>-<codebase>-verified", () => {
+    const streams = [
+      makeStream("demo-qa-test-go-app-verified", "test-go-app", ["main-1"]),
+      makeStream("demo-dev-test-go-app-verified", "test-go-app", ["main-1"]),
+    ];
+    expect(getVerifiedImageStream(streams, "demo", "qa", "test-go-app")?.metadata.name).toBe(
+      "demo-qa-test-go-app-verified"
+    );
+  });
+
+  it("returns undefined when the stage has no own verified stream", () => {
+    expect(getVerifiedImageStream([], "demo", "qa", "test-go-app")).toBeUndefined();
+  });
+});
+
+describe("resolveInputImageStream", () => {
+  const build = makeStream("test-go-app-main", "test-go-app", ["main-1"]);
+  const devVerified = makeStream("demo-dev-test-go-app-verified", "test-go-app", ["main-1"]);
+  const inputDockerStreamsSet = normalizeStreamNameSet(["test-go-app-main"]);
+
+  const stages = [
+    makeStage("other", "sit", 0), // foreign order-0 stage with a DIFFERENT name, listed first
+    makeStage("demo", "dev", 0),
+    makeStage("demo", "qa", 1),
+  ];
+
+  it("order 0 (promote): resolves the pipeline's build stream", () => {
+    const result = resolveInputImageStream({
+      imageStreams: [build, devVerified],
+      stageOrder: 0,
+      inputDockerStreamsSet,
+      stages,
+      cdPipelineName: "demo",
+      isPromote: true,
+    });
+    expect(result?.metadata.name).toBe("test-go-app-main");
+  });
+
+  // Core regression: at order 1 the dropdown must read the PREVIOUS stage's verified stream of
+  // the SAME pipeline (demo-dev-...), not be blanked by the foreign "sit" stage sorted first.
+  it("order 1 (promote): resolves the same pipeline's previous-stage verified stream despite a foreign order-0 stage", () => {
+    const result = resolveInputImageStream({
+      imageStreams: [build, devVerified],
+      stageOrder: 1,
+      inputDockerStreamsSet,
+      stages,
+      cdPipelineName: "demo",
+      isPromote: true,
+    });
+    expect(result?.metadata.name).toBe("demo-dev-test-go-app-verified");
+  });
+
+  it("order 1 (promote): returns undefined when the same pipeline has no previous stage", () => {
+    const result = resolveInputImageStream({
+      imageStreams: [build, devVerified],
+      stageOrder: 1,
+      inputDockerStreamsSet,
+      stages: [makeStage("other", "sit", 0)],
+      cdPipelineName: "demo",
+      isPromote: true,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("non-promote app: resolves the build stream regardless of order", () => {
+    const result = resolveInputImageStream({
+      imageStreams: [build, devVerified],
+      stageOrder: 1,
+      inputDockerStreamsSet,
+      stages,
+      cdPipelineName: "demo",
+      isPromote: false,
+    });
+    expect(result?.metadata.name).toBe("test-go-app-main");
+  });
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/utils/resolveStageImageStreams/index.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/utils/resolveStageImageStreams/index.ts
@@ -1,0 +1,74 @@
+import { CodebaseImageStream, Stage } from "@my-project/shared";
+
+/** Normalize CR names to their image-stream form (dots → dashes) and dedupe into a Set. */
+export const normalizeStreamNameSet = (names: string[] = []): Set<string> =>
+  new Set(names.map((name) => name.replaceAll(".", "-")));
+
+/**
+ * Find the stage immediately preceding `currentStageOrder` **within the same CD pipeline**.
+ *
+ * Every pipeline's Stages live in one namespace, so matching on `order` alone — the previous
+ * behaviour — can return a foreign pipeline's stage whose `spec.name` differs. That makes the
+ * `<pipeline>-<prevStage>-<codebase>-verified` lookup below resolve to nothing, leaving an empty
+ * "Deployed version" dropdown for every application on the stage. Scoping by `cdPipeline`
+ * prevents that cross-pipeline collision.
+ */
+export const findPreviousStage = (
+  stages: Stage[],
+  currentStageOrder: number,
+  cdPipelineName: string
+): Stage | undefined =>
+  stages.find((stage) => stage.spec.order === currentStageOrder - 1 && stage.spec.cdPipeline === cdPipelineName);
+
+/** The stage's own verified stream: `<pipeline>-<stage>-<codebase>-verified`. */
+export const getVerifiedImageStream = (
+  imageStreams: CodebaseImageStream[],
+  cdPipelineName: string,
+  stageName: string,
+  codebase: string
+): CodebaseImageStream | undefined =>
+  imageStreams.find(({ metadata: { name } }) => name === `${cdPipelineName}-${stageName}-${codebase}-verified`);
+
+export interface ResolveInputImageStreamParams {
+  /** Image streams already filtered to a single codebase. */
+  imageStreams: CodebaseImageStream[];
+  stageOrder: number;
+  /** Normalized set of the pipeline's `inputDockerStreams`. */
+  inputDockerStreamsSet: Set<string>;
+  /** All stages in the namespace (scoped to the pipeline internally). */
+  stages: Stage[];
+  cdPipelineName: string;
+  /** Whether this application is in the pipeline's `applicationsToPromote`. */
+  isPromote: boolean;
+}
+
+/**
+ * Resolve the CodebaseImageStream whose tags populate the "Deployed version" dropdown for one
+ * application on a stage:
+ *  - non-promote application, or the first stage (order 0): the pipeline's build stream
+ *    (`inputDockerStreams`);
+ *  - promote application on a later stage: the previous stage's
+ *    `<pipeline>-<prevStage>-<codebase>-verified` stream.
+ */
+export const resolveInputImageStream = ({
+  imageStreams,
+  stageOrder,
+  inputDockerStreamsSet,
+  stages,
+  cdPipelineName,
+  isPromote,
+}: ResolveInputImageStreamParams): CodebaseImageStream | undefined => {
+  if (!isPromote || stageOrder === 0) {
+    return imageStreams.find((stream) => inputDockerStreamsSet.has(stream.metadata.name));
+  }
+
+  const previousStage = findPreviousStage(stages, stageOrder, cdPipelineName);
+  if (!previousStage) {
+    return undefined;
+  }
+
+  return imageStreams.find(
+    ({ spec: { codebase }, metadata: { name } }) =>
+      name === `${cdPipelineName}-${previousStage.spec.name}-${codebase}-verified`
+  );
+};


### PR DESCRIPTION
The promotion stage's input image stream was resolved from the previous stage found by order alone, unscoped to the CD pipeline. Since all pipelines' stages share one namespace, a foreign pipeline's stage could be selected, yielding a non-existent <pipeline>-<prevStage>-<codebase>-verified name and an empty "Deployed version" dropdown for every application on stages of order >= 1.

- Scope the previous-stage lookup to its CD pipeline and extract a shared resolver, removing the duplicate buggy copy that also broke the latest/stable quick-set buttons
- Relax the dropdown render guard from && to || so the input stream's tags still show when the stage's own verified stream is absent (it only adds the optional [STABLE] entry)
- Add regression tests covering the cross-pipeline collision and the guard relaxation

