### PR TITLE
EPMDEDP-17132: bug: use K8s response to build success toast route

### DIFF
--- a/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.test.tsx
+++ b/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.test.tsx
@@ -217,6 +217,58 @@ describe("useResourceCRUDMutation", () => {
       });
     });
 
+    it("should build success options from the K8s response name for generateName resources", async () => {
+      const generateNameResource = {
+        apiVersion: "test.group/v1",
+        kind: "Resource",
+        metadata: {
+          generateName: "run-prefix-",
+          namespace: "default",
+        },
+      } as KubeObjectDraft;
+
+      const serverAssignedName = "run-prefix-abc12";
+      const createdResource = {
+        ...generateNameResource,
+        metadata: { ...generateNameResource.metadata, name: serverAssignedName },
+      };
+      vi.mocked(mockTrpcClient.k8s.create.mutate).mockResolvedValue(createdResource);
+      vi.mocked(showToast).mockReturnValue("toast-id");
+
+      const { result } = renderHook(
+        () =>
+          useResourceCRUDMutation("test-create", k8sOperation.create, {
+            createCustomMessages: (item) => ({
+              success: {
+                message: "Resource has been created",
+                options: {
+                  externalLink: { url: `https://example.com/runs/${item.metadata.name}`, text: "View" },
+                },
+              },
+            }),
+          }),
+        {
+          wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+        }
+      );
+
+      await result.current.mutateAsync({
+        resource: generateNameResource,
+        resourceConfig: mockResourceConfig,
+      });
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith(
+          "Resource has been created",
+          "success",
+          expect.objectContaining({
+            id: "toast-id",
+            externalLink: { url: `https://example.com/runs/${serverAssignedName}`, text: "View" },
+          })
+        );
+      });
+    });
+
     it("should call onMutate callback", async () => {
       const onMutate = vi.fn();
       vi.mocked(mockTrpcClient.k8s.create.mutate).mockResolvedValue(mockResource);

--- a/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.tsx
+++ b/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.tsx
@@ -146,13 +146,18 @@ export const useResourceCRUDMutation = <KubeObjectData extends KubeObjectDraft, 
       const loadingToastId = showToast(loadingMessage, "loading");
 
       promise
-        .then(() => {
-          // Update to success toast with optional link
+        .then((responseData) => {
+          // Re-derive from the response: `generateName` resources only carry their assigned name there, not on the input.
+          const resolvedSuccessOptions =
+            (responseData != null && typeof responseData === "object"
+              ? options?.createCustomMessages?.(responseData as KubeObjectData)?.success?.options
+              : undefined) ?? customMessages?.success?.options;
+
           showToast(successMessage, "success", {
             id: loadingToastId,
-            duration: customMessages?.success?.options?.duration || 5000,
-            route: customMessages?.success?.options?.route,
-            externalLink: customMessages?.success?.options?.externalLink,
+            duration: resolvedSuccessOptions?.duration || 5000,
+            route: resolvedSuccessOptions?.route,
+            externalLink: resolvedSuccessOptions?.externalLink,
           });
         })
         .catch((err) => {


### PR DESCRIPTION
## Description
bug: use K8s response to build success toast route

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit tests
- [ ] Integration tests
- [X] End-to-end tests
- [ ] Manual testing

**Test Configuration**:

- Node.js version:
- pnpm version:
- Browser (for frontend changes):
- Kubernetes version (if applicable):

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have squashed my commits
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm format:check` and code is properly formatted
- [ ] I have run `pnpm test:coverage` and maintained adequate test coverage
