### PR TITLE
EPMDEDP-17118: feat: Register Gateway API and traffic policy resource descriptors

### DIFF
--- a/apps/client/src/modules/k8s/registry/descriptors/backendtrafficpolicies.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/backendtrafficpolicies.ts
@@ -1,0 +1,16 @@
+import { ArrowRightLeft } from "lucide-react";
+import { k8sBackendTrafficPolicyConfig } from "@my-project/shared";
+import { backendTrafficPolicyColumns } from "../dynamic/firstClass/columns";
+import { PolicyOverviewTab } from "../../components/overrides/PolicyOverviewTab";
+import type { ResourceDescriptor } from "../types";
+
+export const backendTrafficPoliciesDescriptor: ResourceDescriptor = {
+  config: k8sBackendTrafficPolicyConfig,
+  label: "Backend Traffic Policies",
+  sidebarGroup: "Network",
+  sidebarIcon: ArrowRightLeft,
+  detailVariant: "namespaced",
+  defaultSort: { sortBy: "name", order: "asc" },
+  columns: backendTrafficPolicyColumns,
+  overviewTab: PolicyOverviewTab,
+};

--- a/apps/client/src/modules/k8s/registry/descriptors/clienttrafficpolicies.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/clienttrafficpolicies.ts
@@ -1,0 +1,16 @@
+import { Globe } from "lucide-react";
+import { k8sClientTrafficPolicyConfig } from "@my-project/shared";
+import { clientTrafficPolicyColumns } from "../dynamic/firstClass/columns";
+import { PolicyOverviewTab } from "../../components/overrides/PolicyOverviewTab";
+import type { ResourceDescriptor } from "../types";
+
+export const clientTrafficPoliciesDescriptor: ResourceDescriptor = {
+  config: k8sClientTrafficPolicyConfig,
+  label: "Client Traffic Policies",
+  sidebarGroup: "Network",
+  sidebarIcon: Globe,
+  detailVariant: "namespaced",
+  defaultSort: { sortBy: "name", order: "asc" },
+  columns: clientTrafficPolicyColumns,
+  overviewTab: PolicyOverviewTab,
+};

--- a/apps/client/src/modules/k8s/registry/descriptors/gateways.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/gateways.ts
@@ -1,0 +1,16 @@
+import { DoorOpen } from "lucide-react";
+import { k8sGatewayConfig } from "@my-project/shared";
+import { gatewayColumns } from "../dynamic/firstClass/columns";
+import { GatewayOverviewTab } from "../../components/overrides/GatewayOverviewTab";
+import type { ResourceDescriptor } from "../types";
+
+export const gatewaysDescriptor: ResourceDescriptor = {
+  config: k8sGatewayConfig,
+  label: "Gateways",
+  sidebarGroup: "Network",
+  sidebarIcon: DoorOpen,
+  detailVariant: "namespaced",
+  defaultSort: { sortBy: "name", order: "asc" },
+  columns: gatewayColumns,
+  overviewTab: GatewayOverviewTab,
+};

--- a/apps/client/src/modules/k8s/registry/descriptors/httproutes.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/httproutes.ts
@@ -1,0 +1,16 @@
+import { Waypoints } from "lucide-react";
+import { k8sHTTPRouteConfig } from "@my-project/shared";
+import { httpRouteColumns } from "../dynamic/firstClass/columns";
+import { HTTPRouteOverviewTab } from "../../components/overrides/HTTPRouteOverviewTab";
+import type { ResourceDescriptor } from "../types";
+
+export const httpRoutesDescriptor: ResourceDescriptor = {
+  config: k8sHTTPRouteConfig,
+  label: "HTTP Routes",
+  sidebarGroup: "Network",
+  sidebarIcon: Waypoints,
+  detailVariant: "namespaced",
+  defaultSort: { sortBy: "name", order: "asc" },
+  columns: httpRouteColumns,
+  overviewTab: HTTPRouteOverviewTab,
+};

--- a/apps/client/src/modules/k8s/registry/descriptors/securitypolicies.ts
+++ b/apps/client/src/modules/k8s/registry/descriptors/securitypolicies.ts
@@ -1,0 +1,16 @@
+import { ShieldCheck } from "lucide-react";
+import { k8sSecurityPolicyConfig } from "@my-project/shared";
+import { securityPolicyColumns } from "../dynamic/firstClass/columns";
+import { PolicyOverviewTab } from "../../components/overrides/PolicyOverviewTab";
+import type { ResourceDescriptor } from "../types";
+
+export const securityPoliciesDescriptor: ResourceDescriptor = {
+  config: k8sSecurityPolicyConfig,
+  label: "Security Policies",
+  sidebarGroup: "Network",
+  sidebarIcon: ShieldCheck,
+  detailVariant: "namespaced",
+  defaultSort: { sortBy: "name", order: "asc" },
+  columns: securityPolicyColumns,
+  overviewTab: PolicyOverviewTab,
+};

--- a/apps/client/src/modules/k8s/registry/index.ts
+++ b/apps/client/src/modules/k8s/registry/index.ts
@@ -8,6 +8,11 @@ import { cronJobsDescriptor } from "./descriptors/cronjobs";
 import { horizontalPodAutoscalersDescriptor } from "./descriptors/horizontal-pod-autoscalers";
 import { servicesDescriptor } from "./descriptors/services";
 import { ingressesDescriptor } from "./descriptors/ingresses";
+import { gatewaysDescriptor } from "./descriptors/gateways";
+import { httpRoutesDescriptor } from "./descriptors/httproutes";
+import { securityPoliciesDescriptor } from "./descriptors/securitypolicies";
+import { backendTrafficPoliciesDescriptor } from "./descriptors/backendtrafficpolicies";
+import { clientTrafficPoliciesDescriptor } from "./descriptors/clienttrafficpolicies";
 import { persistentVolumeClaimsDescriptor } from "./descriptors/persistent-volume-claims";
 import { persistentVolumesDescriptor } from "./descriptors/persistent-volumes";
 import { storageClassesDescriptor } from "./descriptors/storage-classes";
@@ -33,6 +38,11 @@ export const resourceRegistry: ResourceRegistry = {
   // Network
   services: servicesDescriptor,
   ingresses: ingressesDescriptor,
+  gateways: gatewaysDescriptor,
+  httproutes: httpRoutesDescriptor,
+  securitypolicies: securityPoliciesDescriptor,
+  backendtrafficpolicies: backendTrafficPoliciesDescriptor,
+  clienttrafficpolicies: clientTrafficPoliciesDescriptor,
   // Storage
   persistentvolumeclaims: persistentVolumeClaimsDescriptor,
   persistentvolumes: persistentVolumesDescriptor,


### PR DESCRIPTION
Add resource descriptors for Envoy Gateway and Istio/Cilium traffic policy resources to the K8s registry:

- Gateway API: Gateways, HTTP Routes
- Traffic policies: Backend Traffic Policies, Client Traffic Policies, Security Policies

These resources are registered in the resource registry with proper sidebar grouping, icons, columns, and detail view overrides to provide full portal support for Gateway API and service mesh traffic management.
