### PR TITLE
EPMDEDP-17136: feat: add optional HTTPRoute (Envoy Gateway) support to chart

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -55,6 +55,13 @@ A Helm chart for KubeRocketCI Portal
 | eso.vault.role | string | `"krci-portal"` | Vault role for the Kubernetes authentication method. |
 | eso.vault.server | string | `"http://vault.vault:8200"` | Vault server URL. |
 | fullnameOverride | string | `"krci-portal"` | Override the full name of the chart |
+| httproute | object | `{"annotations":{},"dnsWildcard":"","enabled":false,"hostnames":["edpDefault"],"matches":[{"path":{"type":"PathPrefix","value":"/"}}],"parentRefs":[{"name":"main-gateway","namespace":"envoy-gateway-system"}]}` | HTTPRoute (Gateway API / Envoy Gateway) configuration. Alternative to `ingress` for clusters migrating from nginx-ingress to Envoy Gateway. When enabled, an HTTPRoute is created and attached to the referenced Gateway instead of relying on a nginx Ingress. Disabled by default. |
+| httproute.annotations | object | `{}` | Annotations to add to the HTTPRoute |
+| httproute.dnsWildcard | string | `""` | Cluster-wide DNS wildcard domain (e.g. `apps.cluster.example.com`). Used to build the default hostname as `portal-<namespace>.<dnsWildcard>` when `hostnames` contains `edpDefault`. Required when using the `edpDefault` hostname sentinel. |
+| httproute.enabled | bool | `false` | Enable HTTPRoute (Gateway API) resource |
+| httproute.hostnames | list | `["edpDefault"]` | Hostnames for the route. 'edpDefault' renders portal-<namespace>.<dnsWildcard> |
+| httproute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the route rule |
+| httproute.parentRefs | list | `[{"name":"main-gateway","namespace":"envoy-gateway-system"}]` | Parent Gateways the route attaches to (name + namespace of the Envoy Gateway) |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"epamedp/krci-portal","tag":""}` | Image configuration |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"epamedp/krci-portal"` | Image repository |

--- a/deploy-templates/templates/httproute.yaml
+++ b/deploy-templates/templates/httproute.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "krci-portal.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $dnsWildcard := coalesce .Values.httproute.dnsWildcard .Values.ingress.dnsWildcard "" -}}
+{{- if not .Values.httproute.parentRefs -}}
+{{- fail "httproute.parentRefs must contain at least one Gateway reference" -}}
+{{- end -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "krci-portal.labels" . | nindent 4 }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httproute.parentRefs | nindent 4 }}
+  {{- if .Values.httproute.hostnames }}
+  hostnames:
+    {{- range .Values.httproute.hostnames }}
+    {{- /* 'edpDefault' is a sentinel: renders portal-<namespace>.<dnsWildcard>; otherwise the literal hostname is used as-is */ -}}
+    {{- if eq . "edpDefault" }}
+    {{- if not $dnsWildcard }}
+    {{- fail "httproute.dnsWildcard (or ingress.dnsWildcard) must be set when using the 'edpDefault' hostname" }}
+    {{- end }}
+    - portal-{{ $.Release.Namespace }}.{{ $dnsWildcard }}
+    {{- else }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.httproute.matches | nindent 8 }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort | int }}
+{{- end }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -127,6 +127,30 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- HTTPRoute (Gateway API / Envoy Gateway) configuration.
+# Alternative to `ingress` for clusters migrating from nginx-ingress to Envoy Gateway.
+# When enabled, an HTTPRoute is created and attached to the referenced Gateway instead
+# of relying on a nginx Ingress. Disabled by default.
+httproute:
+  # -- Enable HTTPRoute (Gateway API) resource
+  enabled: false
+  # -- Cluster-wide DNS wildcard domain (e.g. `apps.cluster.example.com`). Used to build the default hostname as `portal-<namespace>.<dnsWildcard>` when `hostnames` contains `edpDefault`. Required when using the `edpDefault` hostname sentinel.
+  dnsWildcard: ""
+  # -- Annotations to add to the HTTPRoute
+  annotations: {}
+  # -- Parent Gateways the route attaches to (name + namespace of the Envoy Gateway)
+  parentRefs:
+    - name: main-gateway
+      namespace: envoy-gateway-system
+  # -- Hostnames for the route. 'edpDefault' renders portal-<namespace>.<dnsWildcard>
+  hostnames:
+    - edpDefault
+  # -- Path matches for the route rule
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+
 # -- Resource limits and requests
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Add an optional HTTPRoute (Gateway API) template alongside the existing Ingress, gated by a new httproute.enabled flag (default false). When enabled, the chart renders an HTTPRoute attached to the configured Envoy Gateway (default main-gateway/envoy-gateway-system) with the same host and backend as the Ingress (<fullname>-<namespace>.<dnsWildcard> -> krci-portal:<service port>).

Part of the nginx-ingress -> Envoy Gateway migration; lets the portal be served via Envoy Gateway for validation. Default off, so existing deployments are unaffected.
