### PR TITLE
EPMDEDP-17123: fix: honor allowed namespaces in Kubernetes mode list views

### DIFF
--- a/apps/client/src/k8s/api/hooks/useWatch/types.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/types.ts
@@ -67,6 +67,7 @@ export interface UseWatchListMultipleResult<I extends KubeObjectBase> {
   query: UseQueryResult<WatchListMultipleData<I>, RequestError>;
   dataVersion: string | undefined;
   errors: RequestError[];
+  error: RequestError | null; // Convenience: first per-namespace error, for table components
   isEmpty: boolean;
   isLoading: boolean;
   isReady: boolean;

--- a/apps/client/src/k8s/api/hooks/useWatch/useWatchListMultiple/index.ts
+++ b/apps/client/src/k8s/api/hooks/useWatch/useWatchListMultiple/index.ts
@@ -39,7 +39,7 @@ export interface UseWatchListMultipleParams<I extends KubeObjectBase> {
 const getCombinedQueryKey = (
   clusterName: string,
   resourcePluralName: string,
-  namespaces: string[],
+  namespaces: (string | undefined)[],
   labels?: ResourceLabels
 ) => {
   return [
@@ -68,22 +68,13 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
   );
   const queryClient = useQueryClient();
 
-  // Use provided namespaces or fall back to allowedNamespaces from store
-  const _namespaces = namespaces ?? allowedNamespaces;
+  // Cluster-scoped resources collapse to a single cluster-wide query (namespace =
+  // undefined); fanning out per allowed namespace would just merge duplicate rows.
+  const isClusterScoped = !!resourceConfig.clusterScoped;
+  const _namespaces: (string | undefined)[] = isClusterScoped ? [undefined] : (namespaces ?? allowedNamespaces);
 
-  // Stable reference for namespaces array
-  const namespacesKey = useMemo(
-    () => _namespaces.join(","),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [_namespaces.join(",")]
-  );
-
-  // Stable reference for labels
-  const labelsKey = useMemo(
-    () => (labels ? JSON.stringify(labels) : undefined),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [labels ? JSON.stringify(labels) : undefined]
-  );
+  const namespacesKey = _namespaces.join(",");
+  const labelsKey = labels ? JSON.stringify(labels) : undefined;
 
   // Generate query keys for all namespaces
   const namespaceQueryKeys = useMemo(
@@ -244,9 +235,10 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
     staleTime: queryOptions?.staleTime,
   });
 
-  const dataVersion = useMemo(() => {
-    return namespaceQueries.map((q) => q.data?.metadata?.resourceVersion).join(",");
-  }, [namespaceQueries]);
+  // Not memoized: the merge effect below depends on this and must re-derive on
+  // every incoming watch event (a useMemo keyed on the always-new query array
+  // would never cache anyway).
+  const dataVersion = namespaceQueries.map((q) => q.data?.metadata?.resourceVersion).join(",");
 
   // Update combined query data whenever namespace queries change
   useEffect(() => {
@@ -255,22 +247,24 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
 
     _namespaces.forEach((ns, index) => {
       const query = namespaceQueries[index];
+      // Cluster-scoped resources have an `undefined` namespace; key the Maps by "".
+      const nsKey = ns ?? "";
 
       if (query.isError && query.error) {
-        byNamespace.set(ns, { array: [], map: new Map() });
+        byNamespace.set(nsKey, { array: [], map: new Map() });
         return;
       }
 
       const items = query.data?.items || new Map<string, I>();
       const itemsArray = Array.from(items.values());
 
-      byNamespace.set(ns, {
+      byNamespace.set(nsKey, {
         array: itemsArray,
         map: items,
       });
 
       items.forEach((item: I, name: string) => {
-        mergedMap.set(`${ns}/${name}`, item);
+        mergedMap.set(`${nsKey}/${name}`, item);
       });
     });
 
@@ -308,6 +302,7 @@ export const useWatchListMultiple = <I extends KubeObjectBase>({
     query: combinedQuery,
     dataVersion,
     errors,
+    error: errors[0] ?? null,
     isEmpty: (combinedQuery.data?.array.length ?? 0) === 0,
     isLoading,
     isReady,

--- a/apps/client/src/k8s/store/index.ts
+++ b/apps/client/src/k8s/store/index.ts
@@ -31,18 +31,27 @@ const saveSettingsToStorage = (settings: ClusterSettings) => {
   LOCAL_STORAGE_SERVICE.setItem(LOCAL_STORAGE_KEY, settings);
 };
 
-export const useClusterStore = create<ClusterStore>((set, get) => {
-  const clusterName = K8S_DEFAULT_CLUSTER_NAME;
-  const settings = getSettingsFromStorage();
-  const clusterSettings = settings[clusterName] || {
-    default_namespace: K8S_DEFAULT_CLUSTER_NAMESPACE,
-    allowed_namespaces: [K8S_DEFAULT_CLUSTER_NAMESPACE],
-  };
+// Cluster name and default namespace come from the server's DEFAULT_CLUSTER_* env
+// vars at runtime (via ConfigProvider); the build-time VITE_* constants are dev-only
+// fallbacks, normally undefined in production. Coerce to "" and never persist under an
+// empty cluster name — an undefined fallback used to seed a bogus `{"undefined": …}` entry.
+const FALLBACK_CLUSTER_NAME = K8S_DEFAULT_CLUSTER_NAME || "";
+const FALLBACK_NAMESPACE = K8S_DEFAULT_CLUSTER_NAMESPACE || "";
+const seedAllowedNamespaces = (namespace: string): string[] => (namespace ? [namespace] : []);
 
-  if (!settings[clusterName]) {
+export const useClusterStore = create<ClusterStore>((set, get) => {
+  const clusterName = FALLBACK_CLUSTER_NAME;
+  const settings = getSettingsFromStorage();
+  const persisted = clusterName ? settings[clusterName] : undefined;
+
+  const defaultNamespace = persisted?.default_namespace ?? FALLBACK_NAMESPACE;
+  const allowedNamespaces = persisted?.allowed_namespaces ?? seedAllowedNamespaces(FALLBACK_NAMESPACE);
+
+  // Seed only for a known cluster with nothing stored yet (see note above).
+  if (clusterName && !persisted) {
     settings[clusterName] = {
-      default_namespace: K8S_DEFAULT_CLUSTER_NAMESPACE,
-      allowed_namespaces: [K8S_DEFAULT_CLUSTER_NAMESPACE],
+      default_namespace: defaultNamespace,
+      allowed_namespaces: allowedNamespaces,
     };
     saveSettingsToStorage(settings);
   }
@@ -51,21 +60,18 @@ export const useClusterStore = create<ClusterStore>((set, get) => {
     clusterName,
     setClusterName: (newClusterName) => {
       const settings = getSettingsFromStorage();
-      const newClusterSettings = settings[newClusterName] || {
-        default_namespace: K8S_DEFAULT_CLUSTER_NAMESPACE,
-        allowed_namespaces: [K8S_DEFAULT_CLUSTER_NAMESPACE],
-      };
+      const persisted = settings[newClusterName];
       set({
         clusterName: newClusterName,
-        defaultNamespace: newClusterSettings.default_namespace,
-        allowedNamespaces: newClusterSettings.allowed_namespaces,
+        defaultNamespace: persisted?.default_namespace ?? FALLBACK_NAMESPACE,
+        allowedNamespaces: persisted?.allowed_namespaces ?? seedAllowedNamespaces(FALLBACK_NAMESPACE),
         clusterNameResolved: true,
       });
     },
 
     clusterNameResolved: !!clusterName,
 
-    defaultNamespace: clusterSettings.default_namespace,
+    defaultNamespace,
     setDefaultNamespace: (newDefaultNamespace) => {
       const { clusterName, allowedNamespaces, defaultNamespace } = get();
       const settings = getSettingsFromStorage();
@@ -94,7 +100,7 @@ export const useClusterStore = create<ClusterStore>((set, get) => {
       });
     },
 
-    allowedNamespaces: clusterSettings.allowed_namespaces,
+    allowedNamespaces,
     setAllowedNamespaces: (newAllowedNamespaces) => {
       const { clusterName } = get();
       const settings = getSettingsFromStorage();

--- a/apps/client/src/modules/k8s/components/ResourceTable/index.tsx
+++ b/apps/client/src/modules/k8s/components/ResourceTable/index.tsx
@@ -21,7 +21,10 @@ interface Props<T extends KubeObjectBase> {
   items: T[];
   descriptor: ResourceDescriptor;
   isLoading: boolean;
-  error: Error | null;
+  /** Blocking error — replaces the whole table. */
+  error?: Error | null;
+  /** Non-blocking errors — shown as a banner above the table while accessible data still renders. */
+  errors?: Error[] | null;
   tableId?: string;
   namespace?: string;
   filterFunction?: (item: KubeObjectBase) => boolean;
@@ -114,6 +117,7 @@ export function ResourceTable<T extends KubeObjectBase>({
   descriptor,
   isLoading,
   error,
+  errors,
   tableId,
   namespace,
   filterFunction,
@@ -187,7 +191,8 @@ export function ResourceTable<T extends KubeObjectBase>({
         data={items as KubeObjectBase[]}
         columns={columns}
         isLoading={isLoading}
-        blockerError={error}
+        blockerError={error ?? null}
+        errors={errors}
         filterFunction={filterFunction}
         slots={slots}
         sort={

--- a/apps/client/src/modules/k8s/hooks/useCRList.ts
+++ b/apps/client/src/modules/k8s/hooks/useCRList.ts
@@ -1,15 +1,29 @@
 import { useMemo } from "react";
 import { useWatchList } from "@/k8s/api/hooks/useWatch/useWatchList";
+import { useWatchListMultiple } from "@/k8s/api/hooks/useWatch/useWatchListMultiple";
 import type { CRDObject, KubeObjectBase } from "@my-project/shared";
 import { buildCRDescriptor } from "../registry/dynamic/buildCRDescriptor";
 
-export function useCRList(crd: CRDObject, namespace?: string, preferredVersion?: string) {
-  // Narrow dep to resourceVersion: useWatchList rebuilds the CRD array on every
-  // watch tick, so closing over `crd` would re-run buildCRDescriptor on each event.
-  const config = useMemo(
+// Narrow dep to resourceVersion/uid: the watch hooks rebuild the CRD array on
+// every tick, so closing over `crd` would re-run buildCRDescriptor on each event.
+function useCRDConfig(crd: CRDObject, preferredVersion?: string) {
+  return useMemo(
     () => buildCRDescriptor(crd, preferredVersion).config,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [crd.metadata?.resourceVersion, crd.metadata?.uid, preferredVersion]
   );
+}
+
+export function useCRList(crd: CRDObject, namespace?: string, preferredVersion?: string) {
+  const config = useCRDConfig(crd, preferredVersion);
   return useWatchList<KubeObjectBase>({ resourceConfig: config, namespace });
+}
+
+/** Namespace-aware {@link useCRList}: lists a custom resource across the cluster's allowed namespaces. */
+export function useCRListMulti(crd: CRDObject, namespaces?: string[], preferredVersion?: string) {
+  const config = useCRDConfig(crd, preferredVersion);
+  return useWatchListMultiple<KubeObjectBase>({
+    resourceConfig: config,
+    namespaces,
+  });
 }

--- a/apps/client/src/modules/k8s/hooks/useK8sResourceListMulti.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sResourceListMulti.ts
@@ -1,0 +1,22 @@
+import { useWatchListMultiple } from "@/k8s/api/hooks/useWatch/useWatchListMultiple";
+import type { K8sResourceConfig, KubeObjectBase } from "@my-project/shared";
+
+export interface UseK8sResourceListMultiOptions {
+  /** Namespaces to list across; falls back to the cluster's allowed namespaces when omitted. */
+  namespaces?: string[];
+}
+
+/**
+ * Namespace-aware counterpart to {@link useK8sResourceList}: lists a resource
+ * across the cluster's allowed namespaces (or a narrowed selection) so the
+ * "Allowed namespaces" setting is honoured rather than only the default namespace.
+ */
+export function useK8sResourceListMulti<T extends KubeObjectBase>(
+  config: K8sResourceConfig,
+  options?: UseK8sResourceListMultiOptions
+) {
+  return useWatchListMultiple<T>({
+    resourceConfig: config,
+    namespaces: options?.namespaces,
+  });
+}

--- a/apps/client/src/modules/k8s/hooks/useK8sWatchStatus.ts
+++ b/apps/client/src/modules/k8s/hooks/useK8sWatchStatus.ts
@@ -1,0 +1,14 @@
+import { useMemo } from "react";
+import type { RequestError } from "@/core/types/global";
+import { formatK8sErrors } from "../utils/formatK8sErrors";
+import type { WatchStatus } from "../components/WatchConnectionIndicator";
+
+/** Derives the non-blocking error banner and connection status from a multi-namespace watch's raw errors. */
+export function useK8sWatchStatus(rawErrors: RequestError[] | null | undefined): {
+  errors: Error[];
+  watchStatus: WatchStatus;
+} {
+  const errors = useMemo(() => formatK8sErrors(rawErrors), [rawErrors]);
+  const watchStatus: WatchStatus = errors.length > 0 ? "error" : "connected";
+  return { errors, watchStatus };
+}

--- a/apps/client/src/modules/k8s/hooks/useNamespaceFilterOptions.ts
+++ b/apps/client/src/modules/k8s/hooks/useNamespaceFilterOptions.ts
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import { useSearch } from "@tanstack/react-router";
+import { useShallow } from "zustand/react/shallow";
+import { useClusterStore } from "@/k8s/store";
+import type { SelectOption } from "@/core/components/form";
+
+/**
+ * Options/visibility for the K8s-mode "Namespaces" filter. Shown only when more
+ * than one namespace is allowed, and hidden when a `?namespace=` deep-link pins
+ * the view to one namespace — the fetch ignores the filter selection in that mode
+ * (see `resolveListNamespaces`), so showing it could only empty the table.
+ */
+export function useNamespaceFilterOptions() {
+  const allowedNamespaces = useClusterStore(useShallow((s) => s.allowedNamespaces));
+  const { namespace: urlNamespace } = useSearch({ strict: false }) as { namespace?: string };
+
+  const namespaceOptions = useMemo<SelectOption[]>(
+    () => allowedNamespaces.map((value) => ({ label: value, value })),
+    [allowedNamespaces]
+  );
+
+  return {
+    allowedNamespaces,
+    namespaceOptions,
+    showNamespaceFilter: allowedNamespaces.length > 1 && !urlNamespace,
+  };
+}

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/view.test.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/view.test.tsx
@@ -7,10 +7,12 @@ vi.mock("@/modules/k8s/hooks/useCRDByGVR", () => ({
 
 vi.mock("@/modules/k8s/hooks/useCRList", () => ({
   useCRList: vi.fn(),
+  useCRListMulti: vi.fn(),
 }));
 
 vi.mock("@/k8s/store", () => ({
-  useClusterStore: (selector: (s: { defaultNamespace: string }) => unknown) => selector({ defaultNamespace: "dev" }),
+  useClusterStore: (selector: (s: { defaultNamespace: string; allowedNamespaces: string[] }) => unknown) =>
+    selector({ defaultNamespace: "dev", allowedNamespaces: ["dev"] }),
 }));
 
 vi.mock("@tanstack/react-router", async () => {
@@ -72,7 +74,7 @@ vi.mock("@/modules/k8s/components/ResourceTable", () => ({
 }));
 
 import { useCRDByGVR } from "@/modules/k8s/hooks/useCRDByGVR";
-import { useCRList } from "@/modules/k8s/hooks/useCRList";
+import { useCRListMulti } from "@/modules/k8s/hooks/useCRList";
 import CRListView from "./view";
 
 const defaultCrd = {
@@ -105,7 +107,7 @@ const baseWatchResult = (items: unknown[]) => ({
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(useCRDByGVR).mockReturnValue({ crd: defaultCrd as never, isLoading: false, error: null });
-  vi.mocked(useCRList).mockReturnValue(
+  vi.mocked(useCRListMulti).mockReturnValue(
     baseWatchResult([
       { metadata: { name: "pr-1", namespace: "dev" }, status: { phase: "Running" } },
       { metadata: { name: "pr-2", namespace: "dev" }, status: { phase: "Succeeded" } },

--- a/apps/client/src/modules/k8s/pages/custom-resources/list/view.tsx
+++ b/apps/client/src/modules/k8s/pages/custom-resources/list/view.tsx
@@ -6,11 +6,13 @@ import { PageWrapper } from "@/core/components/PageWrapper";
 import { FilterProvider } from "@/core/providers/Filter";
 import { ResourceTable } from "@/modules/k8s/components/ResourceTable";
 import { useCRDByGVR } from "@/modules/k8s/hooks/useCRDByGVR";
-import { useCRList } from "@/modules/k8s/hooks/useCRList";
+import { useCRListMulti } from "@/modules/k8s/hooks/useCRList";
+import { resolveListNamespaces } from "@/modules/k8s/utils/resolveListNamespaces";
+import { formatK8sErrors } from "@/modules/k8s/utils/formatK8sErrors";
 import { buildCRDescriptor } from "@/modules/k8s/registry/dynamic/buildCRDescriptor";
 import { resolveCRDVersion, CREATION_TIMESTAMP_PRINTER_COL_PATH } from "@/modules/k8s/registry/dynamic/crdUtils";
 import { extractByJsonPath } from "@/modules/k8s/utils/extractByJsonPath";
-import { useClusterStore } from "@/k8s/store";
+import type { RequestError } from "@/core/types/global";
 import type { KubeObjectBase } from "@my-project/shared";
 import { CRListFilter } from "./components/CRListFilter";
 import {
@@ -26,7 +28,6 @@ type Search = { namespace?: string; search?: string };
 export default function CRListView() {
   const { group, version, plural } = useParams({ strict: false }) as Partial<Params>;
   const search = useSearch({ strict: false }) as Search;
-  const storedNs = useClusterStore((s) => s.defaultNamespace);
 
   const { crd, isLoading, error } = useCRDByGVR(group ?? "", version ?? "", plural ?? "");
 
@@ -52,52 +53,39 @@ export default function CRListView() {
     );
   }
 
-  // Key on the CRD's identity so navigating between two CR list pages (e.g.
-  // pipelineruns → applications) remounts CRListInner — otherwise the
-  // `frozenAutoColsRef` inside would survive the navigation and the new CRD
-  // would inherit the previous CRD's filter columns and match functions.
+  // Remount CRListInner per CRD so its `frozenAutoColsRef` doesn't leak the
+  // previous CRD's filter columns when navigating between two CR list pages.
   const innerKey = `${crd.spec.group}/${crd.spec.names.plural}`;
-  return <CRListInner key={innerKey} crd={crd} version={version ?? ""} storedNs={storedNs ?? ""} search={search} />;
+  return <CRListInner key={innerKey} crd={crd} version={version ?? ""} search={search} />;
 }
 
 function CRListInner({
   crd,
   version,
-  storedNs,
   search,
 }: {
   crd: NonNullable<ReturnType<typeof useCRDByGVR>["crd"]>;
   version: string;
-  storedNs: string;
   search: Search;
 }) {
   const descriptor = useMemo(() => buildCRDescriptor(crd, version), [crd, version]);
-  const namespace = !descriptor.config.clusterScoped ? (search.namespace ?? storedNs ?? "") : "";
 
-  const watch = useCRList(crd, namespace, version);
+  const namespaces = useMemo(() => resolveListNamespaces({ urlNamespace: search.namespace }), [search.namespace]);
 
-  // Auto multi-select discovery from the FIRST non-empty watch snapshot.
-  // Cache the result in a ref so later watch ticks (new items arriving via WebSocket)
-  // do not recompute the option set — recomputation would churn FilterProvider and
-  // could surface/hide columns as the distinct-value threshold (≤8) is crossed,
-  // creating a flickering filter UI. MVP trade-off; live-update would require
-  // lifting FilterProvider into a reactive recompute.
-  //
-  // The ref is only frozen once `items.length > 0`. If the first snapshot is empty
-  // (e.g. namespace not yet selected), `frozenAutoColsRef.current` stays null and the
-  // memo re-runs on the next tick once items arrive, avoiding permanently-empty filters.
+  const watch = useCRListMulti(crd, namespaces, version);
+
+  // Discover the multi-select filter columns once, from the first non-empty watch
+  // snapshot, and freeze them in a ref. Recomputing on later watch ticks would
+  // churn FilterProvider and flicker columns as the distinct-value threshold is
+  // crossed. Stays null while empty so it re-runs once items arrive.
   const frozenAutoColsRef = useRef<PrinterColMeta[] | null>(null);
 
-  // Reset the frozen columns whenever the namespace changes so the new namespace's
-  // distinct values are used to build the filter dropdowns. Without this the ref
-  // would hold the previous namespace's frozen result until the component remounts.
+  // Rebuild the columns from fresh data when the deep-linked namespace changes.
   useEffect(() => {
     frozenAutoColsRef.current = null;
-  }, [namespace]);
+  }, [search.namespace]);
 
-  // `watch.data` is intentionally a dep here: we need the memo to re-run when
-  // `data.array.length` transitions from 0 → nonzero so the filter columns are
-  // derived from actual item values rather than an empty set.
+  // Dep on the item count so the memo re-runs when the list goes 0 → nonzero.
   const watchDataLength = watch.isReady ? (watch.data.array as KubeObjectBase[]).length : 0;
   const autoMultiSelectCols = useMemo<PrinterColMeta[]>(() => {
     if (frozenAutoColsRef.current !== null) return frozenAutoColsRef.current;
@@ -120,8 +108,7 @@ function CRListInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [watch.isReady, watchDataLength, crd, version]);
 
-  // Memoize so WebSocket watch ticks don't churn FilterProvider's internal memo/effect
-  // (otherwise URL-sync fires spuriously on every list update).
+  // Memoize so watch ticks don't churn FilterProvider and fire URL-sync spuriously.
   const defaultValues = useMemo(
     () => buildCRListDefaultValues(autoMultiSelectCols, search.search ?? ""),
     [autoMultiSelectCols, search.search]
@@ -147,8 +134,8 @@ function CRListInner({
         descriptor={descriptor}
         items={items}
         printerCols={autoMultiSelectCols}
-        watchError={watch.error}
-        namespace={namespace}
+        watchErrors={watch.errors}
+        namespace={search.namespace}
       />
     </FilterProvider>
   );
@@ -158,16 +145,18 @@ function CRListContent({
   descriptor,
   items,
   printerCols,
-  watchError,
+  watchErrors,
   namespace,
 }: {
   descriptor: ReturnType<typeof buildCRDescriptor>;
   items: KubeObjectBase[];
   printerCols: PrinterColMeta[];
-  watchError: unknown;
-  namespace: string;
+  watchErrors: RequestError[];
+  namespace?: string;
 }) {
   const { filterFunction } = useCRListFilter();
+
+  const errors = useMemo(() => formatK8sErrors(watchErrors), [watchErrors]);
 
   const tableSlots = useMemo(
     () => ({
@@ -185,7 +174,7 @@ function CRListContent({
           items={items}
           descriptor={descriptor}
           isLoading={false}
-          error={(watchError as Error) ?? null}
+          errors={errors}
           namespace={namespace}
           filterFunction={filterFunction}
           slots={tableSlots}

--- a/apps/client/src/modules/k8s/pages/events/page.tsx
+++ b/apps/client/src/modules/k8s/pages/events/page.tsx
@@ -4,10 +4,11 @@ import { useSearch } from "@tanstack/react-router";
 import { PageContentWrapper } from "@/core/components/PageContentWrapper";
 import { PageWrapper } from "@/core/components/PageWrapper";
 import { Button } from "@/core/components/ui/button";
-import { ErrorContent } from "@/core/components/ErrorContent";
-import { useK8sResourceList } from "../../hooks/useK8sResourceList";
-import { WatchConnectionIndicator, type WatchStatus } from "../../components/WatchConnectionIndicator";
-import { useClusterStore } from "@/k8s/store";
+import { Alert } from "@/core/components/ui/alert";
+import { useK8sResourceListMulti } from "../../hooks/useK8sResourceListMulti";
+import { useK8sWatchStatus } from "../../hooks/useK8sWatchStatus";
+import { resolveListNamespaces } from "../../utils/resolveListNamespaces";
+import { WatchConnectionIndicator } from "../../components/WatchConnectionIndicator";
 import { k8sEventConfig, type KubeObjectBase } from "@my-project/shared";
 import { EventStream } from "./components/EventStream";
 
@@ -19,10 +20,9 @@ type TypeFilter = "all" | "Normal" | "Warning";
 
 export default function K8sEventsPage() {
   const search = useSearch({ strict: false }) as { namespace?: string };
-  const stored = useClusterStore((s) => s.defaultNamespace);
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
-  const namespace = search.namespace ?? stored ?? "";
-  const result = useK8sResourceList<K8sEventLike>(k8sEventConfig, namespace);
+  const namespaces = useMemo(() => resolveListNamespaces({ urlNamespace: search.namespace }), [search.namespace]);
+  const result = useK8sResourceListMulti<K8sEventLike>(k8sEventConfig, { namespaces });
   const events = useMemo(() => result.data?.array ?? [], [result.data]);
 
   const filtered = useMemo(
@@ -30,7 +30,7 @@ export default function K8sEventsPage() {
     [events, typeFilter]
   );
 
-  const watchStatus: WatchStatus = result.error ? "error" : "connected";
+  const { errors, watchStatus } = useK8sWatchStatus(result.errors);
 
   return (
     <PageWrapper
@@ -50,13 +50,16 @@ export default function K8sEventsPage() {
             </Button>
           ))}
         </div>
-        {result.error ? (
-          <div className="p-4">
-            <ErrorContent error={result.error} />
+        {errors.length > 0 && (
+          <div className="px-4 pt-4">
+            <Alert variant="destructive" title="Some namespaces could not be loaded">
+              {errors.map((e, i) => (
+                <div key={i}>{e.message}</div>
+              ))}
+            </Alert>
           </div>
-        ) : (
-          <EventStream events={filtered} />
         )}
+        <EventStream events={filtered} />
       </PageContentWrapper>
     </PageWrapper>
   );

--- a/apps/client/src/modules/k8s/pages/list/components/ListFilter/constants.ts
+++ b/apps/client/src/modules/k8s/pages/list/components/ListFilter/constants.ts
@@ -1,15 +1,18 @@
-import { MatchFunctions, createSearchMatchFunction } from "@/core/providers/Filter";
+import { MatchFunctions, createSearchMatchFunction, createNamespaceMatchFunction } from "@/core/providers/Filter";
 import type { KubeObjectBase } from "@my-project/shared";
 import type { K8sListFilterValues } from "./types";
 
 export const k8sListFilterControlNames = {
   SEARCH: "search",
+  NAMESPACES: "namespaces",
 } as const;
 
 export const defaultK8sListFilterValues: K8sListFilterValues = {
   [k8sListFilterControlNames.SEARCH]: "",
+  [k8sListFilterControlNames.NAMESPACES]: [],
 };
 
 export const matchFunctions: MatchFunctions<KubeObjectBase, K8sListFilterValues> = {
   [k8sListFilterControlNames.SEARCH]: createSearchMatchFunction<KubeObjectBase>(),
+  [k8sListFilterControlNames.NAMESPACES]: createNamespaceMatchFunction<KubeObjectBase>(),
 };

--- a/apps/client/src/modules/k8s/pages/list/components/ListFilter/index.tsx
+++ b/apps/client/src/modules/k8s/pages/list/components/ListFilter/index.tsx
@@ -2,6 +2,7 @@ import { X } from "lucide-react";
 import { Button } from "@/core/components/ui/button";
 import { Label } from "@/core/components/ui/label";
 import type { ResourceDescriptor } from "../../../../registry/types";
+import { useNamespaceFilterOptions } from "../../../../hooks/useNamespaceFilterOptions";
 import { k8sListFilterControlNames } from "./constants";
 import { useK8sListFilter } from "./hooks/useK8sListFilter";
 
@@ -11,6 +12,10 @@ interface Props {
 
 export function ListFilter({ descriptor }: Props) {
   const { form, reset, isDefaultValue } = useK8sListFilter();
+  const { namespaceOptions, showNamespaceFilter } = useNamespaceFilterOptions();
+
+  // Cluster-scoped resources have no namespace to filter by.
+  const showNamespaces = showNamespaceFilter && !descriptor.config.clusterScoped;
 
   return (
     <>
@@ -19,6 +24,21 @@ export function ListFilter({ descriptor }: Props) {
           {(field) => <field.FormTextField label="Search" placeholder={`Search ${descriptor.label.toLowerCase()}`} />}
         </form.AppField>
       </div>
+
+      {showNamespaces && (
+        <div className="col-span-4">
+          <form.AppField name={k8sListFilterControlNames.NAMESPACES}>
+            {(field) => (
+              <field.FormCombobox
+                options={namespaceOptions}
+                label="Namespaces"
+                placeholder="Select namespaces"
+                multiple
+              />
+            )}
+          </form.AppField>
+        </div>
+      )}
 
       {!isDefaultValue && (
         <div className="col-span-1 flex flex-col gap-2">

--- a/apps/client/src/modules/k8s/pages/list/components/ListFilter/types.ts
+++ b/apps/client/src/modules/k8s/pages/list/components/ListFilter/types.ts
@@ -5,4 +5,5 @@ export type K8sListFilterNames = ValueOf<typeof k8sListFilterControlNames>;
 
 export type K8sListFilterValues = {
   [k8sListFilterControlNames.SEARCH]: string;
+  [k8sListFilterControlNames.NAMESPACES]: string[];
 };

--- a/apps/client/src/modules/k8s/pages/list/route.ts
+++ b/apps/client/src/modules/k8s/pages/list/route.ts
@@ -8,6 +8,7 @@ export const ROUTE_ID_K8S_LIST = "/_layout/c/$clusterName/k8s/$kind" as const;
 
 const searchSchema = z.object({
   namespace: z.string().optional(),
+  namespaces: z.array(z.string()).optional(),
   tab: z.string().optional(),
 });
 

--- a/apps/client/src/modules/k8s/pages/list/view.tsx
+++ b/apps/client/src/modules/k8s/pages/list/view.tsx
@@ -5,14 +5,15 @@ import { PageContentWrapper } from "@/core/components/PageContentWrapper";
 import { PageWrapper } from "@/core/components/PageWrapper";
 import { FilterProvider } from "@/core/providers/Filter";
 import { ResourceTable } from "../../components/ResourceTable";
-import { WatchConnectionIndicator, type WatchStatus } from "../../components/WatchConnectionIndicator";
+import { WatchConnectionIndicator } from "../../components/WatchConnectionIndicator";
 import { ListFilter } from "./components/ListFilter";
 import { defaultK8sListFilterValues, matchFunctions } from "./components/ListFilter/constants";
 import { useK8sListFilter } from "./components/ListFilter/hooks/useK8sListFilter";
-import { useK8sResourceList } from "../../hooks/useK8sResourceList";
+import { useK8sResourceListMulti } from "../../hooks/useK8sResourceListMulti";
+import { useK8sWatchStatus } from "../../hooks/useK8sWatchStatus";
+import { resolveListNamespaces } from "../../utils/resolveListNamespaces";
 import { resolveDescriptor } from "../../registry/resolve";
 import { resourceRegistry } from "../../registry";
-import { useClusterStore } from "@/k8s/store";
 import type { KubeObjectBase } from "@my-project/shared";
 import type { ResourceDescriptor } from "../../registry/types";
 
@@ -51,13 +52,18 @@ export default function K8sResourceListView() {
 
 function K8sResourceListContent({ descriptor }: { descriptor: ResourceDescriptor }) {
   const search = useSearch({ strict: false }) as { namespace?: string };
-  const stored = useClusterStore((s) => s.defaultNamespace);
-  const { filterFunction } = useK8sListFilter();
+  const { form, filterFunction } = useK8sListFilter();
 
-  const namespace = !descriptor.config.clusterScoped ? (search.namespace ?? stored ?? "") : "";
+  const filterNamespaces = form.state.values.namespaces;
+  const namespaces = useMemo(
+    () => resolveListNamespaces({ urlNamespace: search.namespace, filterNamespaces }),
+    [search.namespace, filterNamespaces]
+  );
 
-  const result = useK8sResourceList<KubeObjectBase>(descriptor.config ?? FALLBACK_CONFIG, namespace);
+  const result = useK8sResourceListMulti<KubeObjectBase>(descriptor.config ?? FALLBACK_CONFIG, { namespaces });
   const items = result.data.array;
+
+  const { errors, watchStatus } = useK8sWatchStatus(result.errors);
 
   const tableSlots = useMemo(
     () => ({
@@ -67,8 +73,6 @@ function K8sResourceListContent({ descriptor }: { descriptor: ResourceDescriptor
     }),
     [descriptor]
   );
-
-  const watchStatus: WatchStatus = result.error ? "error" : "connected";
 
   return (
     <PageWrapper
@@ -80,8 +84,8 @@ function K8sResourceListContent({ descriptor }: { descriptor: ResourceDescriptor
           items={items}
           descriptor={descriptor}
           isLoading={result.isLoading}
-          error={(result.error as Error) ?? null}
-          namespace={namespace}
+          errors={errors}
+          namespace={search.namespace}
           filterFunction={filterFunction}
           slots={tableSlots}
         />

--- a/apps/client/src/modules/k8s/pages/pods/list/components/PodFilter/constants.ts
+++ b/apps/client/src/modules/k8s/pages/pods/list/components/PodFilter/constants.ts
@@ -1,15 +1,17 @@
-import { MatchFunctions, createSearchMatchFunction } from "@/core/providers/Filter";
+import { MatchFunctions, createSearchMatchFunction, createNamespaceMatchFunction } from "@/core/providers/Filter";
 import type { Pod } from "@my-project/shared";
 import type { PodListFilterValues } from "./types";
 
 export const podFilterControlNames = {
   SEARCH: "search",
   STATUS: "status",
+  NAMESPACES: "namespaces",
 } as const;
 
 export const defaultPodFilterValues: PodListFilterValues = {
   [podFilterControlNames.SEARCH]: "",
   [podFilterControlNames.STATUS]: "all",
+  [podFilterControlNames.NAMESPACES]: [],
 };
 
 export const podPhaseValues = ["Running", "Pending", "Succeeded", "Failed", "Unknown"] as const;
@@ -20,4 +22,5 @@ export const matchFunctions: MatchFunctions<Pod, PodListFilterValues> = {
     if (!value || value === "all") return true;
     return (item as { status?: { phase?: string } }).status?.phase === value;
   },
+  [podFilterControlNames.NAMESPACES]: createNamespaceMatchFunction<Pod>(),
 };

--- a/apps/client/src/modules/k8s/pages/pods/list/components/PodFilter/index.tsx
+++ b/apps/client/src/modules/k8s/pages/pods/list/components/PodFilter/index.tsx
@@ -3,11 +3,13 @@ import { X } from "lucide-react";
 import { Button } from "@/core/components/ui/button";
 import { Label } from "@/core/components/ui/label";
 import type { SelectOption } from "@/core/components/form";
+import { useNamespaceFilterOptions } from "../../../../../hooks/useNamespaceFilterOptions";
 import { podFilterControlNames, podPhaseValues } from "./constants";
 import { usePodFilter } from "./hooks/usePodFilter";
 
 export function PodFilter() {
   const { form, reset, isDefaultValue } = usePodFilter();
+  const { namespaceOptions, showNamespaceFilter } = useNamespaceFilterOptions();
 
   const statusOptions: SelectOption[] = React.useMemo(
     () => [{ label: "All", value: "all" }, ...podPhaseValues.map((value) => ({ label: value, value }))],
@@ -27,6 +29,21 @@ export function PodFilter() {
           {(field) => <field.FormSelect label="Status" options={statusOptions} placeholder="Select status" />}
         </form.AppField>
       </div>
+
+      {showNamespaceFilter && (
+        <div className="col-span-3">
+          <form.AppField name={podFilterControlNames.NAMESPACES}>
+            {(field) => (
+              <field.FormCombobox
+                options={namespaceOptions}
+                label="Namespaces"
+                placeholder="Select namespaces"
+                multiple
+              />
+            )}
+          </form.AppField>
+        </div>
+      )}
 
       {!isDefaultValue && (
         <div className="col-span-1 flex flex-col gap-2">

--- a/apps/client/src/modules/k8s/pages/pods/list/components/PodFilter/types.ts
+++ b/apps/client/src/modules/k8s/pages/pods/list/components/PodFilter/types.ts
@@ -6,4 +6,5 @@ export type PodFilterNames = ValueOf<typeof podFilterControlNames>;
 export type PodListFilterValues = {
   [podFilterControlNames.SEARCH]: string;
   [podFilterControlNames.STATUS]: string;
+  [podFilterControlNames.NAMESPACES]: string[];
 };

--- a/apps/client/src/modules/k8s/pages/pods/list/page.tsx
+++ b/apps/client/src/modules/k8s/pages/pods/list/page.tsx
@@ -6,9 +6,10 @@ import { PageContentWrapper } from "@/core/components/PageContentWrapper";
 import { PageWrapper } from "@/core/components/PageWrapper";
 import { DataTable } from "@/core/components/Table";
 import { FilterProvider } from "@/core/providers/Filter";
-import { useK8sResourceList } from "../../../hooks/useK8sResourceList";
-import { WatchConnectionIndicator, type WatchStatus } from "../../../components/WatchConnectionIndicator";
-import { useClusterStore } from "@/k8s/store";
+import { useK8sResourceListMulti } from "../../../hooks/useK8sResourceListMulti";
+import { useK8sWatchStatus } from "../../../hooks/useK8sWatchStatus";
+import { resolveListNamespaces } from "../../../utils/resolveListNamespaces";
+import { WatchConnectionIndicator } from "../../../components/WatchConnectionIndicator";
 import { k8sPodConfig } from "@my-project/shared";
 import type { Pod } from "@my-project/shared";
 import { TABLE_ID_K8S_PODS } from "@/k8s/constants/tables";
@@ -27,13 +28,17 @@ export default function K8sPodsListPage() {
 
 function K8sPodsListContent() {
   const search = useSearch({ strict: false }) as { namespace?: string };
-  const stored = useClusterStore((s) => s.defaultNamespace);
   const columns = useColumns();
-  const { filterFunction } = usePodFilter();
+  const { form, filterFunction } = usePodFilter();
 
-  const namespace = search.namespace ?? stored ?? "";
-  const result = useK8sResourceList<Pod>(k8sPodConfig, namespace);
-  const items = useMemo(() => result.data.array as Pod[], [result.data.array]);
+  const filterNamespaces = form.state.values.namespaces;
+  const namespaces = useMemo(
+    () => resolveListNamespaces({ urlNamespace: search.namespace, filterNamespaces }),
+    [search.namespace, filterNamespaces]
+  );
+  const result = useK8sResourceListMulti<Pod>(k8sPodConfig, { namespaces });
+  const items = result.data.array as Pod[];
+  const { errors, watchStatus } = useK8sWatchStatus(result.errors);
 
   const tableSlots = useMemo(
     () => ({
@@ -43,8 +48,6 @@ function K8sPodsListContent() {
     }),
     []
   );
-
-  const watchStatus: WatchStatus = result.error ? "error" : "connected";
 
   return (
     <PageWrapper
@@ -57,14 +60,16 @@ function K8sPodsListContent() {
           data={items}
           columns={columns}
           isLoading={result.isLoading}
-          blockerError={(result.error as Error) ?? null}
+          errors={errors}
           filterFunction={filterFunction}
           slots={tableSlots}
           emptyListComponent={
             <EmptyList
               icon={<Box width={64} height={64} className="text-muted-foreground" />}
               customText="No Pods found"
-              description={namespace ? `There are no Pods in namespace ${namespace}` : "There are no Pods"}
+              description={
+                search.namespace ? `There are no Pods in namespace ${search.namespace}` : "There are no Pods"
+              }
             />
           }
         />

--- a/apps/client/src/modules/k8s/pages/pods/list/route.ts
+++ b/apps/client/src/modules/k8s/pages/pods/list/route.ts
@@ -7,7 +7,10 @@ export const PATH_K8S_PODS = "pods" as const;
 export { PATH_K8S_PODS_FULL };
 export const ROUTE_ID_K8S_PODS = "/_layout/c/$clusterName/k8s/pods" as const;
 
-const search = z.object({ namespace: z.string().optional() });
+const search = z.object({
+  namespace: z.string().optional(),
+  namespaces: z.array(z.string()).optional(),
+});
 
 export const routeK8sPodsList = createRoute({
   getParentRoute: () => routeK8sMode,

--- a/apps/client/src/modules/k8s/pages/rbac/page.tsx
+++ b/apps/client/src/modules/k8s/pages/rbac/page.tsx
@@ -5,8 +5,9 @@ import { PageContentWrapper } from "@/core/components/PageContentWrapper";
 import { PageWrapper } from "@/core/components/PageWrapper";
 import { FilterProvider } from "@/core/providers/Filter";
 import { ResourceTable } from "../../components/ResourceTable";
-import { useK8sResourceList } from "../../hooks/useK8sResourceList";
-import { useClusterStore } from "@/k8s/store";
+import { useK8sResourceListMulti } from "../../hooks/useK8sResourceListMulti";
+import { resolveListNamespaces } from "../../utils/resolveListNamespaces";
+import { formatK8sErrors } from "../../utils/formatK8sErrors";
 import { resourceRegistry } from "../../registry";
 import { ListFilter } from "../list/components/ListFilter";
 import { defaultK8sListFilterValues, matchFunctions } from "../list/components/ListFilter/constants";
@@ -54,39 +55,26 @@ export default function K8sRbacOverviewPage() {
 }
 
 function RbacTabPanel({ tabKey }: { tabKey: RbacTab }) {
-  const stored = useClusterStore((s) => s.defaultNamespace);
   const descriptor = resourceRegistry[tabKey];
-  const namespace = descriptor && !descriptor.config.clusterScoped ? (stored ?? "") : "";
-  const result = useK8sResourceList<KubeObjectBase>(descriptor.config, namespace);
-  const items = (result.data?.array ?? []) as KubeObjectBase[];
 
   return (
     <FilterProvider matchFunctions={matchFunctions} defaultValues={defaultK8sListFilterValues}>
-      <RbacContent
-        descriptor={descriptor}
-        items={items}
-        isLoading={result.isLoading}
-        error={(result.error as Error) ?? null}
-        namespace={namespace}
-      />
+      <RbacContent descriptor={descriptor} />
     </FilterProvider>
   );
 }
 
-function RbacContent({
-  descriptor,
-  items,
-  isLoading,
-  error,
-  namespace,
-}: {
-  descriptor: ResourceDescriptor;
-  items: KubeObjectBase[];
-  isLoading: boolean;
-  error: Error | null;
-  namespace: string;
-}) {
-  const { filterFunction } = useK8sListFilter();
+function RbacContent({ descriptor }: { descriptor: ResourceDescriptor }) {
+  const { form, filterFunction } = useK8sListFilter();
+
+  // No `?namespace=` deep-link here: the RBAC route has no namespace param and its
+  // tabs mix namespaced (Roles) and cluster-scoped (ClusterRoles) resources.
+  const filterNamespaces = form.state.values.namespaces;
+  const namespaces = useMemo(() => resolveListNamespaces({ filterNamespaces }), [filterNamespaces]);
+
+  const result = useK8sResourceListMulti<KubeObjectBase>(descriptor.config, { namespaces });
+  const items = (result.data?.array ?? []) as KubeObjectBase[];
+  const errors = useMemo(() => formatK8sErrors(result.errors), [result.errors]);
 
   const tableSlots = useMemo(
     () => ({
@@ -101,9 +89,8 @@ function RbacContent({
     <ResourceTable
       items={items}
       descriptor={descriptor}
-      isLoading={isLoading}
-      error={error}
-      namespace={namespace}
+      isLoading={result.isLoading}
+      errors={errors}
       filterFunction={filterFunction}
       slots={tableSlots}
     />

--- a/apps/client/src/modules/k8s/utils/formatK8sErrors.ts
+++ b/apps/client/src/modules/k8s/utils/formatK8sErrors.ts
@@ -1,0 +1,14 @@
+import { getK8sErrorMessage } from "@/k8s/api/utils/getK8sErrorMessage";
+import type { RequestError } from "@/core/types/global";
+
+/**
+ * Converts per-namespace watch errors into `Error`s for the table's non-blocking
+ * banner: when listing across several allowed namespaces, a failure in one (e.g. a
+ * `403`) must not hide the resources from the namespaces that are accessible.
+ */
+export function formatK8sErrors(errors: RequestError[] | null | undefined): Error[] {
+  if (!errors || errors.length === 0) {
+    return [];
+  }
+  return errors.map((error) => new Error(getK8sErrorMessage(error)));
+}

--- a/apps/client/src/modules/k8s/utils/resolveListNamespaces.test.ts
+++ b/apps/client/src/modules/k8s/utils/resolveListNamespaces.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { resolveListNamespaces } from "./resolveListNamespaces";
+
+describe("resolveListNamespaces", () => {
+  it("returns undefined when nothing is selected (falls back to allowed namespaces)", () => {
+    expect(resolveListNamespaces({})).toBeUndefined();
+    expect(resolveListNamespaces({ filterNamespaces: [] })).toBeUndefined();
+  });
+
+  it("scopes to a single namespace when a `?namespace=` deep-link is present", () => {
+    expect(resolveListNamespaces({ urlNamespace: "team-a" })).toEqual(["team-a"]);
+  });
+
+  it("uses the filter selection when provided", () => {
+    expect(resolveListNamespaces({ filterNamespaces: ["team-a", "team-b"] })).toEqual(["team-a", "team-b"]);
+  });
+
+  it("prefers the deep-link namespace over the filter selection", () => {
+    expect(resolveListNamespaces({ urlNamespace: "team-a", filterNamespaces: ["team-b", "team-c"] })).toEqual([
+      "team-a",
+    ]);
+  });
+});

--- a/apps/client/src/modules/k8s/utils/resolveListNamespaces.ts
+++ b/apps/client/src/modules/k8s/utils/resolveListNamespaces.ts
@@ -1,0 +1,23 @@
+/**
+ * Which namespaces a K8s-mode list page fetches from: a `?namespace=` deep-link
+ * wins, else the filter selection, else `undefined` — which lets
+ * `useWatchListMultiple` fall back to the store's allowed namespaces (keeping that
+ * fallback in one place instead of resolving it here).
+ */
+export function resolveListNamespaces({
+  urlNamespace,
+  filterNamespaces,
+}: {
+  urlNamespace?: string;
+  filterNamespaces?: string[];
+}): string[] | undefined {
+  if (urlNamespace) {
+    return [urlNamespace];
+  }
+
+  if (filterNamespaces && filterNamespaces.length > 0) {
+    return filterNamespaces;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Kubernetes-mode list views queried only the default namespace, so resources in the configured "Allowed namespaces" never appeared — and even clearing the setting left the view stuck on the default namespace.

- Fetch each allowed namespace individually and merge, instead of a single default-namespace query. This is required for RBAC-limited users: Kubernetes cannot enumerate the namespaces a user can access and a cluster-wide list is forbidden, so per-namespace LIST (authorized by namespaced RoleBindings) is the only workable approach. Cluster-scoped resources collapse to one cluster-wide query.
- Add a Namespaces multi-select filter (shown when more than one namespace is allowed) to the Pods, generic, and RBAC list views; preserve ?namespace= deep-links as a single-namespace override.
- Make per-namespace errors non-blocking so one inaccessible namespace surfaces a banner without hiding resources from the accessible ones.
- Source the default namespace from the server's DEFAULT_CLUSTER_NAMESPACE env var via config.get, and stop seeding a bogus "undefined" cluster-settings entry from unset build-time vars.
