### PR TITLE
EPMDEDP-17146: fix: don't treat GitServer-owned credentials Secret as externally managed

### DIFF
--- a/apps/client/src/modules/platform/configuration/modules/gitservers/components/EditGitServerForm/index.tsx
+++ b/apps/client/src/modules/platform/configuration/modules/gitservers/components/EditGitServerForm/index.tsx
@@ -10,9 +10,8 @@ import { useTRPCClient } from "@/core/providers/trpc";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
 import { useSecretWatchItem } from "@/k8s/api/groups/Core/Secret";
-import { createGitServerSecretName, safeDecode } from "@my-project/shared";
+import { createGitServerSecretName, gitProvider, k8sGitServerConfig, safeDecode } from "@my-project/shared";
 import { showToast } from "@/core/components/Snackbar";
-import { gitProvider } from "@my-project/shared";
 import { Separator } from "@/core/components/ui/separator";
 import type { GitServer } from "@my-project/shared";
 import type { AnyFormApi } from "@tanstack/react-form";
@@ -52,7 +51,11 @@ export const EditGitServerForm: React.FC<{
   const gitServerSecretWatch = useSecretWatchItem({ name: secretName });
   const gitServerSecret = gitServerSecretWatch.query.data;
 
-  const ownerReference = gitServerSecret?.metadata?.ownerReferences?.[0]?.kind;
+  // Ignore the GitServer's own owner reference (added by the operator for GC only); only an
+  // external controller such as an ExternalSecret marks the credentials as read-only here.
+  const ownerReference = gitServerSecret?.metadata?.ownerReferences?.find(
+    (ref) => ref.controller === true && ref.kind !== k8sGitServerConfig.kind
+  )?.kind;
 
   const defaultValues = React.useMemo<Partial<EditGitServerFormValues>>(() => {
     const base: Partial<EditGitServerFormValues> = {


### PR DESCRIPTION
The codebase-operator now sets the GitServer as the controller owner of its native credentials Secret (for garbage collection on deletion). The Edit Git Server form previously treated any ownerReference on the Secret as a sign it is externally managed (e.g. by an ExternalSecret) and disabled the credential and user fields. That now incorrectly fires for every native integration.

Only consider the Secret externally managed when it is owned by a resource other than the GitServer itself.
