### PR TITLE
EPMDEDP-17135: fix: prevent silent submit when creating an environment without a Clean Pipeline template

### DIFF
--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/CreateStageWizard.stories.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/CreateStageWizard.stories.tsx
@@ -1,7 +1,45 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { QueryClient } from "@tanstack/react-query";
 import { expect } from "storybook/test";
+import { k8sTriggerTemplateConfig, pipelineType, triggerTemplateLabels } from "@my-project/shared";
+import { getK8sWatchListQueryCacheKey } from "@/k8s/api/hooks/useWatch/query-keys";
+import { TEST_CLUSTER_NAME, TEST_NAMESPACE } from "@/test/utils";
 import { CreateStageWizard } from "./index";
 import { withAppProviders } from "@sb/index";
+
+const makeTriggerTemplate = (name: string, type: string) => ({
+  apiVersion: k8sTriggerTemplateConfig.apiVersion,
+  kind: k8sTriggerTemplateConfig.kind,
+  metadata: { name, namespace: TEST_NAMESPACE, labels: { [triggerTemplateLabels.pipelineType]: type } },
+  spec: {},
+});
+
+const mockTriggerTemplates = [
+  makeTriggerTemplate("deploy-full-codemie", pipelineType.deploy),
+  makeTriggerTemplate("clean", pipelineType.clean),
+];
+
+// The wizard now gates rendering until trigger templates finish loading, so the story must
+// seed the watch-list cache — otherwise the watch stays on placeholder data and the form
+// never mounts. Built via the production key helper so the seeded data lands on the exact key.
+const seedTriggerTemplates = (queryClient: QueryClient) => {
+  const items = new Map(mockTriggerTemplates.map((template) => [template.metadata.name, template]));
+
+  queryClient.setQueryData(
+    getK8sWatchListQueryCacheKey(
+      TEST_CLUSTER_NAME,
+      TEST_NAMESPACE,
+      k8sTriggerTemplateConfig.group,
+      k8sTriggerTemplateConfig.pluralName
+    ),
+    {
+      apiVersion: k8sTriggerTemplateConfig.apiVersion,
+      kind: `${k8sTriggerTemplateConfig.kind}List`,
+      metadata: {},
+      items,
+    }
+  );
+};
 
 const meta = {
   title: "Platform/CDPipelines/Wizards/CreateStageWizard",
@@ -11,7 +49,7 @@ const meta = {
   },
   tags: ["autodocs"],
   decorators: [
-    withAppProviders(),
+    withAppProviders({ seedQueryCache: seedTriggerTemplates }),
     (Story) => (
       <div className="p-6">
         <Story />

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/components/Success/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/components/Success/index.tsx
@@ -6,17 +6,18 @@ import { Link } from "@tanstack/react-router";
 import { NAMES } from "../../names";
 import { routeCDPipelineDetails } from "@/modules/platform/cdpipelines/pages/details/route";
 import { routeStageDetails } from "@/modules/platform/cdpipelines/pages/stage-details/route";
-import { routeStageCreate, PATH_STAGE_CREATE_FULL } from "../../../../route";
+import { PATH_STAGE_CREATE_FULL } from "../../../../route";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
 import { useWizardStore } from "../../store";
 import { router } from "@/core/router";
 import { useCreateStageForm } from "../../providers/form/hooks";
+import { useSafeStageCreateParams } from "../../hooks/useSafeStageCreateParams";
 
 export const Success: React.FC = () => {
   const form = useCreateStageForm();
   const name = useStore(form.store, (state) => state.values[NAMES.name]);
-  const { namespace, cdPipeline } = routeStageCreate.useParams();
+  const { namespace, cdPipeline } = useSafeStageCreateParams();
 
   const { clusterName } = useClusterStore(
     useShallow((state) => ({

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/components/WizardNavigation/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/components/WizardNavigation/index.tsx
@@ -5,11 +5,11 @@ import { Link, LinkProps } from "@tanstack/react-router";
 import { ArrowLeft, ArrowRight, Rocket } from "lucide-react";
 import React from "react";
 import { useShallow } from "zustand/react/shallow";
-import { routeStageCreate } from "../../../../route";
 import { CREATE_FORM_PARTS } from "../../names";
 import { NAVIGABLE_STEP_IDXS, useWizardStore } from "../../store";
 import { routeCDPipelineDetails } from "@/modules/platform/cdpipelines/pages/details/route";
 import { useCreateStageForm } from "../../providers/form/hooks";
+import { useSafeStageCreateParams } from "../../hooks/useSafeStageCreateParams";
 
 interface WizardNavigationProps {
   onBack: () => void;
@@ -25,7 +25,7 @@ export const WizardNavigation: React.FC<WizardNavigationProps> = ({
   backRoute,
 }) => {
   const clusterName = useClusterStore(useShallow((state) => state.clusterName));
-  const { namespace, cdPipeline } = routeStageCreate.useParams();
+  const { namespace, cdPipeline } = useSafeStageCreateParams();
   const form = useCreateStageForm();
 
   const { currentStepIdx, getCurrentFormPart } = useWizardStore(
@@ -61,7 +61,6 @@ export const WizardNavigation: React.FC<WizardNavigationProps> = ({
           }
         }
 
-        // Only proceed if no errors in current step
         if (!hasStepErrors) {
           onNext();
         }
@@ -69,7 +68,6 @@ export const WizardNavigation: React.FC<WizardNavigationProps> = ({
         onNext();
       }
     } else {
-      // For steps without form fields (like REVIEW), just proceed
       onNext();
     }
   }, [currentFormPart, onNext, form]);

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/hooks/useDefaultValues.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/hooks/useDefaultValues.ts
@@ -10,12 +10,13 @@ import {
   stageTriggerType,
   stageQualityGateType,
   triggerTemplateLabels,
+  type TriggerTemplate,
 } from "@my-project/shared";
 import React from "react";
 import { useShallow } from "zustand/react/shallow";
 import { v4 as uuidv4 } from "uuid";
 import { NAMES } from "../names";
-import { routeStageCreate } from "../../../route";
+import { useSafeStageCreateParams } from "./useSafeStageCreateParams";
 
 const defaultQualityGate = {
   id: uuidv4(),
@@ -25,15 +26,13 @@ const defaultQualityGate = {
   branchName: null,
 };
 
-export const useDefaultValues = () => {
-  // Safely get route params - fallback to empty object if route is not active (e.g., in Storybook)
-  let routeParams: { namespace?: string; cdPipeline?: string } = {};
-  try {
-    routeParams = routeStageCreate.useParams();
-  } catch {
-    // Route not active - use empty params
-  }
-  const { namespace, cdPipeline: cdPipelineName } = routeParams;
+interface UseDefaultValuesParams {
+  triggerTemplateList: TriggerTemplate[];
+  stagesQuantity: number;
+}
+
+export const useDefaultValues = ({ triggerTemplateList, stagesQuantity }: UseDefaultValuesParams) => {
+  const { namespace, cdPipeline: cdPipelineName } = useSafeStageCreateParams();
 
   const { defaultNamespace } = useClusterStore(
     useShallow((state) => ({
@@ -42,21 +41,6 @@ export const useDefaultValues = () => {
   );
 
   const effectiveNamespace = namespace || defaultNamespace;
-
-  const stagesWatch = useStageWatchList({
-    namespace: effectiveNamespace,
-    labels: {
-      [stageLabels.cdPipeline]: cdPipelineName ?? "",
-    },
-    queryOptions: {
-      enabled: !!cdPipelineName && !!effectiveNamespace,
-    },
-  });
-
-  const stagesQuantity = stagesWatch.data.array.length;
-
-  const triggerTemplateListWatch = useTriggerTemplateWatchList();
-  const triggerTemplateList = triggerTemplateListWatch.data.array;
 
   const deployTriggerTemplate = triggerTemplateList.find(
     (el) => el.metadata.labels?.[triggerTemplateLabels.pipelineType] === pipelineType.deploy
@@ -87,14 +71,7 @@ export const useDefaultValues = () => {
 };
 
 export const useCDPipelineData = () => {
-  // Safely get route params - fallback to empty object if route is not active (e.g., in Storybook)
-  let routeParams: { namespace?: string; cdPipeline?: string } = {};
-  try {
-    routeParams = routeStageCreate.useParams();
-  } catch {
-    // Route not active - use empty params
-  }
-  const { namespace, cdPipeline: cdPipelineName } = routeParams;
+  const { namespace, cdPipeline: cdPipelineName } = useSafeStageCreateParams();
 
   const { defaultNamespace } = useClusterStore(
     useShallow((state) => ({
@@ -122,12 +99,20 @@ export const useCDPipelineData = () => {
     },
   });
 
+  const triggerTemplateListWatch = useTriggerTemplateWatchList();
+
   return {
     cdPipeline: cdPipelineWatch.query.data,
     cdPipelineIsLoading: cdPipelineWatch.query.isLoading,
     cdPipelineError: cdPipelineWatch.query.error,
     otherStages: stagesWatch.data.array,
-    otherStagesIsLoading: stagesWatch.query.isLoading,
+    otherStagesIsLoading: stagesWatch.isLoading,
+    // Use the watch wrapper's `isLoading` (isPending || isPlaceholderData), not the raw
+    // query.isLoading. The list query sets placeholderData, so query.isLoading is false on
+    // first render while the real templates are still loading — gating on it lets the form
+    // mount with an empty cleanTemplate default before the templates arrive.
+    triggerTemplatesIsLoading: triggerTemplateListWatch.isLoading,
+    triggerTemplateList: triggerTemplateListWatch.data.array,
     namespace: effectiveNamespace,
   };
 };

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/hooks/useSafeStageCreateParams.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/hooks/useSafeStageCreateParams.ts
@@ -1,0 +1,12 @@
+import { useParams } from "@tanstack/react-router";
+
+// `strict: false` returns the active route's params without throwing when the wizard renders
+// outside its route (e.g. Storybook); the `= ""` defaults then cover that param-less case.
+export const useSafeStageCreateParams = (): { namespace: string; cdPipeline: string } => {
+  const { namespace = "", cdPipeline = "" } = useParams({ strict: false }) as {
+    namespace?: string;
+    cdPipeline?: string;
+  };
+
+  return { namespace, cdPipeline };
+};

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/index.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/index.tsx
@@ -7,7 +7,6 @@ import React from "react";
 import { useShallow } from "zustand/react/shallow";
 import { showToast } from "@/core/components/Snackbar";
 import { useClusterStore } from "@/k8s/store";
-import { routeStageCreate } from "../../route";
 import { routeCDPipelineDetails } from "@/modules/platform/cdpipelines/pages/details/route";
 import { BasicConfiguration } from "./components/BasicConfiguration";
 import { PipelineConfiguration } from "./components/PipelineConfiguration";
@@ -16,14 +15,23 @@ import { Review } from "./components/Review";
 import { Success } from "./components/Success";
 import { WizardStepper } from "./components/WizardStepper";
 import { WizardNavigation } from "./components/WizardNavigation";
-import { useCDPipelineData } from "./hooks/useDefaultValues";
+import { useCDPipelineData, useDefaultValues } from "./hooks/useDefaultValues";
+import { useSafeStageCreateParams } from "./hooks/useSafeStageCreateParams";
 import { CreateStageFormValues } from "./names";
 import { useWizardStore } from "./store";
 import { CreateStageFormProvider } from "./providers/form/provider";
 import { useCreateStageForm } from "./providers/form/hooks";
 
 export const CreateStageWizard: React.FC = () => {
-  const { cdPipelineIsLoading, cdPipelineError, otherStagesIsLoading } = useCDPipelineData();
+  const {
+    cdPipelineIsLoading,
+    cdPipelineError,
+    otherStages,
+    otherStagesIsLoading,
+    triggerTemplatesIsLoading,
+    triggerTemplateList,
+  } = useCDPipelineData();
+  const defaultValues = useDefaultValues({ triggerTemplateList, stagesQuantity: otherStages.length });
   const {
     triggerCreateStage,
     mutations: { stageCreateMutation },
@@ -92,7 +100,7 @@ export const CreateStageWizard: React.FC = () => {
     return <ErrorContent error={cdPipelineError} />;
   }
 
-  if (cdPipelineIsLoading || otherStagesIsLoading) {
+  if (cdPipelineIsLoading || otherStagesIsLoading || triggerTemplatesIsLoading) {
     return (
       <div className="flex h-full items-center justify-center">
         <LoadingWrapper isLoading={true}>
@@ -103,7 +111,7 @@ export const CreateStageWizard: React.FC = () => {
   }
 
   return (
-    <CreateStageFormProvider onSubmit={onSubmit} onSubmitError={onSubmitError}>
+    <CreateStageFormProvider defaultValues={defaultValues} onSubmit={onSubmit} onSubmitError={onSubmitError}>
       <WizardContent isPending={isPending} />
     </CreateStageFormProvider>
   );
@@ -116,7 +124,7 @@ interface WizardContentProps {
 const WizardContent: React.FC<WizardContentProps> = ({ isPending }) => {
   const form = useCreateStageForm();
   const clusterName = useClusterStore(useShallow((state) => state.clusterName));
-  const { namespace, cdPipeline } = routeStageCreate.useParams();
+  const { namespace, cdPipeline } = useSafeStageCreateParams();
 
   const { currentStepIdx, goToNextStep, goToPreviousStep } = useWizardStore(
     useShallow((state) => ({

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/providers/form/context.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/providers/form/context.ts
@@ -1,9 +1,9 @@
 import { useAppForm } from "@/core/components/form";
 import React from "react";
+import type { FormValidateOrFn } from "@tanstack/react-form";
 import { createStageFormSchema, CreateStageFormValues } from "../../names";
 
-// Internal hook to create the form with proper typing
-// This captures the return type for TypeScript inference
+// Never invoked at runtime — exists solely so ReturnType<> below can capture the fully-typed form instance.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function useCreateStageFormInternal(
   defaultValues: CreateStageFormValues,
@@ -13,6 +13,9 @@ function useCreateStageFormInternal(
 ) {
   const form = useAppForm({
     defaultValues,
+    validators: {
+      onChange: createStageFormSchema as unknown as FormValidateOrFn<CreateStageFormValues>,
+    },
     onSubmit: async ({ value, formApi }) => {
       const validationResult = createStageFormSchema.safeParse(value);
 
@@ -32,7 +35,6 @@ function useCreateStageFormInternal(
       }
 
       try {
-        // Apply transformations before submission
         const transformedValue = {
           ...value,
           name: typeof value.name === "string" ? value.name.trim() : value.name,
@@ -47,7 +49,6 @@ function useCreateStageFormInternal(
   return form;
 }
 
-// Export the form instance type - properly inferred from the hook
 export type CreateStageFormInstance = ReturnType<typeof useCreateStageFormInternal>;
 
 export const CreateStageFormContext = React.createContext<CreateStageFormInstance | null>(null);

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/providers/form/provider.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/providers/form/provider.tsx
@@ -1,20 +1,25 @@
 import { useAppForm } from "@/core/components/form";
 import React from "react";
+import type { FormValidateOrFn } from "@tanstack/react-form";
 import { CreateStageFormContext } from "./context";
 import type { CreateStageFormProviderProps } from "./types";
 import { createStageFormSchema, CreateStageFormValues } from "../../names";
-import { useDefaultValues } from "../../hooks/useDefaultValues";
 
 export const CreateStageFormProvider: React.FC<CreateStageFormProviderProps> = ({
   children,
+  defaultValues,
   onSubmit,
   onSubmitError,
   onSubmitInvalid,
 }) => {
-  const baseDefaultValues = useDefaultValues();
-
   const form = useAppForm({
-    defaultValues: baseDefaultValues as CreateStageFormValues,
+    defaultValues,
+    validators: {
+      // Only validate on change - not on mount. Drives the per-step gate in WizardNavigation
+      // (form.validate("change")) so an invalid step (e.g. an unselected Clean Pipeline
+      // template) blocks "Continue" instead of failing silently at submit.
+      onChange: createStageFormSchema as unknown as FormValidateOrFn<CreateStageFormValues>,
+    },
     onSubmit: async ({ value, formApi }) => {
       const validationResult = createStageFormSchema.safeParse(value);
 

--- a/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/providers/form/types.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stages/create/components/CreateStageWizard/providers/form/types.ts
@@ -3,6 +3,7 @@ import { CreateStageFormValues } from "../../names";
 
 export interface CreateStageFormProviderProps {
   children: ReactNode;
+  defaultValues: CreateStageFormValues;
   onSubmit: (values: CreateStageFormValues) => Promise<void> | void;
   onSubmitError: (error: unknown) => void;
   onSubmitInvalid?: (errors: unknown) => void;


### PR DESCRIPTION
The Create New Environment (Stage) wizard silently failed to create the environment and showed no error when the Clean Pipeline template was left unselected.

- Gate the wizard on the trigger-template watch's loaded state so the Clean Pipeline template default is populated before the form initializes (the list query's placeholder data made the previous gate open too early).
- Add a form-level onChange validator so the per-step "Continue" gate surfaces a validation error and blocks an invalid step instead of failing silently at submit.
- Read stage-create route params via useParams({ strict: false }) so the wizard renders outside its route (e.g. Storybook) without throwing, and seed the story's trigger-template cache accordingly.

