### PR TITLE
EPMDEDP-17136: feat: add optional HTTPRoute (Envoy Gateway) support t…

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -1,6 +1,9 @@
 # krci-portal
 
-![Version: 0.6.0-SNAPSHOT](https://img.shields.io/badge/Version-0.6.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-0.6.0--SNAPSHOT-informational?style=flat-square)
+
+
+
+![Version: 0.6.0-SNAPSHOT](https://img.shields.io/badge/Version-0.6.0--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0-SNAPSHOT](https://img.shields.io/badge/AppVersion-0.6.0--SNAPSHOT-informational?style=flat-square) 
 
 A Helm chart for KubeRocketCI Portal
 
@@ -16,6 +19,8 @@ A Helm chart for KubeRocketCI Portal
 ## Source Code
 
 * <https://github.com/KubeRocketCI/krci-portal>
+
+
 
 ## Values
 
@@ -55,6 +60,13 @@ A Helm chart for KubeRocketCI Portal
 | eso.vault.role | string | `"krci-portal"` | Vault role for the Kubernetes authentication method. |
 | eso.vault.server | string | `"http://vault.vault:8200"` | Vault server URL. |
 | fullnameOverride | string | `"krci-portal"` | Override the full name of the chart |
+| httproute | object | `{"annotations":{},"dnsWildcard":"","enabled":false,"hostnames":["edpDefault"],"matches":[{"path":{"type":"PathPrefix","value":"/"}}],"parentRefs":[{"name":"main-gateway","namespace":"envoy-gateway-system"}]}` | HTTPRoute (Gateway API / Envoy Gateway) configuration. Alternative to `ingress` for clusters migrating from nginx-ingress to Envoy Gateway. When enabled, an HTTPRoute is created and attached to the referenced Gateway instead of relying on a nginx Ingress. Disabled by default. |
+| httproute.annotations | object | `{}` | Annotations to add to the HTTPRoute |
+| httproute.dnsWildcard | string | `""` | DNS wildcard for the cluster (typically the same value as ingress.dnsWildcard) |
+| httproute.enabled | bool | `false` | Enable HTTPRoute (Gateway API) resource |
+| httproute.hostnames | list | `["edpDefault"]` | Hostnames for the route. 'edpDefault' renders <fullname>-<namespace>.<dnsWildcard> |
+| httproute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the route rule |
+| httproute.parentRefs | list | `[{"name":"main-gateway","namespace":"envoy-gateway-system"}]` | Parent Gateways the route attaches to (name + namespace of the Envoy Gateway) |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"epamedp/krci-portal","tag":""}` | Image configuration |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"epamedp/krci-portal"` | Image repository |

--- a/deploy-templates/templates/httproute.yaml
+++ b/deploy-templates/templates/httproute.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "krci-portal.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "krci-portal.labels" . | nindent 4 }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httproute.parentRefs | nindent 4 }}
+  hostnames:
+    {{- range .Values.httproute.hostnames }}
+    # if hostname = edpDefault then use {{ $fullName }}-<namespace>.<dnsWildcard>, otherwise the literal value
+    {{- if eq . "edpDefault" }}
+    - {{ $fullName }}-{{ $.Release.Namespace }}.{{ $.Values.httproute.dnsWildcard }}
+    {{- else }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.httproute.matches | nindent 8 }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+{{- end }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -127,6 +127,30 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- HTTPRoute (Gateway API / Envoy Gateway) configuration.
+# Alternative to `ingress` for clusters migrating from nginx-ingress to Envoy Gateway.
+# When enabled, an HTTPRoute is created and attached to the referenced Gateway instead
+# of relying on a nginx Ingress. Disabled by default.
+httproute:
+  # -- Enable HTTPRoute (Gateway API) resource
+  enabled: false
+  # -- DNS wildcard for the cluster (typically the same value as ingress.dnsWildcard)
+  dnsWildcard: ""
+  # -- Annotations to add to the HTTPRoute
+  annotations: {}
+  # -- Parent Gateways the route attaches to (name + namespace of the Envoy Gateway)
+  parentRefs:
+    - name: main-gateway
+      namespace: envoy-gateway-system
+  # -- Hostnames for the route. 'edpDefault' renders <fullname>-<namespace>.<dnsWildcard>
+  hostnames:
+    - edpDefault
+  # -- Path matches for the route rule
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+
 # -- Resource limits and requests
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Description

Adds an optional `HTTPRoute` (Gateway API) template to the krci-portal chart, alongside the existing `Ingress`, gated by a new `httproute.enabled` flag (default `false`).

When enabled, the chart renders an `HTTPRoute` attached to the configured Envoy Gateway (defaults `main-gateway` / `envoy-gateway-system`) with the same host and backend as the Ingress: `<fullname>-<namespace>.<dnsWildcard>` → `krci-portal:<service.port>`.

Part of the nginx-ingress → Envoy Gateway migration. It lets the Portal be served through Envoy Gateway via Helm values only (no hand-written manifests). Default off, so existing installations render no HTTPRoute and stay on Ingress.

Changed:
- `deploy-templates/templates/httproute.yaml` (new)
- `deploy-templates/values.yaml` — new `httproute` block
- `deploy-templates/README.md` — regenerated with `helm-docs`

Enable per environment:

```yaml
httproute:
  enabled: true
  dnsWildcard: <cluster-dns-wildcard>
```

Jira: EPMDEDP-17136

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing

Rendered the chart with the flag enabled:

```bash
helm template krci-portal deploy-templates \
  --namespace edp-delivery-vpi-dev \
  --set httproute.enabled=true \
  --set httproute.dnsWildcard=eks-sandbox.aws.main.edp.projects.epam.com \
  --show-only templates/httproute.yaml
```

Output: `HTTPRoute/krci-portal`, `parentRefs: main-gateway/envoy-gateway-system`, `hostnames: [krci-portal-edp-delivery-vpi-dev.eks-sandbox.aws.main.edp.projects.epam.com]`, `backendRefs: krci-portal:3000`. With the default (`httproute.enabled=false`) nothing is rendered.

**Test Configuration**:

- Kubernetes API: `gateway.networking.k8s.io/v1` (Envoy Gateway)
- Chart-only change — no application/TypeScript code touched

## Checklist

- [x] My code follows the style guidelines of this project (mirrors the existing `ingress.yaml`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`README.md` via `helm-docs`)
- [x] My changes generate no new warnings
- [ ] I have added tests — N/A (Helm template only)
- [ ] Unit tests pass locally — N/A (no application code changed)
- [ ] Any dependent changes merged/published downstream — enabling per-env (GitOps values) and the ingress-ALB routing (infra terraform) are separate changes under the same EPMDEDP-17136
- [x] I have squashed my commits (single commit)
- [ ] `pnpm lint` — N/A (no TS/JS changes)
- [ ] `pnpm format:check` — N/A (no TS/JS changes)
- [ ] `pnpm test:coverage` — N/A (no TS/JS changes)