### PR TITLE
EPMDEDP-17167: feat: show current deployed version in stage deploy dropdown

### DIFF
--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/components/columns/DeployedVersionConfiguration.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/components/columns/DeployedVersionConfiguration.tsx
@@ -6,13 +6,14 @@ import { useStore } from "@tanstack/react-form";
 import { useTypedFormContext } from "../../hooks/useTypedFormContext";
 import { createImageStreamTags } from "../../utils/createImageStreamTags";
 import { StageAppCodebaseCombinedData } from "@/modules/platform/cdpipelines/pages/stage-details/hooks";
+import { getAppDeployedVersion } from "@/modules/platform/cdpipelines/pages/stage-details/utils/getAppDeployedVersion";
 import { ConditionalWrapper } from "@/core/components/ConditionalWrapper";
 import { Tooltip } from "@/core/components/ui/tooltip";
 import { cn } from "@/core/utils/classname";
 
 const CHANNEL = /^(latest|stable)::/;
 
-/** Compare select value to deployed/default tag. Strips one `latest::` / `stable::` prefix on each side (no loose `includes` — that breaks semver-like tags, e.g. `…SNAPSHOT.10` vs `…SNAPSHOT.1`). */
+/** Whether the selected value resolves to the same image as the running version. Strips one `latest::` / `stable::` prefix on each side, so picking [LATEST]/[STABLE] that resolves to the deployed tag counts as unchanged (no loose `includes` — that breaks semver-like tags, e.g. `…SNAPSHOT.10` vs `…SNAPSHOT.1`). */
 function sameImageTag(selected: string, reference: string): boolean {
   if (reference === "") return selected === "";
   if (selected === "") return false;
@@ -22,20 +23,13 @@ function sameImageTag(selected: string, reference: string): boolean {
   return a === b;
 }
 
-/** String from `defaultValues` when the key exists and the value is set; otherwise `null`. */
-function getDefaultValueForField(defaults: Record<string, unknown> | undefined, field: string): string | null {
-  if (defaults == null || !Object.hasOwn(defaults, field)) return null;
-  const v = defaults[field];
-  if (v === undefined || v === null) return null;
-  return String(v);
-}
-
 export const DeployedVersionConfigurationColumn = ({
   stageAppCodebasesCombinedData,
 }: {
   stageAppCodebasesCombinedData: StageAppCodebaseCombinedData;
 }) => {
-  const { appCodebaseImageStream, appCodebaseVerifiedImageStream, appCodebase } = stageAppCodebasesCombinedData;
+  const { appCodebaseImageStream, appCodebaseVerifiedImageStream, appCodebase, application } =
+    stageAppCodebasesCombinedData;
 
   const form = useTypedFormContext();
   const fieldName = `${appCodebase.metadata.name}${IMAGE_TAG_POSTFIX}` as const;
@@ -57,25 +51,19 @@ export const DeployedVersionConfigurationColumn = ({
     [appCodebaseImageStream, appCodebaseVerifiedImageStream]
   );
 
-  const deployedFromDefaults = getDefaultValueForField(
-    form.options.defaultValues as Record<string, unknown> | undefined,
-    fieldName
-  );
-
   const imageTagsLength = imageStreamTagsOptions.length;
 
-  const runningLabel =
-    deployedFromDefaults !== null
-      ? deployedFromDefaults || undefined
-      : typeof imageTagFromFormValues === "string"
-        ? imageTagFromFormValues || undefined
-        : undefined;
+  // Persistent caption above the selector, so the running version stays visible after a new one is
+  // picked (a Select placeholder would be hidden on selection).
+  const deployedVersion = getAppDeployedVersion(appCodebase, application);
+  const hasDeployedVersion = Boolean(application) && !!deployedVersion && deployedVersion !== "NaN";
+  const deployedVersionCaption = hasDeployedVersion ? `Running version: ${deployedVersion}` : "Not deployed";
 
-  const label = runningLabel
-    ? `Running version: ${runningLabel}`
-    : imageTagsLength
-      ? "Select image tag"
-      : "No image tags available";
+  // Compare the selection against the live running version so the change indicator lights up only on
+  // a real change. "" = nothing running yet, so any concrete selection then counts as a change.
+  const runningRef = hasDeployedVersion ? deployedVersion : "";
+
+  const placeholder = imageTagsLength ? "Select image tag" : "No image tags available";
 
   const hasImageTags = imageTagsLength > 0;
   const helperText = hasImageTags ? "" : "Run at least one build pipeline to produce the necessary artifacts.";
@@ -86,13 +74,8 @@ export const DeployedVersionConfigurationColumn = ({
         const raw = field.state.value as string | undefined;
         const selected = raw !== undefined && raw !== null ? String(raw) : String(imageTagFromFormValues ?? "");
 
-        // `isDirty` stays true after edits even if the user picks the original tag again; `isDefaultValue` is still
-        // true when the value matches `form.options.defaultValues` for this field (TanStack deep check).
-        const matchesDefaultMeta = field.state.meta.isDefaultValue;
-        const unchanged =
-          deployedFromDefaults !== null
-            ? sameImageTag(selected, deployedFromDefaults) || matchesDefaultMeta
-            : !field.state.meta.isDirty || matchesDefaultMeta;
+        // Nothing picked yet is not a change; otherwise compare the resolved tag to the running version.
+        const unchanged = selected === "" || sameImageTag(selected, runningRef);
 
         return (
           <div className="flex w-full flex-row items-stretch gap-2">
@@ -105,7 +88,10 @@ export const DeployedVersionConfigurationColumn = ({
               )}
               aria-hidden
             />
-            <div className="grow">
+            <div className="flex grow flex-col gap-0.5">
+              <span className="text-muted-foreground truncate text-xs leading-none" title={deployedVersionCaption}>
+                {deployedVersionCaption}
+              </span>
               <ConditionalWrapper
                 condition={!hasImageTags}
                 wrapper={(children) => (
@@ -123,7 +109,7 @@ export const DeployedVersionConfigurationColumn = ({
                   disabled={!imageStreamTagsOptions.length}
                 >
                   <SelectTrigger className="text-start">
-                    <SelectValue placeholder={label} />
+                    <SelectValue placeholder={placeholder} />
                   </SelectTrigger>
                   <SelectContent>
                     {imageStreamTagsOptions.map(({ label: optionLabel, value }) => (

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/components/columns/DeployedVersionPreview.tsx
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/components/Content/components/Applications/components/columns/DeployedVersionPreview.tsx
@@ -1,13 +1,9 @@
-import {
-  CODEBASE_COMMON_BUILD_TOOLS,
-  CODEBASE_COMMON_FRAMEWORKS,
-  CODEBASE_COMMON_LANGUAGES,
-} from "@/k8s/api/groups/KRCI/Codebase/configs/mappings";
 import { quickLinkUiNames } from "@/k8s/api/groups/KRCI/QuickLink/constants";
 import { LinkCreationService } from "@/k8s/services/link-creation";
 import { useQuickLinksUrlListWatch } from "@/modules/platform/cdpipelines/pages/stage-details/hooks";
+import { getAppDeployedVersion } from "@/modules/platform/cdpipelines/pages/stage-details/utils/getAppDeployedVersion";
 import { Tooltip } from "@/core/components/ui/tooltip";
-import { Application, applicationLabels, Codebase, getDeployedVersion, systemQuickLink } from "@my-project/shared";
+import { Application, applicationLabels, Codebase, systemQuickLink } from "@my-project/shared";
 import { Link } from "@tanstack/react-router";
 import { CircleCheck, Fingerprint, SquareArrowOutUpRight } from "lucide-react";
 import React from "react";
@@ -58,20 +54,13 @@ export const DeployedVersionPreviewColumn = ({
   appCodebase: Codebase;
   application: Application;
 }) => {
-  const { lang, framework, buildTool } = appCodebase.spec;
-
   const quickLinksUrlListWatch = useQuickLinksUrlListWatch();
 
   const quickLinkURLs = quickLinksUrlListWatch.data?.quickLinkURLs;
 
-  const isHelm =
-    lang === CODEBASE_COMMON_LANGUAGES.HELM &&
-    framework === CODEBASE_COMMON_FRAMEWORKS.HELM &&
-    buildTool === CODEBASE_COMMON_BUILD_TOOLS.HELM;
+  const withValuesOverride = application?.spec ? Object.hasOwn(application.spec, "sources") : false;
 
-  const withValuesOverride = application ? Object.hasOwn(application?.spec, "sources") : false;
-
-  const deployedVersion = getDeployedVersion(withValuesOverride, isHelm, application);
+  const deployedVersion = getAppDeployedVersion(appCodebase, application);
 
   const deployedImage = (() => {
     const images: string[] = application?.status?.summary?.images || [];

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/utils/getAppDeployedVersion/index.test.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/utils/getAppDeployedVersion/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { Application, Codebase } from "@my-project/shared";
+import { getAppDeployedVersion } from "./index.js";
+
+const helmCodebase = {
+  spec: { lang: "helm", framework: "helm", buildTool: "helm" },
+} as unknown as Codebase;
+
+const dockerCodebase = {
+  spec: { lang: "java", framework: "spring-boot", buildTool: "maven" },
+} as unknown as Codebase;
+
+describe("getAppDeployedVersion", () => {
+  it("returns 'NaN' when application is undefined", () => {
+    expect(getAppDeployedVersion(dockerCodebase, undefined)).toBe("NaN");
+    expect(getAppDeployedVersion(helmCodebase, undefined)).toBe("NaN");
+  });
+
+  it("reads targetRevision for a Helm codebase without a values override", () => {
+    const application = {
+      spec: {
+        source: { targetRevision: "charts/2.0.0", helm: { parameters: [] } },
+      },
+    } as unknown as Application;
+
+    expect(getAppDeployedVersion(helmCodebase, application)).toBe("2.0.0");
+  });
+
+  it("reads the image.tag helm parameter for a non-Helm codebase without a values override", () => {
+    const application = {
+      spec: {
+        source: { helm: { parameters: [{ name: "image.tag", value: "v3.0.0" }] } },
+      },
+    } as unknown as Application;
+
+    expect(getAppDeployedVersion(dockerCodebase, application)).toBe("v3.0.0");
+  });
+
+  it("reads from the matching helm source when the application has a values override", () => {
+    const application = {
+      spec: {
+        sources: [{ helm: { parameters: [{ name: "image.tag", value: "v1.0.0" }] }, targetRevision: "main" }],
+      },
+    } as unknown as Application;
+
+    expect(getAppDeployedVersion(dockerCodebase, application)).toBe("v1.0.0");
+  });
+
+  it("does not throw for a just-created application whose spec is not populated yet", () => {
+    const bareApplication = {} as unknown as Application;
+
+    expect(() => getAppDeployedVersion(dockerCodebase, bareApplication)).not.toThrow();
+    expect(getAppDeployedVersion(dockerCodebase, bareApplication)).toBe("");
+    expect(getAppDeployedVersion(helmCodebase, bareApplication)).toBe("");
+  });
+});

--- a/apps/client/src/modules/platform/cdpipelines/pages/stage-details/utils/getAppDeployedVersion/index.ts
+++ b/apps/client/src/modules/platform/cdpipelines/pages/stage-details/utils/getAppDeployedVersion/index.ts
@@ -1,0 +1,28 @@
+import {
+  CODEBASE_COMMON_BUILD_TOOLS,
+  CODEBASE_COMMON_FRAMEWORKS,
+  CODEBASE_COMMON_LANGUAGES,
+} from "@/k8s/api/groups/KRCI/Codebase/configs/mappings";
+import { Application, Codebase, getDeployedVersion } from "@my-project/shared";
+
+/**
+ * Version currently deployed for one application, read from the live ArgoCD `Application` (not from
+ * form defaults, which can be stale for apps whose Application watch resolves after mount).
+ * Centralizes the `isHelm` / `withValuesOverride` derivation shared by several call sites.
+ */
+export const getAppDeployedVersion = (
+  appCodebase: Pick<Codebase, "spec">,
+  application: Application | undefined
+): string => {
+  const { lang, framework, buildTool } = appCodebase.spec;
+
+  const isHelm =
+    lang === CODEBASE_COMMON_LANGUAGES.HELM &&
+    framework === CODEBASE_COMMON_FRAMEWORKS.HELM &&
+    buildTool === CODEBASE_COMMON_BUILD_TOOLS.HELM;
+
+  // `application.spec` can be absent on a just-created Application, so guard before Object.hasOwn.
+  const withValuesOverride = application?.spec ? Object.hasOwn(application.spec, "sources") : false;
+
+  return getDeployedVersion(withValuesOverride, isHelm, application);
+};


### PR DESCRIPTION
Restore the legacy edp-headlamp behavior where the Applications deploy selector shows both the currently-deployed version and the newly-selected one. The running version previously lived only in the Radix Select placeholder, which is hidden once a value is picked, so users lost sight of what is currently deployed.

- Render a persistent "Running version" caption above the selector
- Source it from the live ArgoCD Application, not from form defaults, which are seeded before the Application watch resolves and stay empty for already-deployed apps
- Extract the isHelm/withValuesOverride + getDeployedVersion derivation into a shared getAppDeployedVersion helper reused by the deploy dropdown and the deployed-version preview
- Keep the neutral "Select image tag" placeholder and the existing change-indicator bar

