### PR TITLE
EPMDEDP-17128: feat: add GitLab CI pipeline list and log viewer for codebases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,70 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
+### Features
+
+- add Envoy Gateway and Gateway API support in Portal
+- add permission-aware Custom Resources catalog for users without cluster-wide CRD access
+- reduce Kubernetes events volume on overview and detail views
+- redesign Kubernetes cluster overview dashboard
+- add Service Account token login and make OIDC optional
+- enrich Kubernetes resource overview tabs and list descriptors
+- router registration — CRD detail + CR parent/list/detail routes
+- Scale + Restart + Rollback action UI components + Deployment, StatefulSet, DaemonSet descriptor wiring
+- workload mutation hooks (useK8sActionMutation, useK8sScale, useK8sRestart, useK8sRollback, useDeploymentRevisions, useHpaForTarget) + useUpdatePermission
+- K8sDetailPage — actionsSlot + ButtonWithPermission Delete + useDetailTabs
+- Custom Resources sidebar group (useCRSidebarItems + K8sSidebar + nav.ts)
+- Custom Resource detail page (cluster-scoped + namespaced)
+- Custom Resource list page (CRListView, CRListFilter, routes)
+- CRD list descriptor + CRD detail page
+- CRD/CR infra hooks + ConditionsTable + PrinterColumnValue + extractByJsonPath + useDetailTabs + buildCRDescriptor
+- workload utility helpers + scale/restart/rollback/listRevisions procedures + k8sRouter wiring
+- HoverInfoLabel primitive + Radix Slider primitive + [@radix](https://github.com/radix)-ui/react-slider dependency
+- CRD/CR path constants + registry descriptor shape + resolveDescriptor slug fallback
+- collapsible sidebar sub-group — NavCollapsibleSubGroupItem + SidebarCollapsibleSubGroupMenuItem
+- drop apiVersion from server input + client hook; group-aware watch/permission cache keys
+- K8sClient patchResource/listAllResources + getInitializedK8sClient + rethrowOrHandleK8sError
+- add patch verb, KubeCondition, CRD model, and ReplicaSet model
+- Add scroll-to-top/bottom controls to LogViewer
+- Add branch column to pipeline applications table
+
+### Bug Fixes
+
+- Align notification area for envoy
+- honor allowed namespaces in Kubernetes mode list views
+- populate Deployed version dropdown on CD promotion stages in multi-pipeline clusters
+- exclude EDP from codebase versioning type selection
+- bump concurrently to patch shell-quote CVE-2026-9277
+- make sidebar pin keys param-aware and restore icons for pinned pages
+- align K8s mode list pages with KRCI list layout
+- Set gitlabci icon on the project page
+- remediate dependency vulnerabilities and harden npm supply chain
+- enable search filtering in freeSolo combobox
+- replace backtracking trailing-slash regex with linear stripTrailingSlash helper
+- render mode switcher as icon-only toggle in collapsed sidebar
+- prevent release branches from being created from a commit
+- useDeploymentRevisions refetch-on-mount for live rollback data
+- DataTable and ServerSideTable — useColumnSync + useSyncedSortState hooks
+- DeleteKubeObject — ReactNode description + mutateAsync navigation guard
+- ConfirmDialog isPending guard
+- Align stage quality gate step name validation to min 2 characters
+- Fix silent save failure in resource edit forms
+- Align inputDockerStreams with applications positionally in create wizard
+- Reject misrouted branches in pipeline applications column
+- Improve LogViewer controls layout and focus visibility
+
+### Code Refactoring
+
+- address review findings in sidebar predicate, sort-state, detail-page
+
+### Routine
+
+- bump [@typescript](https://github.com/typescript)-eslint/eslint-plugin
+- align dependabot commit messages with PR validation and reduce PR noise
+- drop transitional route-type casts after registration
+- Remove dead alignInputDockerStreams utility
+- Update current development version
+
 
 <a name="v0.5.0"></a>
 ## [v0.5.0] - 2026-05-21
@@ -139,6 +203,7 @@
 ## v0.1.0 - 2026-03-27
 ### Features
 
+- Enable CHANGELOG.md generation
 - Improve project details page
 - Improve ScrollCopyText component
 - Add deployment submit review step

--- a/apps/client/src/core/components/sidebar/navigationConfig.ts
+++ b/apps/client/src/core/components/sidebar/navigationConfig.ts
@@ -46,6 +46,7 @@ import { PATH_PROJECTS_FULL } from "@/modules/platform/codebases/pages/list/rout
 import { PATH_CDPIPELINES_FULL } from "@/modules/platform/cdpipelines/pages/list/route";
 import { PATH_PIPELINERUNS_FULL } from "@/modules/platform/tekton/pages/pipelinerun-list/route";
 import { PATH_PIPELINES_FULL } from "@/modules/platform/tekton/pages/pipeline-list/route";
+import { PATH_GITLABCI_PIPELINES_FULL } from "@/modules/platform/gitlabci/pages/pipeline-list/route";
 import { PATH_TASKS_FULL } from "@/modules/platform/tekton/pages/task-list/route";
 import { PATH_EVENT_LISTENERS_FULL } from "@/modules/platform/tekton/pages/event-listener-list/route";
 import { PATH_TRIGGERS_FULL } from "@/modules/platform/tekton/pages/trigger-list/route";
@@ -111,6 +112,14 @@ export function createNavigationConfig(clusterName: string, namespace: string): 
           icon: CheckCircle,
           route: {
             to: PATH_TASKS_FULL,
+            params: clusterDefaultParams,
+          },
+        },
+        {
+          title: "GitLab CI",
+          icon: Activity,
+          route: {
+            to: PATH_GITLABCI_PIPELINES_FULL,
             params: clusterDefaultParams,
           },
         },

--- a/apps/client/src/core/constants/page-icons.ts
+++ b/apps/client/src/core/constants/page-icons.ts
@@ -40,6 +40,7 @@ export const PAGE_ICONS = {
   pipelineruns: Activity,
   pipelines: Bot,
   tasks: CheckCircle,
+  "gitlabci-pipelines": Activity,
 
   // Configuration - Webhook Triggers (icons mirror navigationConfig.ts entries)
   "event-listeners": Webhook,
@@ -127,6 +128,7 @@ export const PATH_TO_ICON_TYPE: Record<string, PageIconType> = {
   "/c/$clusterName/cicd/pipelineruns": "pipelineruns",
   "/c/$clusterName/cicd/pipelines": "pipelines",
   "/c/$clusterName/cicd/tasks": "tasks",
+  "/c/$clusterName/cicd/gitlabci-pipelines": "gitlabci-pipelines",
 
   // Configuration - Webhook Triggers
   "/c/$clusterName/configuration/webhook-triggers/event-listeners": "event-listeners",

--- a/apps/client/src/core/router/index.ts
+++ b/apps/client/src/core/router/index.ts
@@ -59,6 +59,7 @@ import { routePipelineDetails } from "@/modules/platform/tekton/pages/pipeline-d
 import { routePipelineList } from "@/modules/platform/tekton/pages/pipeline-list/route";
 import { routePipelineRunList } from "@/modules/platform/tekton/pages/pipelinerun-list/route";
 import { routePipelineRunDetails } from "@/modules/platform/tekton/pages/pipelinerun-details/route";
+import { routeGitLabCIPipelineList } from "@/modules/platform/gitlabci/pages/pipeline-list/route";
 import { routeOverviewDetails } from "@/modules/platform/overview/pages/details/route";
 import { routeArgocdConfiguration } from "@/modules/platform/configuration/modules/argocd/route";
 import { routeClustersConfiguration } from "@/modules/platform/configuration/modules/clusters/route";
@@ -139,6 +140,7 @@ const routeTree = rootRoute.addChildren([
         routeTaskDetails,
         routePipelineRunList,
         routePipelineRunDetails,
+        routeGitLabCIPipelineList,
       ]),
       routeObservability.addChildren([routePipelineMetrics]),
       routeSecurity.addChildren([

--- a/apps/client/src/modules/platform/codebases/pages/details/constants.ts
+++ b/apps/client/src/modules/platform/codebases/pages/details/constants.ts
@@ -1,5 +1,6 @@
 import { RouteSearchTab, routeSearchTabSchema } from "./route";
 
+// Indices must match the tab order in usePageTabs.
 export const tabNameToIndexMap: Record<RouteSearchTab, number> = {
   [routeSearchTabSchema.enum.overview]: 0,
   [routeSearchTabSchema.enum.branches]: 1,

--- a/apps/client/src/modules/platform/codebases/pages/details/hooks/usePageTabs.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/details/hooks/usePageTabs.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Info, GitBranch, GitPullRequest, Shield, AlertTriangle } from "lucide-react";
+import { ciTool } from "@my-project/shared";
 import { ENTITY_ICON } from "@/k8s/constants/entity-icons";
 import { router } from "@/core/router";
 import { BranchList } from "../components/BranchList";
@@ -9,6 +10,8 @@ import { PipelineList } from "../components/PipelineList";
 import { DeploymentStatusWidget } from "../components/DeploymentStatusWidget";
 import { SecurityTab } from "../components/SecurityTab";
 import { VulnerabilitiesTab } from "../components/VulnerabilitiesTab";
+import { CodebaseGitLabCIPipelineList } from "@/modules/platform/gitlabci/components/CodebaseGitLabCIPipelineList";
+import type { Tab } from "@/core/providers/Tabs/components/Tabs/types";
 import { useCodebaseWatch } from "../hooks/data";
 import { routeProjectDetails, RouteSearchTab, routeSearchTabSchema, PATH_PROJECT_DETAILS_FULL } from "../route";
 
@@ -29,7 +32,9 @@ export const usePageTabs = () => {
   );
 
   return React.useMemo(() => {
-    return [
+    const isGitLabCI = codebase?.spec?.ciTool === ciTool.gitlab;
+
+    const tabs: Tab[] = [
       {
         label: "Overview",
         icon: <Info className="size-4" />,
@@ -49,7 +54,7 @@ export const usePageTabs = () => {
         icon: <ENTITY_ICON.pipeline className="size-4" />,
         id: routeSearchTabSchema.enum.pipelines,
         onClick: () => handleTabNavigate(routeSearchTabSchema.enum.pipelines),
-        component: <PipelineList />,
+        component: isGitLabCI && codebase ? <CodebaseGitLabCIPipelineList codebase={codebase} /> : <PipelineList />,
       },
       {
         label: "Code Quality",
@@ -89,5 +94,9 @@ export const usePageTabs = () => {
         component: <DeploymentStatusWidget />,
       },
     ];
-  }, [handleTabNavigate, params.name, params.namespace, params.clusterName, codebase?.spec?.defaultBranch]);
+
+    return tabs;
+    // `codebase` is referentially stable across polls (React Query structural sharing), so
+    // depending on the whole object is cheap and avoids enumerating individual spec fields.
+  }, [handleTabNavigate, params.name, params.namespace, params.clusterName, codebase]);
 };

--- a/apps/client/src/modules/platform/gitlabci/components/CodebaseGitLabCIPipelineList/index.tsx
+++ b/apps/client/src/modules/platform/gitlabci/components/CodebaseGitLabCIPipelineList/index.tsx
@@ -1,0 +1,27 @@
+import { Card } from "@/core/components/ui/card";
+import { Codebase } from "@my-project/shared";
+import React from "react";
+import { GitLabCIPipelineList } from "@/modules/platform/gitlabci/components/GitLabCIPipelineList";
+import { useGitLabCIPipelines } from "@/modules/platform/gitlabci/hooks/useGitLabCIPipelines";
+
+export function CodebaseGitLabCIPipelineList({ codebase }: { codebase: Codebase }) {
+  const codebases = React.useMemo(() => [codebase], [codebase]);
+  const { pipelines, isLoading, errors } = useGitLabCIPipelines({ codebases });
+
+  // Surface the first fetch error as a blocker so failures show an error state, not an empty table.
+  const blockerError = errors[0];
+
+  return (
+    <Card className="p-6">
+      <h3 className="text-foreground mb-4 text-xl font-semibold">Pipelines</h3>
+      <GitLabCIPipelineList
+        pipelines={pipelines}
+        isLoading={isLoading}
+        showCodebaseColumn={false}
+        tableId={`gitlabci-pipelines-${codebase.metadata.name}`}
+        tableName={`${codebase.metadata.name} GitLab CI Pipelines`}
+        blockerError={blockerError}
+      />
+    </Card>
+  );
+}

--- a/apps/client/src/modules/platform/gitlabci/components/GitLabCIPipelineList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/gitlabci/components/GitLabCIPipelineList/hooks/useColumns.tsx
@@ -1,0 +1,189 @@
+import { TableColumn } from "@/core/components/Table/types";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { Button } from "@/core/components/ui/button";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { useClusterStore } from "@/k8s/store";
+import { useDialogOpener } from "@/core/providers/Dialog/hooks";
+import { formatTimestamp, formatUnixTimestamp } from "@/core/utils/date-humanize";
+import { ENTITY_ICON } from "@/k8s/constants/entity-icons";
+import { PATH_PROJECT_DETAILS_FULL, routeSearchTabName } from "@/modules/platform/codebases/pages/details/route";
+import { GitLabCIPipelineLogsDialog } from "@/modules/platform/gitlabci/dialogs/PipelineLogs";
+import { Link } from "@tanstack/react-router";
+import { ExternalLink, GitBranch, GitCommitHorizontal, ScrollText } from "lucide-react";
+import React from "react";
+import { gitlabCIPipelineColumnNames } from "../../../constants";
+import type { GitLabCIPipelineRow } from "../../../hooks/useGitLabCIPipelines";
+import { GitLabCIPipelineStatus } from "../../PipelineStatus";
+
+export function useColumns({
+  showCodebaseColumn = true,
+}: {
+  showCodebaseColumn?: boolean;
+}): TableColumn<GitLabCIPipelineRow>[] {
+  const clusterName = useClusterStore((state) => state.clusterName);
+
+  const openLogsDialog = useDialogOpener(GitLabCIPipelineLogsDialog);
+
+  return React.useMemo(() => {
+    const openLogs = (row: GitLabCIPipelineRow) =>
+      openLogsDialog({
+        gitServer: row.gitServer,
+        project: row.project,
+        pipelineId: row.id,
+        pipelineStatus: row.status,
+        codebaseName: row.codebaseName,
+        ref: row.ref,
+        webUrl: row.web_url,
+      });
+
+    const columns: TableColumn<GitLabCIPipelineRow>[] = [
+      {
+        id: gitlabCIPipelineColumnNames.PIPELINE,
+        label: "Pipeline",
+        data: {
+          // Pipeline ids are numeric strings; sort them numerically so #10 ranks after #9
+          // (the shared columnSortableValuePath sort is lexicographic, which would mis-order them).
+          customSortFn: (a, b) => Number(a.id) - Number(b.id),
+          render: ({ data }) => (
+            <Tooltip title="View pipeline logs" delayDuration={500}>
+              <Button
+                variant="link"
+                className="w-full justify-start gap-1 p-0 whitespace-normal"
+                onClick={() => openLogs(data)}
+              >
+                <ENTITY_ICON.pipelineRun className="text-muted-foreground/70 size-4 shrink-0" />
+                <span className="truncate">#{data.id}</span>
+              </Button>
+            </Tooltip>
+          ),
+        },
+        cell: { baseWidth: 12 },
+      },
+      {
+        id: gitlabCIPipelineColumnNames.STATUS,
+        label: "Status",
+        data: {
+          columnSortableValuePath: "status",
+          render: ({ data }) => <GitLabCIPipelineStatus status={data.status} />,
+        },
+        cell: { baseWidth: 12 },
+      },
+      ...(showCodebaseColumn
+        ? [
+            {
+              id: gitlabCIPipelineColumnNames.CODEBASE,
+              label: "Project",
+              data: {
+                columnSortableValuePath: "codebaseName",
+                render: ({ data }) => (
+                  <Button variant="link" asChild className="w-full justify-start p-0 whitespace-normal">
+                    <Link
+                      to={PATH_PROJECT_DETAILS_FULL}
+                      params={{ name: data.codebaseName, namespace: data.namespace, clusterName }}
+                      search={{ tab: routeSearchTabName.pipelines }}
+                    >
+                      <ENTITY_ICON.project className="text-muted-foreground/70" />
+                      <TextWithTooltip text={data.codebaseName} />
+                    </Link>
+                  </Button>
+                ),
+              },
+              cell: { baseWidth: 14 },
+            } satisfies TableColumn<GitLabCIPipelineRow>,
+          ]
+        : []),
+      {
+        id: gitlabCIPipelineColumnNames.REF,
+        label: "Ref",
+        data: {
+          columnSortableValuePath: "ref",
+          render: ({ data }) =>
+            data.ref ? (
+              <div className="text-muted-foreground flex items-center gap-1 overflow-hidden text-sm">
+                <GitBranch className="size-3.5 shrink-0" />
+                <TextWithTooltip text={data.ref} />
+              </div>
+            ) : (
+              <span className="text-muted-foreground text-sm">-</span>
+            ),
+        },
+        cell: { baseWidth: 14 },
+      },
+      {
+        id: gitlabCIPipelineColumnNames.COMMIT,
+        label: "Commit",
+        data: {
+          render: ({ data }) =>
+            data.sha ? (
+              <Tooltip title={data.sha} delayDuration={500}>
+                <span className="text-muted-foreground inline-flex items-center gap-1 font-mono text-xs">
+                  <GitCommitHorizontal className="size-3.5" />
+                  {data.sha.slice(0, 7)}
+                </span>
+              </Tooltip>
+            ) : (
+              <span className="text-muted-foreground text-sm">-</span>
+            ),
+        },
+        cell: { baseWidth: 10 },
+      },
+      {
+        id: gitlabCIPipelineColumnNames.SOURCE,
+        label: "Source",
+        data: {
+          columnSortableValuePath: "source",
+          render: ({ data }) =>
+            data.source ? (
+              <div className="text-muted-foreground text-sm">
+                <TextWithTooltip text={data.source} />
+              </div>
+            ) : (
+              <span className="text-muted-foreground text-sm">-</span>
+            ),
+        },
+        cell: { baseWidth: 12 },
+      },
+      {
+        id: gitlabCIPipelineColumnNames.CREATED,
+        label: "Created",
+        data: {
+          columnSortableValuePath: "created_at",
+          render: ({ data }) =>
+            data.created_at ? (
+              <Tooltip title={formatUnixTimestamp(data.created_at)} delayDuration={500}>
+                <span className="text-sm whitespace-nowrap">{formatTimestamp(data.created_at)}</span>
+              </Tooltip>
+            ) : (
+              <span className="text-muted-foreground text-sm">-</span>
+            ),
+        },
+        cell: { baseWidth: 12 },
+      },
+      {
+        id: gitlabCIPipelineColumnNames.ACTIONS,
+        label: "Actions",
+        data: {
+          render: ({ data }) => (
+            <div className="flex items-center gap-1">
+              <Tooltip title="View logs" delayDuration={500}>
+                <Button variant="ghost" size="icon" aria-label="View pipeline logs" onClick={() => openLogs(data)}>
+                  <ScrollText size={16} />
+                </Button>
+              </Tooltip>
+              <Tooltip title="Open in GitLab" delayDuration={500}>
+                <Button variant="ghost" size="icon" aria-label="Open pipeline in GitLab" asChild>
+                  <a href={data.web_url} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink size={16} />
+                  </a>
+                </Button>
+              </Tooltip>
+            </div>
+          ),
+        },
+        cell: { isFixed: true, baseWidth: 9 },
+      },
+    ];
+
+    return columns;
+  }, [showCodebaseColumn, clusterName, openLogsDialog]);
+}

--- a/apps/client/src/modules/platform/gitlabci/components/GitLabCIPipelineList/index.tsx
+++ b/apps/client/src/modules/platform/gitlabci/components/GitLabCIPipelineList/index.tsx
@@ -1,0 +1,44 @@
+import { EmptyList } from "@/core/components/EmptyList";
+import { DataTable } from "@/core/components/Table";
+import { GITLABCI_TABLE_ID } from "../../constants";
+import type { GitLabCIPipelineRow } from "../../hooks/useGitLabCIPipelines";
+import { useColumns } from "./hooks/useColumns";
+
+export interface GitLabCIPipelineListProps {
+  pipelines: GitLabCIPipelineRow[];
+  isLoading: boolean;
+  showCodebaseColumn?: boolean;
+  tableId?: string;
+  tableName?: string;
+  emptyItemName?: string;
+  blockerError?: Error | null;
+  errors?: Error[] | null;
+}
+
+export function GitLabCIPipelineList({
+  pipelines,
+  isLoading,
+  showCodebaseColumn = true,
+  tableId = GITLABCI_TABLE_ID,
+  tableName = "GitLab CI Pipelines",
+  emptyItemName = "GitLab CI pipelines",
+  blockerError,
+  errors,
+}: GitLabCIPipelineListProps) {
+  const columns = useColumns({ showCodebaseColumn });
+
+  return (
+    <DataTable
+      id={tableId}
+      name={tableName}
+      columns={columns}
+      data={pipelines}
+      isLoading={isLoading}
+      blockerError={blockerError}
+      errors={errors}
+      emptyListComponent={<EmptyList missingItemName={emptyItemName} />}
+      pagination={{ show: true, rowsPerPage: 10 }}
+      outlined={false}
+    />
+  );
+}

--- a/apps/client/src/modules/platform/gitlabci/components/PipelineStatus/index.tsx
+++ b/apps/client/src/modules/platform/gitlabci/components/PipelineStatus/index.tsx
@@ -1,0 +1,24 @@
+import { StatusIcon } from "@/core/components/StatusIcon";
+import { Badge } from "@/core/components/ui/badge";
+import { getGitLabCIPipelineStatusIcon } from "../../utils/getStatusIcon";
+
+export function GitLabCIPipelineStatus({ status }: { status: string }) {
+  const statusIcon = getGitLabCIPipelineStatusIcon(status);
+
+  return (
+    <Badge
+      className="h-6 max-w-full min-w-0 shrink justify-start"
+      style={{ backgroundColor: `${statusIcon.color}15`, color: statusIcon.color }}
+    >
+      <span className="inline-flex shrink-0">
+        <StatusIcon
+          Icon={statusIcon.component}
+          color={statusIcon.color}
+          isSpinning={statusIcon.isSpinning}
+          width={12}
+        />
+      </span>
+      <span className="min-w-0 flex-1 truncate capitalize">{statusIcon.title}</span>
+    </Badge>
+  );
+}

--- a/apps/client/src/modules/platform/gitlabci/constants.ts
+++ b/apps/client/src/modules/platform/gitlabci/constants.ts
@@ -1,0 +1,12 @@
+export const gitlabCIPipelineColumnNames = {
+  PIPELINE: "pipeline",
+  STATUS: "status",
+  CODEBASE: "codebase",
+  REF: "ref",
+  COMMIT: "commit",
+  SOURCE: "source",
+  CREATED: "created",
+  ACTIONS: "actions",
+} as const;
+
+export const GITLABCI_TABLE_ID = "gitlabci-pipelines" as const;

--- a/apps/client/src/modules/platform/gitlabci/dialogs/PipelineLogs/constants.ts
+++ b/apps/client/src/modules/platform/gitlabci/dialogs/PipelineLogs/constants.ts
@@ -1,0 +1,1 @@
+export const GITLABCI_PIPELINE_LOGS_DIALOG_NAME = "GitLabCIPipelineLogsDialog";

--- a/apps/client/src/modules/platform/gitlabci/dialogs/PipelineLogs/index.tsx
+++ b/apps/client/src/modules/platform/gitlabci/dialogs/PipelineLogs/index.tsx
@@ -1,0 +1,260 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/core/components/ui/dialog";
+import { Card } from "@/core/components/ui/card";
+import { Button } from "@/core/components/ui/button";
+import { LogViewer } from "@/core/components/LogViewer";
+import { StatusIcon } from "@/core/components/StatusIcon";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import { formatDuration } from "@/core/utils/date-humanize";
+import { useQuery } from "@tanstack/react-query";
+import { GitFusionPipelineJob } from "@my-project/shared";
+import { AlertTriangle, ExternalLink, GitBranch } from "lucide-react";
+import React from "react";
+import { useShallow } from "zustand/react/shallow";
+import { GitLabCIPipelineStatus } from "../../components/PipelineStatus";
+import { getGitLabCIPipelineStatusIcon, isGitLabCIPipelineActive } from "../../utils/getStatusIcon";
+import { GITLABCI_PIPELINE_LOGS_DIALOG_NAME } from "./constants";
+import type { GitLabCIPipelineLogsDialogPropsWithBase } from "./types";
+
+// Mirrors GitFusion's server-side trace size cap.
+const TRACE_LIMIT_LABEL = "4 MB";
+
+const formatJobDuration = (job: GitFusionPipelineJob): string | null => {
+  if (job.started_at && job.finished_at) {
+    return formatDuration(job.started_at, job.finished_at);
+  }
+  if (typeof job.duration === "number" && job.duration > 0) {
+    return `${Math.round(job.duration)}s`;
+  }
+  return null;
+};
+
+// Default to the first failed job so errors surface first.
+const pickDefaultJob = (jobs: GitFusionPipelineJob[]): string | null => {
+  if (jobs.length === 0) return null;
+  // status is unvalidated HTTP data, so guard with `?? ""` (as getStatusIcon/isGitLabCIPipelineActive
+  // do) and compare case-insensitively.
+  const failed = jobs.find((j) => (j.status ?? "").toLowerCase() === "failed");
+  return (failed ?? jobs[0]).id;
+};
+
+function JobRow({ job, selected, onClick }: { job: GitFusionPipelineJob; selected: boolean; onClick: () => void }) {
+  const statusIcon = getGitLabCIPipelineStatusIcon(job.status);
+  const duration = formatJobDuration(job);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors ${
+        selected ? "bg-muted font-medium" : "hover:bg-muted/60"
+      }`}
+    >
+      <span className="inline-flex shrink-0">
+        <StatusIcon
+          Icon={statusIcon.component}
+          color={statusIcon.color}
+          isSpinning={statusIcon.isSpinning}
+          width={14}
+        />
+      </span>
+      <span className="min-w-0 flex-1 truncate">
+        <TextWithTooltip text={job.name} />
+      </span>
+      {duration && <span className="text-muted-foreground shrink-0 text-xs">{duration}</span>}
+    </button>
+  );
+}
+
+export function GitLabCIPipelineLogsDialog({
+  props: { gitServer, project, pipelineId, pipelineStatus, codebaseName, ref, webUrl },
+  state: { open, closeDialog },
+}: GitLabCIPipelineLogsDialogPropsWithBase) {
+  const trpc = useTRPCClient();
+  const { clusterName, defaultNamespace } = useClusterStore(
+    useShallow((state) => ({ clusterName: state.clusterName, defaultNamespace: state.defaultNamespace }))
+  );
+
+  const pipelineActive = isGitLabCIPipelineActive(pipelineStatus);
+
+  const jobsQuery = useQuery({
+    queryKey: ["gitfusion", "pipelineJobs", clusterName, defaultNamespace, gitServer, project, pipelineId],
+    queryFn: () =>
+      trpc.gitfusion.getPipelineJobList.query({
+        clusterName,
+        namespace: defaultNamespace,
+        gitServer,
+        project,
+        pipelineId,
+      }),
+    enabled: open && !!pipelineId,
+    // pipelineStatus is a dialog-open snapshot that never updates, so derive liveness from
+    // the freshest polled jobs (fall back to it until the first response). Stops once terminal.
+    refetchInterval: (query) => {
+      const polledJobs = query.state.data?.data ?? [];
+      const active =
+        polledJobs.length > 0 ? polledJobs.some((job) => isGitLabCIPipelineActive(job.status)) : pipelineActive;
+      return active ? 5000 : false;
+    },
+    // Active pipelines refetch eagerly (incl. on focus); terminal pipelines have an
+    // immutable job list, so cache it indefinitely and avoid redundant refetches.
+    staleTime: pipelineActive ? 0 : Infinity,
+  });
+
+  const jobs = React.useMemo(() => jobsQuery.data?.data ?? [], [jobsQuery.data]);
+
+  const [selectedJobId, setSelectedJobId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (jobs.length === 0) return;
+    setSelectedJobId((current) => (current && jobs.some((j) => j.id === current) ? current : pickDefaultJob(jobs)));
+  }, [jobs]);
+
+  const selectedJob = jobs.find((j) => j.id === selectedJobId) ?? null;
+  const selectedJobActive = isGitLabCIPipelineActive(selectedJob?.status);
+
+  const selectedJobStatusIcon = selectedJob ? getGitLabCIPipelineStatusIcon(selectedJob.status) : null;
+
+  const traceQuery = useQuery({
+    queryKey: ["gitfusion", "jobTrace", clusterName, defaultNamespace, gitServer, project, selectedJobId],
+    queryFn: () =>
+      trpc.gitfusion.getPipelineJobTrace.query({
+        clusterName,
+        namespace: defaultNamespace,
+        gitServer,
+        project,
+        jobId: selectedJobId!,
+      }),
+    enabled: open && !!selectedJobId,
+    refetchInterval: selectedJobActive ? 5000 : false,
+    // Active job logs refetch eagerly; a finished job's trace is immutable, so cache it.
+    staleTime: selectedJobActive ? 0 : Infinity,
+  });
+
+  // Group jobs by stage, preserving first-seen stage order (execution order).
+  const stages = React.useMemo(() => {
+    const order: string[] = [];
+    const byStage = new Map<string, GitFusionPipelineJob[]>();
+    for (const job of jobs) {
+      if (!byStage.has(job.stage)) {
+        byStage.set(job.stage, []);
+        order.push(job.stage);
+      }
+      byStage.get(job.stage)!.push(job);
+    }
+    return order.map((stage) => ({ stage, jobs: byStage.get(stage)! }));
+  }, [jobs]);
+
+  const traceContent = traceQuery.data?.content ?? "";
+  const traceTruncated = traceQuery.data?.truncated === true;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && closeDialog()}>
+      <DialogContent className="flex h-[90vh] w-full max-w-[1400px] flex-col p-0">
+        <DialogHeader className="border-b px-6 py-4">
+          <DialogTitle className="flex flex-wrap items-center gap-3 text-xl font-semibold">
+            <span>Pipeline #{pipelineId}</span>
+            <GitLabCIPipelineStatus status={pipelineStatus} />
+            <span className="text-muted-foreground inline-flex items-center gap-1 text-sm font-normal">
+              {codebaseName}
+            </span>
+            <span className="text-muted-foreground inline-flex items-center gap-1 text-sm font-normal">
+              <GitBranch className="size-3.5" /> {ref}
+            </span>
+            <Button variant="link" size="sm" asChild className="ml-auto p-0">
+              <a href={webUrl} target="_blank" rel="noopener noreferrer">
+                Open in GitLab <ExternalLink className="ml-1 size-3.5" />
+              </a>
+            </Button>
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 gap-4 p-4">
+          <div className="w-[280px] shrink-0">
+            <Card className="flex h-full flex-col">
+              <div className="border-b px-4 py-3">
+                <h3 className="text-foreground font-medium">Jobs</h3>
+                <p className="text-muted-foreground mt-0.5 text-xs">
+                  {jobs.length} {jobs.length === 1 ? "job" : "jobs"}
+                </p>
+              </div>
+              <div className="flex-1 space-y-3 overflow-auto p-2">
+                {jobsQuery.isLoading && <p className="text-muted-foreground px-2 py-1 text-sm">Loading jobs…</p>}
+                {jobsQuery.isError && (
+                  <p className="text-destructive px-2 py-1 text-sm">Failed to load jobs: {String(jobsQuery.error)}</p>
+                )}
+                {!jobsQuery.isLoading && !jobsQuery.isError && jobs.length === 0 && (
+                  <p className="text-muted-foreground px-2 py-1 text-sm">No jobs found for this pipeline.</p>
+                )}
+                {stages.map(({ stage, jobs: stageJobs }) => (
+                  <div key={stage}>
+                    <p className="text-muted-foreground px-2 pb-1 text-xs font-medium tracking-wide uppercase">
+                      {stage}
+                    </p>
+                    <div className="space-y-0.5">
+                      {stageJobs.map((job) => (
+                        <JobRow
+                          key={job.id}
+                          job={job}
+                          selected={job.id === selectedJobId}
+                          onClick={() => setSelectedJobId(job.id)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <div className="flex h-full flex-col overflow-hidden">
+              {selectedJob && selectedJobStatusIcon && (
+                <div className="mb-2 flex items-center gap-2 px-1 text-sm">
+                  <StatusIcon
+                    Icon={selectedJobStatusIcon.component}
+                    color={selectedJobStatusIcon.color}
+                    isSpinning={selectedJobStatusIcon.isSpinning}
+                    width={14}
+                  />
+                  <span className="font-medium">{selectedJob.name}</span>
+                  {selectedJob.failure_reason && (
+                    <span className="text-muted-foreground text-xs">({selectedJob.failure_reason})</span>
+                  )}
+                </div>
+              )}
+              {traceTruncated && (
+                <div className="mb-2 flex items-center gap-2 rounded-md border border-yellow-300 bg-yellow-50 px-3 py-2 text-sm text-yellow-800 dark:border-yellow-700 dark:bg-yellow-950/30 dark:text-yellow-300">
+                  <AlertTriangle className="size-4 shrink-0" />
+                  <span>
+                    Log truncated at {TRACE_LIMIT_LABEL}.{" "}
+                    <a
+                      href={webUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium underline underline-offset-2"
+                    >
+                      Open in GitLab
+                    </a>{" "}
+                    for the full trace.
+                  </span>
+                </div>
+              )}
+              <div className="min-h-0 flex-1">
+                <LogViewer
+                  content={traceContent}
+                  isLoading={traceQuery.isLoading && !traceContent}
+                  error={traceQuery.error ? String(traceQuery.error) : undefined}
+                  emptyMessage={selectedJobId ? "No log output for this job." : "Select a job to view its logs."}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+GitLabCIPipelineLogsDialog.displayName = GITLABCI_PIPELINE_LOGS_DIALOG_NAME;

--- a/apps/client/src/modules/platform/gitlabci/dialogs/PipelineLogs/types.ts
+++ b/apps/client/src/modules/platform/gitlabci/dialogs/PipelineLogs/types.ts
@@ -1,0 +1,14 @@
+import { DialogProps } from "@/core/providers/Dialog/types";
+
+export interface GitLabCIPipelineLogsDialogProps {
+  gitServer: string;
+  /** Project path, e.g. "krci/my-app". */
+  project: string;
+  pipelineId: string;
+  pipelineStatus: string;
+  codebaseName: string;
+  ref: string;
+  webUrl: string;
+}
+
+export type GitLabCIPipelineLogsDialogPropsWithBase = DialogProps<GitLabCIPipelineLogsDialogProps>;

--- a/apps/client/src/modules/platform/gitlabci/hooks/useGitLabCIPipelines.tsx
+++ b/apps/client/src/modules/platform/gitlabci/hooks/useGitLabCIPipelines.tsx
@@ -1,0 +1,125 @@
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import { useQueries, type UseQueryResult } from "@tanstack/react-query";
+import { Codebase, GitFusionPipeline, GitFusionPipelineListResponse, stripLeadingSlash } from "@my-project/shared";
+import React from "react";
+import { useShallow } from "zustand/react/shallow";
+
+/**
+ * A GitFusion pipeline plus the Codebase it belongs to — the `/api/v1/pipelines` response
+ * has no Codebase notion, so we attach it client-side while fanning out one request per codebase.
+ */
+export interface GitLabCIPipelineRow extends GitFusionPipeline {
+  codebaseName: string;
+  namespace: string;
+  gitServer: string;
+  project: string;
+}
+
+interface UseGitLabCIPipelinesParams {
+  /** Codebases to fetch pipelines for; callers must pre-filter to ciTool=gitlab. */
+  codebases: Codebase[];
+  perPage?: number;
+  enabled?: boolean;
+  /** Poll interval in ms; `false` disables polling. */
+  refetchInterval?: number | false;
+}
+
+/**
+ * Fetches GitLab CI pipelines for the given codebases (one tRPC request each) and merges
+ * them into a single list sorted newest-first by `created_at`.
+ *
+ * **Performance:** fans out one HTTP request per codebase on every poll cycle — practical
+ * up to ~30 codebases; beyond that the N×poll load is significant. A server-side aggregate
+ * endpoint is planned (v0.7).
+ */
+export function useGitLabCIPipelines({
+  codebases,
+  perPage = 20,
+  enabled = true,
+  refetchInterval = 15_000,
+}: UseGitLabCIPipelinesParams) {
+  const trpc = useTRPCClient();
+  const { clusterName, defaultNamespace } = useClusterStore(
+    useShallow((state) => ({
+      clusterName: state.clusterName,
+      defaultNamespace: state.defaultNamespace,
+    }))
+  );
+
+  // Jitter the interval so concurrent instances desync their polls and avoid a thundering-herd
+  // burst to GitFusion. The offset is computed once per instance (useRef, not useMemo) so it stays
+  // stable across re-renders instead of re-randomizing — and resyncing — the shared poll timer.
+  const jitterOffsetRef = React.useRef(Math.random() * 5_000);
+  const jitteredInterval: number | false =
+    refetchInterval === false ? false : refetchInterval + jitterOffsetRef.current;
+
+  // staleTime tracks the base poll interval (not the jittered value) so a focus/mount
+  // between polls does not trigger a spurious refetch. Falls back to 0 when polling is
+  // disabled so the data is still revalidated on mount.
+  const staleTime = typeof refetchInterval === "number" ? refetchInterval : 0;
+
+  // Narrow each codebase to only the fields the rows need, so the query/combine closures don't
+  // retain whole Codebase objects (spec/status/labels) for their lifetime.
+  const targets = React.useMemo(
+    () =>
+      codebases.map((codebase) => ({
+        codebaseName: codebase.metadata.name,
+        namespace: codebase.metadata.namespace,
+        gitServer: codebase.spec.gitServer,
+        project: stripLeadingSlash(codebase.spec.gitUrlPath),
+      })),
+    [codebases]
+  );
+
+  // Merge every codebase's pipelines into one newest-first list. `combine` runs inside useQueries
+  // and is memoized (useCallback), so it recomputes only when the query results change — which is
+  // why no separate signature of the (per-render-fresh) `queries` array is needed.
+  const combine = React.useCallback(
+    (results: UseQueryResult<GitFusionPipelineListResponse>[]) => {
+      const rows: GitLabCIPipelineRow[] = [];
+
+      results.forEach((result, index) => {
+        const target = targets[index];
+        if (!target || !result.data) return;
+
+        for (const pipeline of result.data.data) {
+          rows.push({
+            ...pipeline,
+            codebaseName: target.codebaseName,
+            namespace: target.namespace ?? defaultNamespace,
+            gitServer: target.gitServer,
+            project: target.project,
+          });
+        }
+      });
+
+      rows.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+
+      return {
+        pipelines: rows,
+        isLoading: results.length > 0 && results.some((result) => result.isLoading),
+        errors: results.map((result) => result.error).filter((error): error is Error => Boolean(error)),
+      };
+    },
+    [targets, defaultNamespace]
+  );
+
+  return useQueries({
+    queries: targets.map(({ gitServer, project }) => ({
+      queryKey: ["gitfusion", "pipelineList", clusterName, defaultNamespace, gitServer, project, perPage],
+      queryFn: () =>
+        trpc.gitfusion.getPipelineList.query({
+          clusterName,
+          namespace: defaultNamespace,
+          gitServer,
+          project,
+          perPage,
+        }),
+      enabled: enabled && !!gitServer && !!project,
+      refetchInterval: jitteredInterval,
+      staleTime,
+    })),
+    combine,
+  });
+}

--- a/apps/client/src/modules/platform/gitlabci/pages/pipeline-list/page.tsx
+++ b/apps/client/src/modules/platform/gitlabci/pages/pipeline-list/page.tsx
@@ -1,0 +1,57 @@
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { Card } from "@/core/components/ui/card";
+import { useCodebaseWatchList } from "@/k8s/api/groups/KRCI/Codebase";
+import { ciTool } from "@my-project/shared";
+import { ENTITY_ICON } from "@/k8s/constants/entity-icons";
+import React from "react";
+import { GitLabCIPipelineList } from "@/modules/platform/gitlabci/components/GitLabCIPipelineList";
+import { useGitLabCIPipelines } from "@/modules/platform/gitlabci/hooks/useGitLabCIPipelines";
+
+function AllGitLabCIPipelines() {
+  const codebaseListWatch = useCodebaseWatchList();
+
+  const gitlabCodebases = React.useMemo(
+    () => codebaseListWatch.data.array.filter((codebase) => codebase.spec.ciTool === ciTool.gitlab),
+    [codebaseListWatch.data.array]
+  );
+
+  const { pipelines, isLoading, errors } = useGitLabCIPipelines({ codebases: gitlabCodebases });
+
+  const isInitialLoading =
+    codebaseListWatch.isLoading || (gitlabCodebases.length > 0 && isLoading && pipelines.length === 0);
+
+  const codebaseWatchError = codebaseListWatch.error as Error | undefined;
+  const allQueriesFailed = gitlabCodebases.length > 0 && errors.length === gitlabCodebases.length;
+
+  const blockerError: Error | undefined = codebaseWatchError ?? (allQueriesFailed ? errors[0] : undefined);
+  const partialErrors: Error[] | undefined = !blockerError && errors.length > 0 ? errors : undefined;
+
+  return (
+    <GitLabCIPipelineList
+      pipelines={pipelines}
+      isLoading={isInitialLoading}
+      showCodebaseColumn
+      tableId="gitlabci-pipelines-all"
+      tableName="All GitLab CI Pipelines"
+      blockerError={blockerError}
+      errors={partialErrors}
+    />
+  );
+}
+
+export function GitLabCIPipelineListPage() {
+  return (
+    <PageWrapper breadcrumbs={[{ label: "GitLab CI Pipelines" }]}>
+      <PageContentWrapper
+        icon={ENTITY_ICON.pipelineRun}
+        title="GitLab CI Pipelines"
+        description="Monitor GitLab CI pipelines across all components configured to run their CI in GitLab CI."
+      >
+        <Card className="px-6 pb-6">
+          <AllGitLabCIPipelines />
+        </Card>
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/platform/gitlabci/pages/pipeline-list/route.lazy.ts
+++ b/apps/client/src/modules/platform/gitlabci/pages/pipeline-list/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_GITLABCI_PIPELINES } from "./route";
+import { GitLabCIPipelineListPage } from "./page";
+
+const GitLabCIPipelineListRoute = createLazyRoute(ROUTE_ID_GITLABCI_PIPELINES)({
+  component: GitLabCIPipelineListPage,
+});
+
+export default GitLabCIPipelineListRoute;

--- a/apps/client/src/modules/platform/gitlabci/pages/pipeline-list/route.ts
+++ b/apps/client/src/modules/platform/gitlabci/pages/pipeline-list/route.ts
@@ -1,0 +1,17 @@
+import { routeCICD } from "@/core/router/routes";
+import { createRoute } from "@tanstack/react-router";
+
+export const PATH_GITLABCI_PIPELINES = "gitlabci-pipelines" as const;
+export const PATH_GITLABCI_PIPELINES_FULL = "/c/$clusterName/cicd/gitlabci-pipelines" as const;
+export const ROUTE_ID_GITLABCI_PIPELINES = "/_layout/c/$clusterName/cicd/gitlabci-pipelines" as const;
+
+export type Search = Record<string, unknown>;
+
+export const routeGitLabCIPipelineList = createRoute({
+  getParentRoute: () => routeCICD,
+  path: PATH_GITLABCI_PIPELINES,
+  validateSearch: (search: Record<string, unknown>): Search => search,
+  head: () => ({
+    meta: [{ title: "GitLab CI Pipelines | KRCI" }],
+  }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/platform/gitlabci/utils/getStatusIcon.test.ts
+++ b/apps/client/src/modules/platform/gitlabci/utils/getStatusIcon.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "vitest";
+import { getGitLabCIPipelineStatusIcon, isGitLabCIPipelineActive } from "./getStatusIcon";
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import { Ban, CircleCheck, CirclePause, CircleX, Clock, LoaderCircle, ShieldQuestion, SkipForward } from "lucide-react";
+
+describe("getGitLabCIPipelineStatusIcon", () => {
+  test("returns success icon for 'success' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("success");
+
+    expect(result.component).toBe(CircleCheck);
+    expect(result.color).toBe(STATUS_COLOR.SUCCESS);
+    expect(result.title).toBe("Success");
+    expect(result.isSpinning).toBeUndefined();
+  });
+
+  test("returns error icon for 'failed' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("failed");
+
+    expect(result.component).toBe(CircleX);
+    expect(result.color).toBe(STATUS_COLOR.ERROR);
+    expect(result.title).toBe("Failed");
+  });
+
+  test("returns spinning loader for 'running' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("running");
+
+    expect(result.component).toBe(LoaderCircle);
+    expect(result.color).toBe(STATUS_COLOR.IN_PROGRESS);
+    expect(result.isSpinning).toBe(true);
+    expect(result.title).toBe("Running");
+  });
+
+  test("returns clock icon for 'pending' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("pending");
+
+    expect(result.component).toBe(Clock);
+    expect(result.color).toBe(STATUS_COLOR.IN_PROGRESS);
+    expect(result.title).toBe("Pending");
+  });
+
+  test("returns clock icon for 'created' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("created");
+
+    expect(result.component).toBe(Clock);
+    expect(result.color).toBe(STATUS_COLOR.IN_PROGRESS);
+    expect(result.title).toBe("Created");
+  });
+
+  test("returns clock icon for 'preparing' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("preparing");
+
+    expect(result.component).toBe(Clock);
+    expect(result.color).toBe(STATUS_COLOR.IN_PROGRESS);
+    expect(result.title).toBe("Preparing");
+  });
+
+  test("returns clock icon for 'scheduled' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("scheduled");
+
+    expect(result.component).toBe(Clock);
+    expect(result.color).toBe(STATUS_COLOR.IN_PROGRESS);
+    expect(result.title).toBe("Scheduled");
+  });
+
+  test("returns clock icon for 'waiting_for_resource' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("waiting_for_resource");
+
+    expect(result.component).toBe(Clock);
+    expect(result.color).toBe(STATUS_COLOR.IN_PROGRESS);
+    expect(result.title).toBe("Waiting For Resource");
+  });
+
+  test("returns ban icon for 'canceled' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("canceled");
+
+    expect(result.component).toBe(Ban);
+    expect(result.color).toBe(STATUS_COLOR.SUSPENDED);
+    expect(result.title).toBe("Canceled");
+  });
+
+  test("returns ban icon for 'cancelled' status (alternate spelling)", () => {
+    const result = getGitLabCIPipelineStatusIcon("cancelled");
+
+    expect(result.component).toBe(Ban);
+    expect(result.color).toBe(STATUS_COLOR.SUSPENDED);
+    expect(result.title).toBe("Canceled");
+  });
+
+  test("returns skip-forward icon for 'skipped' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("skipped");
+
+    expect(result.component).toBe(SkipForward);
+    expect(result.color).toBe(STATUS_COLOR.SUSPENDED);
+    expect(result.title).toBe("Skipped");
+  });
+
+  test("returns pause icon for 'manual' status", () => {
+    const result = getGitLabCIPipelineStatusIcon("manual");
+
+    expect(result.component).toBe(CirclePause);
+    expect(result.color).toBe(STATUS_COLOR.MISSING);
+    expect(result.title).toBe("Manual");
+  });
+
+  test("returns unknown icon for undefined status", () => {
+    const result = getGitLabCIPipelineStatusIcon(undefined);
+
+    expect(result.component).toBe(ShieldQuestion);
+    expect(result.color).toBe(STATUS_COLOR.UNKNOWN);
+    expect(result.title).toBe("Unknown");
+  });
+
+  test("returns unknown icon with title-cased label for an unrecognised status", () => {
+    const result = getGitLabCIPipelineStatusIcon("some_new_status");
+
+    expect(result.component).toBe(ShieldQuestion);
+    expect(result.color).toBe(STATUS_COLOR.UNKNOWN);
+    expect(result.title).toBe("Some New Status");
+  });
+
+  test("is case-insensitive (upper-case input normalises to lower-case)", () => {
+    const result = getGitLabCIPipelineStatusIcon("SUCCESS");
+
+    expect(result.component).toBe(CircleCheck);
+    expect(result.color).toBe(STATUS_COLOR.SUCCESS);
+    expect(result.title).toBe("Success");
+  });
+});
+
+describe("isGitLabCIPipelineActive", () => {
+  test.each(["running", "pending", "created", "preparing", "scheduled", "waiting_for_resource"])(
+    "returns true for active status '%s'",
+    (status) => {
+      expect(isGitLabCIPipelineActive(status)).toBe(true);
+    }
+  );
+
+  test.each(["success", "failed", "canceled", "cancelled", "skipped", "manual"])(
+    "returns false for terminal status '%s'",
+    (status) => {
+      expect(isGitLabCIPipelineActive(status)).toBe(false);
+    }
+  );
+
+  test("returns false for undefined status", () => {
+    expect(isGitLabCIPipelineActive(undefined)).toBe(false);
+  });
+
+  test("returns false for an unrecognised status", () => {
+    expect(isGitLabCIPipelineActive("some_new_status")).toBe(false);
+  });
+
+  test("is case-insensitive (upper-case input normalises to lower-case)", () => {
+    expect(isGitLabCIPipelineActive("RUNNING")).toBe(true);
+  });
+});

--- a/apps/client/src/modules/platform/gitlabci/utils/getStatusIcon.ts
+++ b/apps/client/src/modules/platform/gitlabci/utils/getStatusIcon.ts
@@ -1,0 +1,48 @@
+import { STATUS_COLOR } from "@/k8s/constants/colors";
+import { Ban, CircleCheck, CirclePause, CircleX, Clock, LoaderCircle, ShieldQuestion, SkipForward } from "lucide-react";
+import type { K8sResourceStatusIcon } from "@/k8s/types";
+
+export interface GitLabCIStatusIcon extends K8sResourceStatusIcon {
+  title: string;
+}
+
+const titleCase = (status: string): string => status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+// Non-terminal statuses — the single source of truth for "is this still active" (e.g. polling).
+const ACTIVE_STATUSES = new Set(["running", "pending", "created", "preparing", "scheduled", "waiting_for_resource"]);
+
+export function isGitLabCIPipelineActive(status: string | undefined): boolean {
+  return ACTIVE_STATUSES.has((status ?? "").toLowerCase());
+}
+
+export function getGitLabCIPipelineStatusIcon(status: string | undefined): GitLabCIStatusIcon {
+  const normalized = (status ?? "").toLowerCase();
+
+  switch (normalized) {
+    case "success":
+      return { component: CircleCheck, color: STATUS_COLOR.SUCCESS, title: "Success" };
+    case "failed":
+      return { component: CircleX, color: STATUS_COLOR.ERROR, title: "Failed" };
+    case "running":
+      return { component: LoaderCircle, color: STATUS_COLOR.IN_PROGRESS, isSpinning: true, title: "Running" };
+    case "pending":
+    case "created":
+    case "preparing":
+    case "scheduled":
+    case "waiting_for_resource":
+      return { component: Clock, color: STATUS_COLOR.IN_PROGRESS, title: titleCase(normalized) };
+    case "canceled":
+    case "cancelled":
+      return { component: Ban, color: STATUS_COLOR.SUSPENDED, title: "Canceled" };
+    case "skipped":
+      return { component: SkipForward, color: STATUS_COLOR.SUSPENDED, title: "Skipped" };
+    case "manual":
+      return { component: CirclePause, color: STATUS_COLOR.MISSING, title: "Manual" };
+    default:
+      return {
+        component: ShieldQuestion,
+        color: STATUS_COLOR.UNKNOWN,
+        title: status ? titleCase(normalized) : "Unknown",
+      };
+  }
+}

--- a/packages/shared/src/models/k8s/integrations/gitfusion/index.ts
+++ b/packages/shared/src/models/k8s/integrations/gitfusion/index.ts
@@ -71,3 +71,72 @@ export interface GitLabPipelineResponse {
   created_at: string;
   updated_at: string;
 }
+
+/** Normalized CI/CD pipeline as returned by GitFusion's `GET /api/v1/pipelines` (provider-agnostic; GitLab today). */
+export interface GitFusionPipeline {
+  id: string; // string to accommodate non-numeric provider IDs
+  project_id?: string;
+  ref: string;
+  sha: string;
+  /** What triggered the pipeline (e.g. "push", "merge_request_event", "web", "other"). */
+  source?: string;
+  /** Normalized status — see GitFusionPipelineStatus. */
+  status: string;
+  created_at: string;
+  updated_at?: string;
+  web_url: string;
+}
+
+/** Normalized pipeline statuses GitFusion emits for a GitLab pipeline. */
+export type GitFusionPipelineStatus =
+  | "success"
+  | "failed"
+  | "running"
+  | "pending"
+  | "canceled"
+  | "cancelled"
+  | "skipped"
+  | "manual"
+  | "created"
+  | "preparing"
+  | "scheduled"
+  | "waiting_for_resource"
+  | "unknown";
+
+export interface GitFusionPipelineListResponse {
+  data: GitFusionPipeline[];
+  pagination: { page: number; per_page: number; total: number };
+}
+
+/**
+ * A single job within a pipeline, from GitFusion's `GET /api/v1/pipeline-jobs`. Jobs are
+ * grouped by `stage` and each has its own log (trace).
+ */
+export interface GitFusionPipelineJob {
+  id: string;
+  name: string;
+  stage: string;
+  /** Provider-native status (e.g. success, failed, running, manual, skipped). */
+  status: string;
+  ref?: string;
+  web_url?: string;
+  allow_failure?: boolean;
+  /** Job duration in seconds. */
+  duration?: number;
+  created_at?: string;
+  started_at?: string;
+  finished_at?: string;
+  failure_reason?: string;
+}
+
+export interface GitFusionPipelineJobListResponse {
+  data: GitFusionPipelineJob[];
+}
+
+/** Raw trace (log) of a single pipeline job, from `GET /api/v1/pipeline-job-trace`. */
+export interface GitFusionPipelineJobTrace {
+  job_id: string;
+  content: string;
+  /** True when the backend truncated the log at its size ceiling (~4 MB); the full trace is in GitLab. */
+  truncated?: boolean;
+}

--- a/packages/trpc/src/clients/gitfusion/index.ts
+++ b/packages/trpc/src/clients/gitfusion/index.ts
@@ -5,6 +5,9 @@ import {
   GitFusionOrganizationListResponse,
   GitFusionBranchListResponse,
   GitFusionPullRequestListResponse,
+  GitFusionPipelineListResponse,
+  GitFusionPipelineJobListResponse,
+  GitFusionPipelineJobTrace,
   GitLabPipelineResponse,
   GitLabPipelineVariable,
   stripTrailingSlash,
@@ -313,6 +316,50 @@ export class GitFusionClient {
     await this.fetchJson<void>(url, {
       method: "DELETE",
     });
+  }
+
+  /** List CI/CD pipelines for a project (provider-agnostic; GitLab today). */
+  async getPipelines(
+    gitServer: string,
+    project: string,
+    opts?: { ref?: string; status?: string; page?: number; perPage?: number }
+  ): Promise<GitFusionPipelineListResponse> {
+    const endpoint = this.buildEndpoint("/api/v1/pipelines", {
+      gitServer,
+      project,
+      ref: opts?.ref,
+      status: opts?.status,
+      page: opts?.page,
+      perPage: opts?.perPage,
+    });
+
+    return this.fetchJson<GitFusionPipelineListResponse>(endpoint);
+  }
+
+  /** List the jobs of a CI/CD pipeline (provider-agnostic; GitLab today). */
+  async getPipelineJobs(
+    gitServer: string,
+    project: string,
+    pipelineId: string
+  ): Promise<GitFusionPipelineJobListResponse> {
+    const endpoint = this.buildEndpoint("/api/v1/pipeline-jobs", {
+      gitServer,
+      project,
+      pipelineId,
+    });
+
+    return this.fetchJson<GitFusionPipelineJobListResponse>(endpoint);
+  }
+
+  /** Get the trace (log) of a CI/CD pipeline job. */
+  async getJobTrace(gitServer: string, project: string, jobId: string): Promise<GitFusionPipelineJobTrace> {
+    const endpoint = this.buildEndpoint("/api/v1/pipeline-job-trace", {
+      gitServer,
+      project,
+      jobId,
+    });
+
+    return this.fetchJson<GitFusionPipelineJobTrace>(endpoint);
   }
 
   /**

--- a/packages/trpc/src/routers/gitfusion/index.ts
+++ b/packages/trpc/src/routers/gitfusion/index.ts
@@ -7,6 +7,9 @@ import {
   triggerGitLabPipeline,
   getPullRequestList,
   getOpenPullRequestsSummary,
+  getPipelineList,
+  getPipelineJobList,
+  getPipelineJobTrace,
 } from "./procedures/index.js";
 
 export const gitfusionRouter = t.router({
@@ -17,4 +20,7 @@ export const gitfusionRouter = t.router({
   triggerGitLabPipeline,
   getPullRequestList,
   getOpenPullRequestsSummary,
+  getPipelineList,
+  getPipelineJobList,
+  getPipelineJobTrace,
 });

--- a/packages/trpc/src/routers/gitfusion/procedures/getPipelineJobList/index.test.ts
+++ b/packages/trpc/src/routers/gitfusion/procedures/getPipelineJobList/index.test.ts
@@ -1,0 +1,42 @@
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetPipelineJobs = vi.fn();
+
+vi.mock("../../../../clients/gitfusion/index.js", () => ({
+  createGitFusionClient: () => ({
+    getPipelineJobs: mockGetPipelineJobs,
+  }),
+}));
+
+describe("gitfusion.getPipelineJobList", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return the pipeline job list", async () => {
+    const mockResponse = {
+      data: [{ id: "16", name: "build", stage: "build", status: "success" }],
+    };
+    mockGetPipelineJobs.mockResolvedValueOnce(mockResponse);
+
+    const caller = createCaller(mockContext);
+    const result = await caller.gitfusion.getPipelineJobList({
+      clusterName: "cluster",
+      namespace: "ns",
+      gitServer: "gitlab",
+      project: "krci/my-app",
+      pipelineId: "5",
+    });
+
+    expect(result).toEqual(mockResponse);
+    expect(mockGetPipelineJobs).toHaveBeenCalledWith("gitlab", "krci/my-app", "5");
+  });
+});

--- a/packages/trpc/src/routers/gitfusion/procedures/getPipelineJobList/index.ts
+++ b/packages/trpc/src/routers/gitfusion/procedures/getPipelineJobList/index.ts
@@ -1,0 +1,22 @@
+import { protectedProcedure } from "../../../../procedures/protected/index.js";
+import { z } from "zod";
+import { createGitFusionClient } from "../../../../clients/gitfusion/index.js";
+
+export const getPipelineJobListProcedure = protectedProcedure
+  .input(
+    z.object({
+      // clusterName and namespace are accepted for API compatibility but unused —
+      // GitFusion uses network policies for cluster-level security.
+      clusterName: z.string(),
+      namespace: z.string(),
+      gitServer: z.string(),
+      project: z.string(),
+      pipelineId: z.string(),
+    })
+  )
+  .query(async ({ input }) => {
+    const { gitServer, project, pipelineId } = input;
+
+    const gitFusionClient = createGitFusionClient();
+    return gitFusionClient.getPipelineJobs(gitServer, project, pipelineId);
+  });

--- a/packages/trpc/src/routers/gitfusion/procedures/getPipelineJobTrace/index.test.ts
+++ b/packages/trpc/src/routers/gitfusion/procedures/getPipelineJobTrace/index.test.ts
@@ -1,0 +1,40 @@
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetJobTrace = vi.fn();
+
+vi.mock("../../../../clients/gitfusion/index.js", () => ({
+  createGitFusionClient: () => ({
+    getJobTrace: mockGetJobTrace,
+  }),
+}));
+
+describe("gitfusion.getPipelineJobTrace", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return the job trace", async () => {
+    const mockResponse = { job_id: "23", content: "build log output" };
+    mockGetJobTrace.mockResolvedValueOnce(mockResponse);
+
+    const caller = createCaller(mockContext);
+    const result = await caller.gitfusion.getPipelineJobTrace({
+      clusterName: "cluster",
+      namespace: "ns",
+      gitServer: "gitlab",
+      project: "krci/my-app",
+      jobId: "23",
+    });
+
+    expect(result).toEqual(mockResponse);
+    expect(mockGetJobTrace).toHaveBeenCalledWith("gitlab", "krci/my-app", "23");
+  });
+});

--- a/packages/trpc/src/routers/gitfusion/procedures/getPipelineJobTrace/index.ts
+++ b/packages/trpc/src/routers/gitfusion/procedures/getPipelineJobTrace/index.ts
@@ -1,0 +1,22 @@
+import { protectedProcedure } from "../../../../procedures/protected/index.js";
+import { z } from "zod";
+import { createGitFusionClient } from "../../../../clients/gitfusion/index.js";
+
+export const getPipelineJobTraceProcedure = protectedProcedure
+  .input(
+    z.object({
+      // clusterName and namespace are accepted for API compatibility but unused —
+      // GitFusion uses network policies for cluster-level security.
+      clusterName: z.string(),
+      namespace: z.string(),
+      gitServer: z.string(),
+      project: z.string(),
+      jobId: z.string(),
+    })
+  )
+  .query(async ({ input }) => {
+    const { gitServer, project, jobId } = input;
+
+    const gitFusionClient = createGitFusionClient();
+    return gitFusionClient.getJobTrace(gitServer, project, jobId);
+  });

--- a/packages/trpc/src/routers/gitfusion/procedures/getPipelineList/index.test.ts
+++ b/packages/trpc/src/routers/gitfusion/procedures/getPipelineList/index.test.ts
@@ -1,0 +1,79 @@
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetPipelines = vi.fn();
+
+vi.mock("../../../../clients/gitfusion/index.js", () => ({
+  createGitFusionClient: () => ({
+    getPipelines: mockGetPipelines,
+  }),
+}));
+
+describe("gitfusion.getPipelineList", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return pipeline list", async () => {
+    const mockResponse = {
+      data: [
+        {
+          id: "5",
+          ref: "main",
+          sha: "abc123",
+          status: "success",
+          web_url: "https://gitlab/-/pipelines/5",
+          created_at: "2026-06-20T08:09:09Z",
+        },
+      ],
+      pagination: { page: 1, per_page: 20, total: 1 },
+    };
+    mockGetPipelines.mockResolvedValueOnce(mockResponse);
+
+    const caller = createCaller(mockContext);
+    const result = await caller.gitfusion.getPipelineList({
+      clusterName: "cluster",
+      namespace: "ns",
+      gitServer: "gitlab",
+      project: "krci/my-app",
+    });
+
+    expect(result).toEqual(mockResponse);
+    expect(mockGetPipelines).toHaveBeenCalledWith("gitlab", "krci/my-app", {
+      ref: undefined,
+      status: undefined,
+      page: undefined,
+      perPage: undefined,
+    });
+  });
+
+  it("should forward ref/status/pagination filters", async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: [], pagination: { page: 2, per_page: 10, total: 0 } });
+
+    const caller = createCaller(mockContext);
+    await caller.gitfusion.getPipelineList({
+      clusterName: "cluster",
+      namespace: "ns",
+      gitServer: "gitlab",
+      project: "krci/my-app",
+      ref: "main",
+      status: "running",
+      page: 2,
+      perPage: 10,
+    });
+
+    expect(mockGetPipelines).toHaveBeenCalledWith("gitlab", "krci/my-app", {
+      ref: "main",
+      status: "running",
+      page: 2,
+      perPage: 10,
+    });
+  });
+});

--- a/packages/trpc/src/routers/gitfusion/procedures/getPipelineList/index.ts
+++ b/packages/trpc/src/routers/gitfusion/procedures/getPipelineList/index.ts
@@ -1,0 +1,25 @@
+import { protectedProcedure } from "../../../../procedures/protected/index.js";
+import { z } from "zod";
+import { createGitFusionClient } from "../../../../clients/gitfusion/index.js";
+
+export const getPipelineListProcedure = protectedProcedure
+  .input(
+    z.object({
+      // clusterName and namespace are accepted for API compatibility but unused —
+      // GitFusion uses network policies for cluster-level security.
+      clusterName: z.string(),
+      namespace: z.string(),
+      gitServer: z.string(),
+      project: z.string(), // e.g. "krci/my-app" (spec.gitUrlPath without the leading slash)
+      ref: z.string().optional(),
+      status: z.string().optional(),
+      page: z.number().optional(),
+      perPage: z.number().optional(),
+    })
+  )
+  .query(async ({ input }) => {
+    const { gitServer, project, ref, status, page, perPage } = input;
+
+    const gitFusionClient = createGitFusionClient();
+    return gitFusionClient.getPipelines(gitServer, project, { ref, status, page, perPage });
+  });

--- a/packages/trpc/src/routers/gitfusion/procedures/index.ts
+++ b/packages/trpc/src/routers/gitfusion/procedures/index.ts
@@ -5,3 +5,6 @@ export { invalidateBranchListCacheProcedure as invalidateBranchListCache } from 
 export { triggerGitLabPipelineProcedure as triggerGitLabPipeline } from "./triggerGitLabPipeline/index.js";
 export { getPullRequestListProcedure as getPullRequestList } from "./getPullRequestList/index.js";
 export { getOpenPullRequestsSummaryProcedure as getOpenPullRequestsSummary } from "./getOpenPullRequestsSummary/index.js";
+export { getPipelineListProcedure as getPipelineList } from "./getPipelineList/index.js";
+export { getPipelineJobListProcedure as getPipelineJobList } from "./getPipelineJobList/index.js";
+export { getPipelineJobTraceProcedure as getPipelineJobTrace } from "./getPipelineJobTrace/index.js";


### PR DESCRIPTION
Introduces a new GitLab CI integration surface in the portal:
- exposes codebase pipelines via a dedicated tab on the codebase detail page
- adds a full pipeline list page with status, duration, and branch columns
- provides a pipeline logs dialog for streaming job trace output per stage
- backs the UI with new tRPC procedures (getPipelineList, getPipelineJobList, getPipelineJobTrace) wired through the gitfusion router and client
