### PR TITLE
EPMDEDP-17133: fix: replace NetListener.tlsSecret with structured tlsCertificateRef

### DIFF
--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/components/DetailDrawer.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/components/DetailDrawer.tsx
@@ -110,7 +110,9 @@ export function DetailDrawer({ resource, gateways, policies, onClose }: DetailDr
                       <div className="mb-1 font-medium">
                         {l.name} — {l.protocol}:{l.port}
                         {l.hostname ? ` (${l.hostname})` : ""}
-                        {l.tlsSecret ? ` [Secret: ${l.tlsSecret}]` : ""}
+                        {l.tlsCertificateRef
+                          ? ` [Cert ref: ${l.tlsCertificateRef.kind ? `${l.tlsCertificateRef.kind}/` : ""}${l.tlsCertificateRef.name}]`
+                          : ""}
                       </div>
                       <div className="flex flex-wrap gap-1">
                         {l.conditions.map((c) => (

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/components/GatewayCard.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/components/GatewayCard.tsx
@@ -108,9 +108,11 @@ export function GatewayCard({ gateway, policies, onSelect }: GatewayCardProps) {
                     {listener.hostname ?? "*"}
                   </TableCellUI>
                   <TableCellUI className="px-3 py-2 font-mono text-xs">
-                    {listener.tlsSecret ? (
+                    {listener.tlsCertificateRef ? (
                       <Badge variant="outline" className="bg-muted text-xs">
-                        Secret: {listener.tlsSecret}
+                        {listener.tlsCertificateRef.kind
+                          ? `${listener.tlsCertificateRef.kind}/${listener.tlsCertificateRef.name}`
+                          : listener.tlsCertificateRef.name}
                       </Badge>
                     ) : (
                       <span className="text-muted-foreground">—</span>

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/live/buildNetworkingData.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/live/buildNetworkingData.ts
@@ -54,15 +54,21 @@ export function mapGateway(gw: Gateway, envoyServices: Service[]): NetGateway {
     const statusL = statusListenerByName.get(name) ?? {};
     const rawConds: AnyRecord[] = Array.isArray(statusL["conditions"]) ? statusL["conditions"] : [];
 
-    // TLS secret from spec.listeners[].tls.certificateRefs[0].name
-    const tlsSecret: string | undefined = sl["tls"]?.["certificateRefs"]?.[0]?.["name"];
+    const certRef: AnyRecord | undefined = sl["tls"]?.["certificateRefs"]?.[0];
+    const tlsCertificateRef = certRef
+      ? {
+          kind: certRef["kind"] as string | undefined,
+          namespace: certRef["namespace"] as string | undefined,
+          name: (certRef["name"] as string) ?? "",
+        }
+      : undefined;
 
     return {
       name,
       protocol: sl["protocol"] ?? "",
       port: sl["port"] ?? 0,
       hostname: sl["hostname"],
-      tlsSecret,
+      tlsCertificateRef,
       attachedRoutes: statusL["attachedRoutes"] ?? 0,
       conditions: rawConds.map(toCondition),
     };

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/mock.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/mock.ts
@@ -33,7 +33,7 @@ const gatewayEg: NetGateway = {
       protocol: "HTTP",
       port: 80,
       hostname: undefined,
-      tlsSecret: undefined,
+      tlsCertificateRef: undefined,
       attachedRoutes: 1,
       conditions: [
         { type: "Accepted", status: "True", reason: "Accepted", observedGeneration: 1 },
@@ -46,7 +46,7 @@ const gatewayEg: NetGateway = {
       protocol: "HTTPS",
       port: 443,
       hostname: "*.example.com",
-      tlsSecret: "example-tls",
+      tlsCertificateRef: { name: "example-tls" },
       attachedRoutes: 1,
       conditions: [
         { type: "Accepted", status: "True", reason: "Accepted", observedGeneration: 1 },

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/types.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Networking/types.ts
@@ -14,7 +14,7 @@ export interface NetListener {
   protocol: string;
   port: number;
   hostname?: string;
-  tlsSecret?: string;
+  tlsCertificateRef?: { kind?: string; namespace?: string; name: string };
   attachedRoutes: number;
   conditions: NetCondition[];
 }


### PR DESCRIPTION
`tlsSecret?: string` triggered Snyk SAST HardcodedNonCryptoSecret (CWE-547) because the field name contains "secret". Renamed to `tlsCertificateRef` and widened the type to `{ kind?, namespace?, name }` to preserve all fields from the Gateway API `spec.listeners[].tls.certificateRefs[0]` entry — kind, namespace, and name. The UI now renders `kind/name` when kind is present, enabling correct display of cert-manager Certificate refs alongside plain Secret refs.

