### PR TITLE
EPMDEDP-17144: fix: clear stale Git URL Path validation when switching Git server provider

### DIFF
--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/GitAndProjectInfo/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/GitAndProjectInfo/index.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useStore } from "@tanstack/react-form";
-import { codebaseCreationStrategy, gitProvider } from "@my-project/shared";
+import { codebaseCreationStrategy } from "@my-project/shared";
 import { Separator } from "@/core/components/ui/separator";
 import { useGitServerWatchItem } from "@/k8s/api/groups/KRCI/GitServer";
 import { FolderGit2 } from "lucide-react";
 import { NAMES } from "../../names";
 import { useCreateCodebaseForm } from "../../providers/form/hooks";
+import { isGerritProvider } from "../../utils";
 import {
   RepositoryUrl,
   GitServer,
@@ -35,9 +36,14 @@ const GitUrlPreview: React.FC = () => {
     const owner = ownerFieldValue || "org";
     const repo = repositoryNameFieldValue || "repo";
     const gitUrlPath = gitUrlPathFieldValue || "repo";
-    const isGerrit = gitServerFieldValue === gitProvider.gerrit;
-    return isGerrit ? `${host}/${gitUrlPath}` : `${host}/${owner}/${repo}`;
-  }, [gitServer?.spec?.gitHost, ownerFieldValue, repositoryNameFieldValue, gitServerFieldValue, gitUrlPathFieldValue]);
+    return isGerritProvider(gitServer?.spec?.gitProvider) ? `${host}/${gitUrlPath}` : `${host}/${owner}/${repo}`;
+  }, [
+    gitServer?.spec?.gitHost,
+    gitServer?.spec?.gitProvider,
+    ownerFieldValue,
+    repositoryNameFieldValue,
+    gitUrlPathFieldValue,
+  ]);
 
   return (
     <div className="bg-card col-span-4 space-y-2 rounded-lg border p-3">
@@ -56,8 +62,7 @@ const GitPart: React.FC = () => {
   const isCreateFromTemplate = useStore(form.store, (s) => s.values[NAMES.ui_creationMethod] === "template");
 
   const gitServerWatch = useGitServerWatchItem({ name: gitServerFieldValue });
-  const gitServerProvider = gitServerWatch.data?.spec?.gitProvider;
-  const isGerritOrNoApi = gitServerProvider?.includes(gitProvider.gerrit);
+  const isGerritOrNoApi = isGerritProvider(gitServerWatch.data?.spec?.gitProvider);
 
   return (
     <>

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/Review/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/Review/index.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { useStore } from "@tanstack/react-form";
 import { NAMES } from "../../names";
 import { useCreateCodebaseForm } from "../../providers/form/hooks";
+import { isGerritProvider } from "../../utils";
 import { Card } from "@/core/components/ui/card";
-import { ciTool as ciToolValues, codebaseVersioning, gitProvider, isDefaultGitlabCiTemplate } from "@my-project/shared";
+import { ciTool as ciToolValues, codebaseVersioning, isDefaultGitlabCiTemplate } from "@my-project/shared";
 import { InfoColumns } from "@/core/components/InfoColumns";
 import { GridItem } from "@/core/components/InfoColumns/types";
 import { ScrollCopyText } from "@/core/components/ScrollCopyText";
@@ -119,7 +120,7 @@ export const Review: React.FC = () => {
     const owner = repositoryOwner || "org";
     const repo = repositoryName || "repo";
     const gitUrlPathValue = gitUrlPath || "repo";
-    const isGerrit = gitServerProvider?.includes(gitProvider.gerrit);
+    const isGerrit = isGerritProvider(gitServerProvider);
 
     return isGerrit ? `${host}/${gitUrlPathValue}` : `${host}/${owner}/${repo}`;
   }, [gitServerData?.spec?.gitHost, repositoryOwner, repositoryName, gitServerProvider, gitUrlPath, repositoryUrl]);

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/GitServer/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/GitServer/index.tsx
@@ -30,6 +30,14 @@ export const GitServer: React.FC = () => {
       validators={{
         onChange: ({ value }) => (!value ? "Select an existing Git server" : undefined),
       }}
+      listeners={{
+        // Mirror the selected server's provider into form state so dependent field
+        // validators can read it at validation time (see utils.ts/isGerritProvider).
+        onChange: ({ value }) => {
+          const provider = gitServers.find((gitServer) => gitServer.metadata.name === value)?.spec?.gitProvider;
+          form.setFieldValue(NAMES.ui_gitServerProvider, provider ?? "", { dontUpdateMeta: true });
+        },
+      }}
     >
       {(field) => (
         <field.FormSelect

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/GitUrlPath/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/GitUrlPath/index.tsx
@@ -1,24 +1,17 @@
 import React from "react";
-import { useStore } from "@tanstack/react-form";
-import { gitProvider } from "@my-project/shared";
-import { useGitServerWatchItem } from "@/k8s/api/groups/KRCI/GitServer";
 import { useCreateCodebaseForm } from "../../../providers/form/hooks";
 import { NAMES } from "../../../names";
+import { isGerritProvider } from "../../../utils";
 
 export const GitUrlPath: React.FC = () => {
   const form = useCreateCodebaseForm();
-  const gitServerFieldValue = useStore(form.store, (s) => s.values[NAMES.gitServer]);
-
-  const gitServerWatch = useGitServerWatchItem({ name: gitServerFieldValue });
-  const gitServerProvider = gitServerWatch.data?.spec?.gitProvider;
-  const isGerrit = gitServerProvider?.includes(gitProvider.gerrit);
 
   return (
     <form.AppField
       name={NAMES.gitUrlPath}
       validators={{
-        onChange: ({ value }) => {
-          // Only validate if git server is Gerrit
+        onChange: ({ value, fieldApi }) => {
+          const isGerrit = isGerritProvider(fieldApi.form.getFieldValue(NAMES.ui_gitServerProvider));
           if (!isGerrit) {
             return undefined;
           }

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/Owner/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/Owner/index.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import { useStore } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
-import { gitProvider } from "@my-project/shared";
 import { useTRPCClient } from "@/core/providers/trpc";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
-import { useGitServerWatchItem } from "@/k8s/api/groups/KRCI/GitServer";
 import { useCreateCodebaseForm } from "../../../providers/form/hooks";
 import { NAMES } from "../../../names";
+import { isGerritProvider } from "../../../utils";
 
 export const Owner: React.FC = () => {
   const form = useCreateCodebaseForm();
   const trpc = useTRPCClient();
   const gitServerFieldValue = useStore(form.store, (s) => s.values[NAMES.gitServer]);
-
-  const gitServerWatch = useGitServerWatchItem({ name: gitServerFieldValue });
-  const gitServerProvider = gitServerWatch.data?.spec?.gitProvider;
-  const isGerrit = gitServerProvider?.includes(gitProvider.gerrit);
 
   const { clusterName, defaultNamespace } = useClusterStore(
     useShallow((s) => ({ clusterName: s.clusterName, defaultNamespace: s.defaultNamespace }))
@@ -44,8 +39,8 @@ export const Owner: React.FC = () => {
     <form.AppField
       name={NAMES.ui_repositoryOwner}
       validators={{
-        onChange: ({ value }) => {
-          // Only validate if git server is NOT Gerrit
+        onChange: ({ value, fieldApi }) => {
+          const isGerrit = isGerritProvider(fieldApi.form.getFieldValue(NAMES.ui_gitServerProvider));
           if (isGerrit) {
             return undefined;
           }

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/RepositoryName/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/RepositoryName/index.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import { useStore } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
-import { codebaseCreationStrategy, gitProvider } from "@my-project/shared";
+import { codebaseCreationStrategy } from "@my-project/shared";
 import { useTRPCClient } from "@/core/providers/trpc";
 import { useClusterStore } from "@/k8s/store";
 import { useShallow } from "zustand/react/shallow";
-import { useGitServerWatchItem } from "@/k8s/api/groups/KRCI/GitServer";
 import { validationRules } from "@/core/constants/validation";
 import { validateField } from "@/core/utils/forms/validation";
 import { useCreateCodebaseForm } from "../../../providers/form/hooks";
 import { NAMES } from "../../../names";
+import { isGerritProvider } from "../../../utils";
 
 export const RepositoryName: React.FC = () => {
   const form = useCreateCodebaseForm();
@@ -17,10 +17,6 @@ export const RepositoryName: React.FC = () => {
   const gitServerFieldValue = useStore(form.store, (s) => s.values[NAMES.gitServer]);
   const ownerFieldValue = useStore(form.store, (s) => s.values[NAMES.ui_repositoryOwner]);
   const strategyFieldValue = useStore(form.store, (s) => s.values[NAMES.strategy]);
-
-  const gitServerWatch = useGitServerWatchItem({ name: gitServerFieldValue });
-  const gitServerProvider = gitServerWatch.data?.spec?.gitProvider;
-  const isGerrit = gitServerProvider?.includes(gitProvider.gerrit);
 
   const { clusterName, defaultNamespace } = useClusterStore(
     useShallow((s) => ({ clusterName: s.clusterName, defaultNamespace: s.defaultNamespace }))
@@ -56,7 +52,8 @@ export const RepositoryName: React.FC = () => {
     <form.AppField
       name={NAMES.ui_repositoryName}
       validators={{
-        onChange: ({ value }) => {
+        onChange: ({ value, fieldApi }) => {
+          const isGerrit = isGerritProvider(fieldApi.form.getFieldValue(NAMES.ui_gitServerProvider));
           if (isGerrit) return undefined;
           if (!value || value.trim().length === 0) {
             return isImportStrategy ? "Select repository" : "Enter the repository name";

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/constants.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/constants.ts
@@ -25,6 +25,8 @@ export type FormPart = ValueOf<typeof FORM_PARTS>;
 
 export const CREATE_FORM_PARTS = {
   [FORM_PARTS.METHOD]: [NAMES.ui_creationMethod, NAMES.ui_creationTemplate, NAMES.type, NAMES.strategy],
+  // ui_gitServerProvider is intentionally omitted: it is a hidden mirror of the selected Git
+  // server's provider (no validator of its own), read only by the other fields' validators.
   [FORM_PARTS.GIT_SETUP]: [
     NAMES.repositoryUrl,
     NAMES.gitServer,

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/hooks/useDefaultValues.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/hooks/useDefaultValues.ts
@@ -32,6 +32,7 @@ export const useDefaultValues = (): DeepPartial<CreateCodebaseFormValues> => {
       [NAMES.ciTool]: ciTool.tekton,
       [NAMES.ui_gitlabCiTemplate]: null,
       [NAMES.gitServer]: firstValidGitServer?.metadata.name || "",
+      [NAMES.ui_gitServerProvider]: firstValidGitServer?.spec?.gitProvider || "",
       [NAMES.deploymentScript]: codebaseDeploymentScript["helm-chart"],
       [NAMES.repositoryUrl]: null,
       [NAMES.ui_creationMethod]: "template",

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/schema.test.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { codebaseCreationStrategy, codebaseType, gitProvider } from "@my-project/shared";
+import { createCodebaseFormSchema } from "./schema";
+
+// A fully-populated form value (all steps) so the schema's superRefine runs.
+const completeValues = {
+  ui_creationMethod: "custom",
+  type: codebaseType.application,
+  strategy: codebaseCreationStrategy.create,
+  gitServer: "my-gerrit-server", // intentionally NOT named "gerrit"
+  ui_gitServerProvider: gitProvider.gerrit,
+  gitUrlPath: "team/repo",
+  ui_repositoryOwner: "",
+  ui_repositoryName: "",
+  defaultBranch: "main",
+  name: "my-app",
+  description: "desc",
+  private: true,
+  emptyProject: false,
+  ui_hasCodebaseAuth: false,
+  ui_hasJiraServerIntegration: false,
+  lang: "java",
+  framework: "java17",
+  buildTool: "maven",
+  versioningType: "default",
+  ciTool: "tekton",
+  deploymentScript: "helm-chart",
+  repositoryUrl: null,
+  versioningStartFrom: "0.1.0-SNAPSHOT",
+  commitMessagePattern: "",
+};
+
+const paths = (values: unknown): string[] => {
+  const r = createCodebaseFormSchema.safeParse(values);
+  return r.success ? [] : r.error.errors.map((e) => String(e.path[0]));
+};
+
+describe("createCodebaseFormSchema Git server detection", () => {
+  it("validates the Gerrit branch based on provider, not the git server name", () => {
+    // ui_gitServerProvider=gerrit -> validate gitUrlPath, ignore owner/repo even though the
+    // git server is named "my-gerrit-server" (the old name-based check would have failed).
+    const errs = paths({ ...completeValues, gitUrlPath: "ab" });
+    expect(errs).toContain("gitUrlPath");
+    expect(errs).not.toContain("ui_repositoryOwner");
+    expect(errs).not.toContain("ui_repositoryName");
+  });
+
+  it("accepts a valid Gerrit path and does not require owner/repository", () => {
+    expect(paths(completeValues)).toEqual([]);
+  });
+
+  it("validates the non-Gerrit branch (owner/repository) when provider is GitHub", () => {
+    const errs = paths({ ...completeValues, ui_gitServerProvider: gitProvider.github });
+    expect(errs).toContain("ui_repositoryOwner");
+    expect(errs).toContain("ui_repositoryName");
+    expect(errs).not.toContain("gitUrlPath");
+  });
+});

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/schema.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/schema.ts
@@ -1,11 +1,7 @@
-import {
-  codebaseCreationStrategy,
-  codebaseType,
-  createCodebaseDraftInputSchema,
-  gitProvider,
-} from "@my-project/shared";
+import { codebaseCreationStrategy, codebaseType, createCodebaseDraftInputSchema } from "@my-project/shared";
 import z from "zod";
 import { validationRules } from "@/core/constants/validation";
+import { isGerritProvider } from "./utils";
 
 // ============================================================================
 // UTILITY FUNCTIONS
@@ -20,8 +16,6 @@ const isApplication = (type: string | null | undefined): boolean => type === cod
 const isAutotest = (type: string | null | undefined): boolean => type === codebaseType.autotest;
 
 const isCloneStrategy = (strategy: string | null | undefined): boolean => strategy === codebaseCreationStrategy.clone;
-
-const isGerrit = (gitServer: string | null | undefined): boolean => gitServer === gitProvider.gerrit;
 
 // ============================================================================
 // EXTENDED SCHEMAS (from single source of truth)
@@ -63,6 +57,10 @@ const langSchema = createCodebaseDraftInputSchema.shape.lang.min(1, "Select code
 const uiOnlyFields = {
   ui_creationMethod: z.string().nullable().optional(),
   ui_creationTemplate: z.string().nullable().optional(),
+  // Provider of the currently selected Git server, mirrored into form state so field
+  // validators (and the submit-time schema) can read it synchronously at validation time
+  // rather than from a render-captured closure (see utils.ts/isGerritProvider).
+  ui_gitServerProvider: z.string().nullable().optional(),
   ui_repositoryOwner: z.string().optional(),
   ui_repositoryName: z.string().optional(),
   ui_hasCodebaseAuth: z.boolean(),
@@ -229,7 +227,7 @@ const validateGitSetupStep = (data: FormData, ctx: z.RefinementCtx) => {
   if (!data.gitServer) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["gitServer"], message: "Select an existing Git server" });
   }
-  if (isGerrit(data.gitServer)) {
+  if (isGerritProvider(data.ui_gitServerProvider)) {
     validateGerritGitUrlPath(data, ctx);
   } else {
     validateNonGerritRepository(data, ctx);

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/utils.test.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { gitProvider } from "@my-project/shared";
+import { isGerritProvider } from "./utils";
+
+describe("isGerritProvider", () => {
+  it("is true for the gerrit provider", () => {
+    expect(isGerritProvider(gitProvider.gerrit)).toBe(true);
+  });
+
+  it("is false for non-gerrit providers", () => {
+    expect(isGerritProvider(gitProvider.github)).toBe(false);
+    expect(isGerritProvider(gitProvider.gitlab)).toBe(false);
+    expect(isGerritProvider(gitProvider.bitbucket)).toBe(false);
+  });
+
+  it("is false for empty / nullish provider values", () => {
+    expect(isGerritProvider("")).toBe(false);
+    expect(isGerritProvider(null)).toBe(false);
+    expect(isGerritProvider(undefined)).toBe(false);
+  });
+});

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/utils.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/utils.ts
@@ -1,0 +1,4 @@
+import { gitProvider } from "@my-project/shared";
+
+/** Whether the given Git provider value represents a Gerrit server. */
+export const isGerritProvider = (provider: string | null | undefined): boolean => provider === gitProvider.gerrit;


### PR DESCRIPTION
In the Create-strategy project wizard, selecting Gerrit, focusing the empty Git URL Path, then switching to GitHub and clicking Continue silently did nothing with no validation message.

The gitUrlPath / owner / repositoryName field validators derived Gerrit-ness from a closure captured at render. TanStack Form keeps a field's instance after it unmounts and re-runs its last validator during validateAllFields, so the hidden gitUrlPath field kept evaluating as Gerrit against its empty value and blocked navigation invisibly.

Mirror the selected provider into form state (ui_gitServerProvider, matching the CreateGitOpsForm pattern) and have the dependent validators read it at validation time via fieldApi.getFieldValue, so an unmounted field always evaluates against the current provider. Fixes both Gerrit->GitHub and the symmetric GitHub->Gerrit direction. Display components (layout, URL preview, review) keep reading the live Git server watch, consistent with the sibling form.

Also make the submit-time schema detect Gerrit by provider (ui_gitServerProvider) instead of by Git server name, so validation is correct when the Gerrit server is not literally named "gerrit".
