### PR TITLE
EPMDEDP-17137: fix: prevent intermittent "Not Found" on Overview and namespace-scoped pages

### DIFF
--- a/apps/client/src/core/components/NotFound/NotFound.stories.tsx
+++ b/apps/client/src/core/components/NotFound/NotFound.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withAppProviders } from "@sb/index";
+import NotFound from "./index";
+
+const meta = {
+  title: "Core/Components/NotFound",
+  component: NotFound,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [withAppProviders()],
+} satisfies Meta<typeof NotFound>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/client/src/core/components/NotFound/index.tsx
+++ b/apps/client/src/core/components/NotFound/index.tsx
@@ -1,5 +1,46 @@
+import { Link, useRouter, useRouterState } from "@tanstack/react-router";
+import { ArrowLeft, Compass, Home } from "lucide-react";
+import { Button } from "@/core/components/ui/button";
+import { Badge } from "@/core/components/ui/badge";
+
 function NotFound() {
-  return <div>not found</div>;
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const router = useRouter();
+
+  return (
+    <div className="flex min-h-[60vh] w-full flex-col items-center justify-center gap-6 p-8 text-center">
+      <div className="bg-muted flex h-20 w-20 items-center justify-center rounded-full">
+        <Compass className="text-muted-foreground h-10 w-10" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h1 className="text-foreground text-3xl font-bold">Page not found</h1>
+        <p className="text-muted-foreground mx-auto max-w-sm text-sm">
+          There&apos;s nothing at this address. The page may have moved, or the link is incomplete.
+        </p>
+      </div>
+
+      <Badge variant="neutral" className="font-mono">
+        404 &middot; {pathname}
+      </Badge>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+        <Button asChild>
+          <Link to="/home">
+            <Home className="h-4 w-4" />
+            Back to home
+          </Link>
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => (router.history.canGoBack() ? router.history.back() : router.navigate({ to: "/home" }))}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Go back
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export default NotFound;

--- a/apps/client/src/core/providers/Config/provider.test.tsx
+++ b/apps/client/src/core/providers/Config/provider.test.tsx
@@ -22,6 +22,7 @@ const {
   const mockClusterStore = {
     clusterName: null as string | null,
     clusterNameResolved: true,
+    defaultNamespace: "" as string,
     setClusterName: mockSetClusterName,
     setDefaultNamespace: mockSetDefaultNamespace,
     setAllowedNamespaces: mockSetAllowedNamespaces,
@@ -89,7 +90,7 @@ describe("ConfigProvider", () => {
     vi.clearAllMocks();
     mockClusterStore.clusterName = null;
     mockClusterStore.clusterNameResolved = true;
-    localStorage.clear();
+    mockClusterStore.defaultNamespace = "";
   });
 
   afterEach(() => {
@@ -150,7 +151,7 @@ describe("ConfigProvider", () => {
       await waitFor(() => {
         expect(mockSetClusterName).toHaveBeenCalledWith("test-cluster");
         expect(mockSetDefaultNamespace).toHaveBeenCalledWith("default");
-        expect(mockSetAllowedNamespaces).toHaveBeenCalledWith(["default"]);
+        expect(mockSetAllowedNamespaces).not.toHaveBeenCalled();
         expect(mockSetSonarWebUrl).toHaveBeenCalledWith("https://sonar.example.com");
         expect(mockSetDependencyTrackWebUrl).toHaveBeenCalledWith("https://dependency-track.example.com");
       });
@@ -177,14 +178,9 @@ describe("ConfigProvider", () => {
       });
     });
 
-    it("should preserve custom namespace settings from localStorage", async () => {
-      const customSettings = {
-        "test-cluster": {
-          defaultNamespace: "custom-namespace",
-          allowedNamespaces: ["custom-namespace", "other"],
-        },
-      };
-      localStorage.setItem("cluster_settings", JSON.stringify(customSettings));
+    it("should not override a default namespace already resolved in the store", async () => {
+      // Must not clobber a user-chosen namespace (e.g. via "Manage Namespaces") with the server default.
+      mockClusterStore.defaultNamespace = "custom-namespace";
 
       mockTrpcClient.config.get.query.mockResolvedValue({
         clusterName: "test-cluster",
@@ -200,9 +196,58 @@ describe("ConfigProvider", () => {
       );
 
       await waitFor(() => {
-        expect(mockSetDefaultNamespace).not.toHaveBeenCalled();
-        expect(mockSetAllowedNamespaces).not.toHaveBeenCalled();
+        expect(mockSetClusterName).toHaveBeenCalledWith("test-cluster");
       });
+      expect(mockSetDefaultNamespace).not.toHaveBeenCalled();
+      expect(mockSetAllowedNamespaces).not.toHaveBeenCalled();
+    });
+
+    it("should adopt the server default namespace when the store has none (stale cluster_settings)", async () => {
+      // Regression: a stale cluster_settings entry (persisted before the server had a namespace)
+      // leaves defaultNamespace empty; the provider must still reconcile it from server config.
+      mockClusterStore.clusterName = "test-cluster";
+      mockClusterStore.defaultNamespace = "";
+
+      mockTrpcClient.config.get.query.mockResolvedValue({
+        clusterName: "test-cluster",
+        defaultNamespace: "c4jerry4",
+        sonarWebUrl: "https://sonar.example.com",
+        dependencyTrackWebUrl: "https://dependency-track.example.com",
+      });
+
+      renderWithProviders(
+        <ConfigProvider>
+          <div />
+        </ConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(mockSetDefaultNamespace).toHaveBeenCalledWith("c4jerry4");
+      });
+    });
+
+    it("should not persist an empty namespace when the server provides none", async () => {
+      // An unset DEFAULT_CLUSTER_NAMESPACE must not make the client seed an empty namespace —
+      // that used to poison cluster_settings and keep the client broken after the server was fixed.
+      mockClusterStore.defaultNamespace = "";
+
+      mockTrpcClient.config.get.query.mockResolvedValue({
+        clusterName: "test-cluster",
+        defaultNamespace: "",
+        sonarWebUrl: "",
+        dependencyTrackWebUrl: "",
+      });
+
+      renderWithProviders(
+        <ConfigProvider>
+          <div />
+        </ConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(mockSetClusterName).toHaveBeenCalledWith("test-cluster");
+      });
+      expect(mockSetDefaultNamespace).not.toHaveBeenCalled();
     });
 
     it("should always update security tool URLs from server config", async () => {

--- a/apps/client/src/core/providers/Config/provider.tsx
+++ b/apps/client/src/core/providers/Config/provider.tsx
@@ -12,7 +12,6 @@ export const ConfigProvider = ({ children }: React.PropsWithChildren) => {
   const clusterNameResolved = useClusterStore((state) => state.clusterNameResolved);
   const setClusterName = useClusterStore((state) => state.setClusterName);
   const setDefaultNamespace = useClusterStore((state) => state.setDefaultNamespace);
-  const setAllowedNamespaces = useClusterStore((state) => state.setAllowedNamespaces);
   const setSonarWebUrl = useClusterStore((state) => state.setSonarWebUrl);
   const setDependencyTrackWebUrl = useClusterStore((state) => state.setDependencyTrackWebUrl);
 
@@ -25,31 +24,27 @@ export const ConfigProvider = ({ children }: React.PropsWithChildren) => {
   });
 
   useEffect(() => {
-    if (configQuery.data) {
-      const { clusterName: serverClusterName, defaultNamespace, sonarWebUrl, dependencyTrackWebUrl } = configQuery.data;
-
-      if (!clusterName) {
-        setClusterName(serverClusterName);
-
-        const settings = localStorage.getItem("cluster_settings");
-        if (!settings || !JSON.parse(settings)[serverClusterName]) {
-          setDefaultNamespace(defaultNamespace);
-          setAllowedNamespaces([defaultNamespace]);
-        }
-      }
-
-      setSonarWebUrl(sonarWebUrl);
-      setDependencyTrackWebUrl(dependencyTrackWebUrl);
+    if (!configQuery.data) {
+      return;
     }
-  }, [
-    configQuery.data,
-    clusterName,
-    setClusterName,
-    setDefaultNamespace,
-    setAllowedNamespaces,
-    setSonarWebUrl,
-    setDependencyTrackWebUrl,
-  ]);
+
+    const { clusterName: serverClusterName, defaultNamespace, sonarWebUrl, dependencyTrackWebUrl } = configQuery.data;
+
+    if (!clusterName) {
+      setClusterName(serverClusterName);
+    }
+
+    // Reconcile AFTER setClusterName: that call synchronously hydrates defaultNamespace from
+    // persisted cluster_settings, so a user-chosen namespace loads first and the guard preserves
+    // it. Adopt the server default only when the store is still empty (e.g. a stale entry
+    // persisted before the server had a namespace). setDefaultNamespace also repairs allowedNamespaces.
+    if (defaultNamespace && !useClusterStore.getState().defaultNamespace) {
+      setDefaultNamespace(defaultNamespace);
+    }
+
+    setSonarWebUrl(sonarWebUrl);
+    setDependencyTrackWebUrl(dependencyTrackWebUrl);
+  }, [configQuery.data, clusterName, setClusterName, setDefaultNamespace, setSonarWebUrl, setDependencyTrackWebUrl]);
 
   if (configQuery.isLoading && !configQuery.isError) {
     return <LoadingProgressBar />;

--- a/apps/client/src/core/router/index.ts
+++ b/apps/client/src/core/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter } from "@tanstack/react-router";
 import { LoadingProgressBar } from "../components/ui/LoadingProgressBar";
 import { RouterErrorComponent } from "./components/RouterErrorComponent";
+import NotFound from "../components/NotFound";
 import { routeHome } from "../../modules/home/pages/home/route";
 import { routeProjectList } from "../../modules/platform/codebases/pages/list/route";
 import { routeProjectCreate } from "../../modules/platform/codebases/pages/create/route";
@@ -222,6 +223,7 @@ export const router = createRouter({
   defaultPreloadStaleTime: 0,
   defaultPendingComponent: LoadingProgressBar,
   defaultErrorComponent: RouterErrorComponent,
+  defaultNotFoundComponent: NotFound,
   context: {
     queryClient: undefined!,
   },


### PR DESCRIPTION
The portal could render a "Not Found" instead of the Overview and other namespace-scoped sections (pipeline metrics, SCA/SAST) when the cluster's default namespace was missing from client state, leaving those routes without a required namespace segment.

- Reconcile the default namespace from server config whenever client state has none, so a stale or empty cached value no longer breaks navigation; a user-selected namespace is kept.
- Render a portal-styled page for unmatched routes instead of the bare browser fallback.

