### PR TITLE
EPMDEDP-17138: fix: derive OIDC identity from ID Token to fix Entra ID member login

### DIFF
--- a/packages/trpc/src/clients/oidc/index.test.ts
+++ b/packages/trpc/src/clients/oidc/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TRPCError } from "@trpc/server";
 import { OIDCClient } from "./index.js";
 import type { Configuration } from "openid-client";
@@ -16,10 +16,11 @@ vi.mock("jose", async () => {
   };
 });
 
-// Mock openid-client (fetchProtectedResource, authorizationCodeGrant, refreshTokenGrant)
+// Mock openid-client (fetchProtectedResource, authorizationCodeGrant, refreshTokenGrant, fetchUserInfo)
 const mockFetchProtectedResource = vi.fn();
 const mockAuthorizationCodeGrant = vi.fn();
 const mockRefreshTokenGrant = vi.fn();
+const mockFetchUserInfoLib = vi.fn();
 vi.mock("openid-client", async () => {
   const actual = await vi.importActual("openid-client");
   return {
@@ -27,6 +28,7 @@ vi.mock("openid-client", async () => {
     fetchProtectedResource: (...args: any[]) => mockFetchProtectedResource(...args),
     authorizationCodeGrant: (...args: any[]) => mockAuthorizationCodeGrant(...args),
     refreshTokenGrant: (...args: any[]) => mockRefreshTokenGrant(...args),
+    fetchUserInfo: (...args: any[]) => mockFetchUserInfoLib(...args),
   };
 });
 
@@ -156,6 +158,19 @@ describe("OIDCClient", () => {
       expect(result).toEqual(mockUserInfo);
     });
 
+    it("should throw an actionable UNAUTHORIZED when the userinfo response is missing email", async () => {
+      const oidcConfig = createMockOIDCConfig();
+      mockFetchProtectedResource.mockResolvedValue(mockResponse({ sub: "user-123", name: "No Email User" }));
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(client.validateTokenAndGetUserInfo(oidcConfig, OPAQUE_TOKEN)).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+        message: expect.stringContaining("does not have an email address"),
+      });
+
+      errorSpy.mockRestore();
+    });
+
     it("should use userinfo when metadata has no jwks_uri", async () => {
       const oidcConfig = createMockOIDCConfig({ jwks_uri: undefined });
       mockFetchProtectedResource.mockResolvedValue(mockResponse(mockUserInfo));
@@ -242,6 +257,111 @@ describe("OIDCClient", () => {
 
       // createRemoteJWKSet should only be called once (cached)
       expect(mockCreateRemoteJWKSet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("resolveUserFromTokenResponse", () => {
+    const oidcConfig = createMockOIDCConfig();
+
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    function makeTokens(
+      claims: Record<string, unknown> | undefined,
+      access_token: string | undefined = "access-token"
+    ): any {
+      return { access_token, token_type: "bearer", claims: () => claims };
+    }
+
+    it("uses ID Token claims and skips UserInfo when the ID Token is sufficient", async () => {
+      const tokens = makeTokens({ sub: "user-123", email: "user@example.com", name: "Test User" });
+
+      const result = await client.resolveUserFromTokenResponse(oidcConfig, tokens);
+
+      expect(result).toMatchObject({ sub: "user-123", email: "user@example.com", name: "Test User" });
+      expect(mockFetchUserInfoLib).not.toHaveBeenCalled();
+    });
+
+    it("supplements with UserInfo when the ID Token lacks a required claim (e.g. Keycloak emits email there)", async () => {
+      const tokens = makeTokens({ sub: "user-123", name: "Test User" });
+      mockFetchUserInfoLib.mockResolvedValue({ sub: "user-123", email: "user@example.com" });
+
+      const result = await client.resolveUserFromTokenResponse(oidcConfig, tokens);
+
+      expect(result).toMatchObject({ sub: "user-123", email: "user@example.com", name: "Test User" });
+      expect(mockFetchUserInfoLib).toHaveBeenCalledWith(oidcConfig, "access-token", "user-123");
+    });
+
+    it("keeps ID Token claims authoritative over UserInfo on conflict", async () => {
+      const tokens = makeTokens({ sub: "user-123", name: "From ID Token" });
+      mockFetchUserInfoLib.mockResolvedValue({ sub: "user-123", email: "user@example.com", name: "From UserInfo" });
+
+      const result = await client.resolveUserFromTokenResponse(oidcConfig, tokens);
+
+      expect(result.name).toBe("From ID Token");
+      expect(result.email).toBe("user@example.com");
+    });
+
+    it("throws an actionable UNAUTHORIZED when email is absent and UserInfo is unavailable", async () => {
+      const tokens = makeTokens({ sub: "user-123", name: "Test User" });
+      mockFetchUserInfoLib.mockRejectedValue(new Error("userinfo 500"));
+
+      await expect(client.resolveUserFromTokenResponse(oidcConfig, tokens)).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+        message: expect.stringContaining("does not have an email address"),
+      });
+    });
+
+    it("throws an actionable UNAUTHORIZED when neither the ID Token nor UserInfo provides email", async () => {
+      const tokens = makeTokens({ sub: "user-123", name: "Test User" });
+      mockFetchUserInfoLib.mockResolvedValue({ sub: "user-123", name: "Test User" });
+
+      await expect(client.resolveUserFromTokenResponse(oidcConfig, tokens)).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+        message: expect.stringContaining("does not have an email address"),
+      });
+    });
+
+    it("normalizes groups from ID Token claims", async () => {
+      const tokens = makeTokens({
+        sub: "user-123",
+        email: "user@example.com",
+        name: "Test User",
+        groups: ['["admin","users"]'],
+      });
+
+      const result = await client.resolveUserFromTokenResponse(oidcConfig, tokens);
+
+      expect(result.groups).toEqual(["admin", "users"]);
+    });
+
+    it("falls back to the UserInfo endpoint when there is no ID Token (non-openid flow)", async () => {
+      const tokens = makeTokens(undefined);
+      mockFetchProtectedResource.mockResolvedValue(mockResponse(mockUserInfo));
+
+      const result = await client.resolveUserFromTokenResponse(oidcConfig, tokens);
+
+      expect(result).toMatchObject(mockUserInfo);
+      expect(mockFetchProtectedResource).toHaveBeenCalled();
+    });
+
+    it("throws UNAUTHORIZED when neither an ID Token nor an access token is returned", async () => {
+      const tokens = { token_type: "bearer", claims: () => undefined } as any;
+
+      await expect(client.resolveUserFromTokenResponse(oidcConfig, tokens)).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+        message: expect.stringContaining("neither an ID Token nor an access token"),
+      });
     });
   });
 

--- a/packages/trpc/src/clients/oidc/index.ts
+++ b/packages/trpc/src/clients/oidc/index.ts
@@ -1,12 +1,14 @@
 import {
   Configuration,
   TokenEndpointResponse,
+  TokenEndpointResponseHelpers,
   allowInsecureRequests,
   authorizationCodeGrant,
   buildAuthorizationUrl,
   calculatePKCECodeChallenge,
   discovery,
   fetchProtectedResource,
+  fetchUserInfo as fetchOIDCUserInfo,
   randomPKCECodeVerifier,
   randomState,
   refreshTokenGrant,
@@ -137,7 +139,7 @@ export class OIDCClient {
     url: URL,
     codeVerifier: string,
     expectedState: string
-  ): Promise<TokenEndpointResponse> {
+  ): Promise<TokenEndpointResponse & TokenEndpointResponseHelpers> {
     return authorizationCodeGrant(oidcConfig, url, {
       pkceCodeVerifier: codeVerifier,
       expectedState,
@@ -305,6 +307,49 @@ export class OIDCClient {
     }
   }
 
+  /**
+   * Resolves the user identity for the authorization-code flow: ID Token first
+   * (already validated by authorizationCodeGrant), then UserInfo as a best-effort,
+   * subject-matched (OIDC Core §5.3.2) supplement, merged ID-Token-authoritative.
+   * Captures email whether the IdP emits it in the ID Token (Entra ID optional
+   * claim) or only via UserInfo (Keycloak).
+   */
+  async resolveUserFromTokenResponse(
+    oidcConfig: Configuration,
+    tokens: TokenEndpointResponse & TokenEndpointResponseHelpers
+  ): Promise<OIDCUser> {
+    const idTokenClaims = tokens.claims() as Record<string, unknown> | undefined;
+
+    if (!idTokenClaims) {
+      if (!tokens.access_token) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "Sign-in failed: the identity provider returned neither an ID Token nor an access token.",
+        });
+      }
+      return this.fetchUserInfoOrThrow(oidcConfig, tokens.access_token);
+    }
+
+    const fromIdToken = OIDCUserSchema.safeParse(idTokenClaims);
+    if (fromIdToken.success) {
+      return normalizeUserGroups(fromIdToken.data);
+    }
+
+    let userInfoClaims: Record<string, unknown> | undefined;
+    const subject = typeof idTokenClaims.sub === "string" ? idTokenClaims.sub : undefined;
+    if (tokens.access_token && subject) {
+      try {
+        userInfoClaims = (await fetchOIDCUserInfo(oidcConfig, tokens.access_token, subject)) as Record<string, unknown>;
+      } catch (err) {
+        console.warn("[OIDC] UserInfo supplement skipped; proceeding with ID Token claims", err);
+      }
+    }
+
+    const mergedClaims = userInfoClaims ? { ...userInfoClaims, ...idTokenClaims } : idTokenClaims;
+
+    return this.parseOIDCUserOrThrow(mergedClaims);
+  }
+
   async fetchUserInfo(oidcConfig: Configuration, accessToken: string): Promise<OIDCUser> {
     const userinfoEndpoint = oidcConfig.serverMetadata().userinfo_endpoint;
 
@@ -338,11 +383,43 @@ export class OIDCClient {
       throw new Error("Invalid response from userinfo endpoint");
     }
 
-    const parsed = OIDCUserSchema.safeParse(raw);
-    if (!parsed.success) {
-      throw new Error("Invalid user info response from userinfo endpoint");
+    return this.parseOIDCUserOrThrow(raw as Record<string, unknown>);
+  }
+
+  /**
+   * Validates raw identity claims against {@link OIDCUserSchema}, returning a
+   * normalized {@link OIDCUser}. On failure, throws an actionable TRPCError that
+   * names the missing claim(s) — most often `email`, which Entra ID omits for
+   * member accounts without a mailbox.
+   */
+  private parseOIDCUserOrThrow(claims: Record<string, unknown>): OIDCUser {
+    const parsed = OIDCUserSchema.safeParse(claims);
+    if (parsed.success) {
+      return normalizeUserGroups(parsed.data);
     }
-    return normalizeUserGroups(parsed.data);
+
+    const failedClaims = [...new Set(parsed.error.issues.map((issue) => String(issue.path[0] ?? "")).filter(Boolean))];
+
+    console.error("[OIDC] Identity claims failed validation", {
+      failedClaims,
+      availableClaims: Object.keys(claims),
+      issues: parsed.error.issues,
+    });
+
+    if (failedClaims.includes("email")) {
+      throw new TRPCError({
+        code: "UNAUTHORIZED",
+        message:
+          "Your account does not have an email address, which is required to sign in. " +
+          "Please ask your administrator to add an email address to your account.",
+      });
+    }
+
+    const claimList = failedClaims.length ? ` (${failedClaims.join(", ")})` : "";
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: `Sign-in failed: the identity provider did not return the required profile information${claimList}.`,
+    });
   }
 
   buildEndSessionUrl(
@@ -440,6 +517,8 @@ export class OIDCClient {
     try {
       return await this.fetchUserInfo(oidcConfig, token);
     } catch (error) {
+      // Surface actionable errors (e.g. missing email) instead of masking them.
+      if (error instanceof TRPCError) throw error;
       const errorMessage = (error as Error)?.message || "Unknown error";
       throw new TRPCError({
         code: "UNAUTHORIZED",

--- a/packages/trpc/src/routers/auth/procedures/loginCallback/index.test.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginCallback/index.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockDiscover = vi.fn();
 const mockExchangeCodeForTokens = vi.fn();
 const mockNormalizeTokenResponse = vi.fn();
-const mockFetchUserInfo = vi.fn();
+const mockResolveUser = vi.fn();
 
 vi.mock("../../../../clients/oidc/index.js", () => ({
   OIDCClient: vi.fn(function () {
@@ -14,7 +14,7 @@ vi.mock("../../../../clients/oidc/index.js", () => ({
       discoverOrThrow: mockDiscover,
       exchangeCodeForTokens: mockExchangeCodeForTokens,
       normalizeTokenResponse: mockNormalizeTokenResponse,
-      fetchUserInfoOrThrow: mockFetchUserInfo,
+      resolveUserFromTokenResponse: mockResolveUser,
     };
   }),
 }));
@@ -54,9 +54,9 @@ describe("authLoginCallbackProcedure", () => {
       clientSearch: "?redirect=/pipelines",
     };
     mockDiscover.mockResolvedValue({});
-    mockExchangeCodeForTokens.mockResolvedValue({ access_token: "access-token" });
+    mockExchangeCodeForTokens.mockResolvedValue({ access_token: "access-token", claims: () => mockUserInfo });
     mockNormalizeTokenResponse.mockReturnValue(mockNormalizedTokens);
-    mockFetchUserInfo.mockResolvedValue(mockUserInfo);
+    mockResolveUser.mockResolvedValue(mockUserInfo);
   });
 
   afterEach(() => {
@@ -82,7 +82,7 @@ describe("authLoginCallbackProcedure", () => {
     });
     expect(mockContext.session.login).toBeUndefined();
     expect(mockExchangeCodeForTokens).toHaveBeenCalled();
-    expect(mockFetchUserInfo).toHaveBeenCalled();
+    expect(mockResolveUser).toHaveBeenCalled();
   });
 
   it("should reject callback URL with wrong origin", async () => {

--- a/packages/trpc/src/routers/auth/procedures/loginCallback/index.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginCallback/index.ts
@@ -38,7 +38,7 @@ export const authLoginCallbackProcedure = publicProcedure
 
     const normalizedTokens = oidcClient.normalizeTokenResponse(tokens);
 
-    const userInfo = await oidcClient.fetchUserInfoOrThrow(config, tokens.access_token);
+    const userInfo = await oidcClient.resolveUserFromTokenResponse(config, tokens);
 
     ctx.session.user = {
       data: userInfo,


### PR DESCRIPTION
# Pull Request

## Description

Azure Entra ID **member** accounts could not sign in via SSO — `auth.loginCallback` returned `401 "Invalid user info response from userinfo endpoint"`. Identity was derived **solely from the OIDC UserInfo endpoint**; on Entra v1.0 (`sts.windows.net`) the `email` claim is emitted by default only for guests, while for members it comes from the configured `email` optional claim, which lands in the **ID Token** — not the legacy v1.0 UserInfo response. `OIDCUserSchema` requires `email`, so member logins were rejected (guests and Keycloak were unaffected).

This change resolves identity **ID-Token-first** (already validated by `authorizationCodeGrant`: signature / issuer / audience), supplements best-effort with UserInfo (subject-matched per OIDC Core §5.3.2), merges with the ID Token authoritative, then validates. `email` is kept required (source of truth); the cryptic error is replaced with an actionable message when it is genuinely absent. The approach is provider-agnostic (Keycloak / Entra ID / Okta).

Jira: [EPMDEDP-17138](https://jiraeu.epam.com/browse/EPMDEDP-17138)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

Full `packages/trpc` test suite passes (**725 tests**), including new `resolveUserFromTokenResponse` cases (ID-Token fast path, UserInfo supplement with §5.3.2 subject match, merge precedence, and the actionable missing-email error). `tsc` is clean, Prettier is clean, and a security review found no issues.

Manual end-to-end login with a real Entra ID member account is pending in a live environment. Operational follow-up (handled separately): confirm member accounts have `mail`/`proxyAddresses` populated, and verify the cluster `--oidc-username-claim`.

**Test Configuration**:

- Node.js version: v22.23.0
- pnpm version: 11.5.1
- Browser (for frontend changes): N/A (server-side only)
- Kubernetes version (if applicable): N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code (ran `/code-review`, `/simplify`, and `/security-review`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — not required for this change
- [x] My changes generate no new warnings (`tsc` clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules — N/A
- [x] I have squashed my commits (single commit)
- [ ] I have run `pnpm lint` and fixed any issues — N/A: `packages/trpc` has no ESLint config (only `apps/*` are linted); validated with `tsc` + Prettier instead
- [x] I have run `pnpm format:check` and code is properly formatted
- [x] I have run `pnpm test:coverage` and maintained adequate test coverage
