### PR TITLE
EPMDEDP-17150: feat: show "Triggered By" actor on PipelineRun details

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ OIDC_CODE_CHALLENGE_METHOD=S256
 
 TEKTON_RESULTS_URL = http://tekton-results.tekton-pipelines.svc.cluster.local:8080
 
+# krci-audit read API. Powers the PipelineRun "Triggered By" information.
+KRCI_AUDIT_URL = http://krci-audit-api.krci-audit:8080
+
 # Dependency Track Integration
 DEPENDENCY_TRACK_URL=
 DEPENDENCY_TRACK_API_KEY=

--- a/apps/client/src/core/components/AutomationAvatar/index.tsx
+++ b/apps/client/src/core/components/AutomationAvatar/index.tsx
@@ -1,0 +1,40 @@
+import { UserRoundCog } from "lucide-react";
+import { Avatar, AvatarFallback } from "@/core/components/ui/avatar";
+import { cn } from "@/core/utils/classname";
+
+interface AutomationAvatarProps {
+  /** Service-account (or other system principal) name shown in the tooltip. */
+  name: string;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: "size-6",
+  md: "size-8",
+} as const;
+
+// Glyph is sized below the circle (unlike AuthorAvatar's initials) so the finer
+// person+cog detail stays legible; circle size is fixed by sizeClasses.
+const iconSizes = {
+  sm: "size-4",
+  md: "size-5",
+} as const;
+
+/**
+ * Automation/service-account indicator — the non-human counterpart to AuthorAvatar's human
+ * initials, for actors classified as automation (e.g. Tekton trigger service accounts). The
+ * person+cog glyph reads as "a configured/automated identity". Native browser tooltip shows
+ * the full actor name on hover.
+ */
+export const AutomationAvatar = ({ name, size = "sm", className }: AutomationAvatarProps) => {
+  return (
+    <span title={name}>
+      <Avatar className={cn(sizeClasses[size], className)}>
+        <AvatarFallback className={sizeClasses[size]}>
+          <UserRoundCog className={iconSizes[size]} />
+        </AvatarFallback>
+      </Avatar>
+    </span>
+  );
+};

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/components/TriggeredByField/TriggeredByField.stories.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/components/TriggeredByField/TriggeredByField.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TriggeredByField } from "./index";
+
+const meta = {
+  title: "Feature/PipelineRunDetails/TriggeredByField",
+  component: TriggeredByField,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof TriggeredByField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Human: Story = {
+  args: {
+    triggeredBy: { actorClass: "human", actor: "dev@example.com", displayName: "dev@example.com" },
+  },
+};
+
+export const Automation: Story = {
+  args: {
+    triggeredBy: {
+      actorClass: "automation",
+      actor: "system:serviceaccount:krci:krci-admin",
+      displayName: "krci-admin",
+    },
+  },
+};
+
+/** Explicitly unresolved actor (never audited, system:unknown, or krci-audit unavailable). */
+export const Unknown: Story = {
+  args: {
+    triggeredBy: { actorClass: "unknown" },
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    triggeredBy: undefined,
+  },
+};

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/components/TriggeredByField/index.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/components/TriggeredByField/index.tsx
@@ -1,0 +1,42 @@
+import { TriggeredBy } from "@my-project/shared";
+import { UserCheck } from "lucide-react";
+import { AuthorAvatar } from "@/core/components/AuthorAvatar";
+import { AutomationAvatar } from "@/core/components/AutomationAvatar";
+import { Tooltip } from "@/core/components/ui/tooltip";
+
+export interface TriggeredByFieldProps {
+  /** Classified krci-audit CREATE actor. `undefined` while loading (renders the "N/A" placeholder). */
+  triggeredBy: TriggeredBy | undefined;
+}
+
+/**
+ * PipelineRun header field showing who *triggered* (created) the run — the krci-audit CREATE
+ * actor — as opposed to "Author" (the git commit author).
+ */
+export const TriggeredByField = ({ triggeredBy }: TriggeredByFieldProps) => {
+  return (
+    <div className="flex items-center gap-2">
+      <UserCheck className="text-muted-foreground size-4" />
+      <span className="text-muted-foreground text-sm">Triggered By:</span>
+      <TriggeredByActor triggeredBy={triggeredBy} />
+    </div>
+  );
+};
+
+const TriggeredByActor = ({ triggeredBy }: TriggeredByFieldProps) => {
+  if (!triggeredBy || triggeredBy.actorClass === "unknown") {
+    return (
+      <Tooltip title="No creator recorded for this run. Ensure krci-audit is enabled and configured properly.">
+        <span className="text-muted-foreground text-sm">N/A</span>
+      </Tooltip>
+    );
+  }
+
+  const display = triggeredBy.displayName ?? "";
+
+  if (triggeredBy.actorClass === "automation") {
+    return <AutomationAvatar name={display} size="sm" />;
+  }
+
+  return <AuthorAvatar author={display} size="sm" />;
+};

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/useTriggeredBy.test.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/useTriggeredBy.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useTriggeredBy } from "./useTriggeredBy";
+import { TriggeredBy } from "@my-project/shared";
+
+const mockQuery = vi.fn();
+
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({
+    krciAudit: {
+      getTriggeredBy: { query: mockQuery },
+    },
+  }),
+}));
+
+const mockClusterStoreState = { clusterName: "test-cluster" };
+vi.mock("@/k8s/store", () => ({
+  useClusterStore: Object.assign(
+    vi.fn((selector) => (selector ? selector(mockClusterStoreState) : mockClusterStoreState)),
+    { setState: vi.fn(), getState: vi.fn(() => mockClusterStoreState) }
+  ),
+}));
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { Wrapper };
+}
+
+describe("useTriggeredBy", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("requests the actor by namespace/name and exposes the classified result", async () => {
+    const response: TriggeredBy = { actorClass: "human", actor: "dev@example.com", displayName: "dev@example.com" };
+    mockQuery.mockResolvedValue(response);
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useTriggeredBy("krci", "run-abc"), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current).toEqual(response));
+    expect(mockQuery).toHaveBeenCalledWith({ namespace: "krci", name: "run-abc" });
+  });
+
+  it("returns undefined (no crash) while loading or when the query fails", async () => {
+    mockQuery.mockRejectedValue(new Error("krci-audit unavailable"));
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useTriggeredBy("krci", "run-down"), { wrapper: Wrapper });
+
+    expect(result.current).toBeUndefined();
+    await waitFor(() => expect(mockQuery).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it("does not call the API until namespace and name are present", async () => {
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useTriggeredBy(undefined, undefined), { wrapper: Wrapper });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("does not call the API when explicitly disabled", async () => {
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useTriggeredBy("krci", "run-abc", false), { wrapper: Wrapper });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/useTriggeredBy.ts
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/useTriggeredBy.ts
@@ -1,0 +1,31 @@
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useClusterStore } from "@/k8s/store";
+import { TriggeredBy } from "@my-project/shared";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Resolves "Triggered By" (the krci-audit CREATE actor) for a PipelineRun by namespace/name,
+ * which correlates both live runs and ones reconstructed from Tekton Results history.
+ *
+ * A resolved actor is immutable so it caches indefinitely; a `degraded` fallback (transient
+ * krci-audit/RBAC failure) is kept stale and refetched on next mount so an outage doesn't pin "N/A".
+ */
+export function useTriggeredBy(
+  namespace: string | undefined,
+  name: string | undefined,
+  enabled = true
+): TriggeredBy | undefined {
+  const trpc = useTRPCClient();
+  const clusterName = useClusterStore((state) => state.clusterName);
+
+  const { data } = useQuery({
+    queryKey: ["krciAudit", "getTriggeredBy", clusterName, namespace, name],
+    queryFn: () => trpc.krciAudit.getTriggeredBy.query({ namespace: namespace!, name: name! }),
+    enabled: enabled && !!namespace && !!name,
+    // Refetch degraded results (staleTime 0) on next mount; cache resolved actors forever.
+    // refetchOnMount defaults to true, so the stale degraded entry refetches automatically.
+    staleTime: (query) => (query.state.data?.degraded ? 0 : Infinity),
+  });
+
+  return data;
+}

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/view.tsx
@@ -42,6 +42,8 @@ import { useShallow } from "zustand/react/shallow";
 import { PipelineRunProvider } from "./providers/PipelineRun/provider";
 import { usePipelineRunContext } from "./providers/PipelineRun/hooks";
 import { StopPipelineRunButton } from "./components/StopPipelineRunButton";
+import { TriggeredByField } from "./components/TriggeredByField";
+import { useTriggeredBy } from "./hooks/useTriggeredBy";
 
 /**
  * Look up an annotation from resultAnnotations JSON first, then fall back to raw metadata annotations.
@@ -72,6 +74,10 @@ function HeaderMetadata() {
       enabled: !!codebaseBranchMetadataName && unifiedData.source === "live",
     },
   });
+
+  // "Triggered By" — the krci-audit CREATE actor, resolved by namespace/name (correct for both
+  // live and Tekton Results history runs). Independent of the git "Author" annotation above.
+  const triggeredBy = useTriggeredBy(params.namespace, params.name, unifiedData.isReady && !!pipelineRun);
 
   if (!unifiedData.isReady || !pipelineRun) {
     return null;
@@ -210,6 +216,8 @@ function HeaderMetadata() {
             </div>
           );
         })()}
+
+        <TriggeredByField triggeredBy={triggeredBy} />
 
         {startedAt && (
           <div className="flex items-center gap-2">

--- a/packages/shared/src/models/index.ts
+++ b/packages/shared/src/models/index.ts
@@ -6,3 +6,4 @@ export * from "./prometheus/index.js";
 export * from "./sonarqube/index.js";
 export * from "./user/index.js";
 export * from "./tektonResults/index.js";
+export * from "./krciAudit/index.js";

--- a/packages/shared/src/models/krciAudit/index.ts
+++ b/packages/shared/src/models/krciAudit/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export * from "./schemas.js";

--- a/packages/shared/src/models/krciAudit/schemas.ts
+++ b/packages/shared/src/models/krciAudit/schemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+/** Runtime guard for krci-audit's `GET /api/v1/audit/initiator` response, so a schema drift
+ *  on krci-audit's side fails loudly (and degrades to "N/A") instead of silently misclassifying. */
+export const krciAuditInitiatorSchema = z.object({
+  found: z.boolean(),
+  actor: z.string().optional(),
+  operation: z.enum(["CREATE", "UPDATE", "DELETE", "CONNECT"]).optional(),
+  timestamp: z.string().optional(),
+});

--- a/packages/shared/src/models/krciAudit/types.ts
+++ b/packages/shared/src/models/krciAudit/types.ts
@@ -1,0 +1,30 @@
+/** Admission operation recorded by krci-audit on an event. */
+export type KrciAuditOperation = "CREATE" | "UPDATE" | "DELETE" | "CONNECT";
+
+/**
+ * Raw shape of krci-audit's `GET /api/v1/audit/initiator` response
+ * (the `Initiator` schema). `found: false` means the object was never audited — not an error.
+ */
+export interface KrciAuditInitiator {
+  found: boolean;
+  actor?: string;
+  operation?: KrciAuditOperation;
+  timestamp?: string;
+}
+
+export type TriggeredByActorClass = "human" | "automation" | "unknown";
+
+/** Portal-classified "Triggered By" result for one PipelineRun. */
+export interface TriggeredBy {
+  actorClass: TriggeredByActorClass;
+  /** Raw krci-audit actor username (present when actorClass !== "unknown"). */
+  actor?: string;
+  /** Short display name for the hover tooltip: email for human, service-account short name for automation. */
+  displayName?: string;
+  /**
+   * Set only when the result is a transient fallback (krci-audit or the RBAC check failed),
+   * as opposed to a genuine "never audited" / "system:unknown" actor. Lets the client refetch
+   * instead of caching the miss forever.
+   */
+  degraded?: boolean;
+}

--- a/packages/trpc/src/clients/krciAudit/index.test.ts
+++ b/packages/trpc/src/clients/krciAudit/index.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KrciAuditClient } from "./index.js";
+
+const BASE = "http://krci-audit.krci:8080";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let originalFetch: typeof globalThis.fetch;
+
+function mockFetchOnce(body: unknown, status = 200) {
+  fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("createKrciAuditClient", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("throws when KRCI_AUDIT_URL is not set", async () => {
+    delete process.env.KRCI_AUDIT_URL;
+    const { createKrciAuditClient } = await import("./index.js");
+
+    expect(() => createKrciAuditClient()).toThrow("KRCI_AUDIT_URL");
+  });
+
+  it("returns a client when the env is configured", async () => {
+    process.env.KRCI_AUDIT_URL = BASE;
+    const { createKrciAuditClient } = await import("./index.js");
+
+    const client = createKrciAuditClient();
+
+    // Not `toBeInstanceOf`: the dynamic import above (after vi.resetModules) yields a
+    // distinct KrciAuditClient class identity from the static import at the top of the file.
+    expect(client).toBeDefined();
+    expect(typeof client.getInitiator).toBe("function");
+  });
+});
+
+describe("KrciAuditClient", () => {
+  it("throws when apiBaseURL is empty", () => {
+    expect(() => new KrciAuditClient({ apiBaseURL: "" })).toThrow("API base URL is not configured");
+  });
+
+  it("strips a trailing slash from the base URL", async () => {
+    mockFetchOnce({ found: false });
+    const client = new KrciAuditClient({ apiBaseURL: `${BASE}/` });
+
+    await client.getInitiator({ objectUid: "uid-123" });
+
+    // A single slash between host and path proves the trailing slash was stripped (no "8080//api").
+    expect(String(fetchMock.mock.calls[0][0])).toBe(`${BASE}/api/v1/audit/initiator?objectUid=uid-123`);
+  });
+});
+
+describe("KrciAuditClient.getInitiator", () => {
+  it("requests by objectUid and returns the parsed result", async () => {
+    mockFetchOnce({ found: true, actor: "dev@example.com", operation: "CREATE", timestamp: "2026-07-06T00:00:00Z" });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    const result = await client.getInitiator({ objectUid: "uid-123" });
+
+    expect(result).toEqual({
+      found: true,
+      actor: "dev@example.com",
+      operation: "CREATE",
+      timestamp: "2026-07-06T00:00:00Z",
+    });
+    expect(String(fetchMock.mock.calls[0][0])).toBe(`${BASE}/api/v1/audit/initiator?objectUid=uid-123`);
+  });
+
+  it("requests by kind+namespace+name, encoding each param", async () => {
+    mockFetchOnce({ found: true, actor: "system:serviceaccount:krci:krci-admin", operation: "CREATE" });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await client.getInitiator({ kind: "PipelineRun", namespace: "krci", name: "run a/b" });
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      `${BASE}/api/v1/audit/initiator?kind=PipelineRun&namespace=krci&name=run+a%2Fb`
+    );
+  });
+
+  it("returns found:false for an un-audited object (not an error)", async () => {
+    mockFetchOnce({ found: false });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    const result = await client.getInitiator({ objectUid: "uid-never-audited" });
+
+    expect(result).toEqual({ found: false });
+  });
+
+  it("throws when the response shape is invalid (missing required `found`)", async () => {
+    mockFetchOnce({ actor: "dev@example.com" });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await expect(client.getInitiator({ objectUid: "uid-123" })).rejects.toThrow();
+  });
+
+  it("throws a TRPCError for a 500 response", async () => {
+    mockFetchOnce({ code: "internal_error", message: "boom" }, 500);
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await expect(client.getInitiator({ objectUid: "uid-123" })).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
+  });
+
+  it("throws a TRPCError for a 400 response", async () => {
+    mockFetchOnce({ code: "bad_request", message: "provide objectUid" }, 400);
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await expect(client.getInitiator({ kind: "PipelineRun", namespace: "krci", name: "" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+});

--- a/packages/trpc/src/clients/krciAudit/index.ts
+++ b/packages/trpc/src/clients/krciAudit/index.ts
@@ -1,0 +1,151 @@
+import { TRPCError } from "@trpc/server";
+import type { TRPC_ERROR_CODE_KEY } from "@trpc/server/rpc";
+import { KrciAuditInitiator, krciAuditInitiatorSchema, stripTrailingSlash } from "@my-project/shared";
+
+const DEFAULT_TIMEOUT_MS = 10_000; // single-object lookup, keep it snappy
+
+const HTTP_STATUS_TO_TRPC_CODE: Record<number, TRPC_ERROR_CODE_KEY> = {
+  400: "BAD_REQUEST",
+  // 401 → FORBIDDEN (not UNAUTHORIZED): UNAUTHORIZED triggers the portal login redirect,
+  // but a krci-audit auth failure is a downstream issue, not an expired portal session.
+  401: "FORBIDDEN",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  408: "TIMEOUT",
+  429: "TOO_MANY_REQUESTS",
+};
+
+function getTRPCErrorCode(httpStatusCode: number): TRPC_ERROR_CODE_KEY {
+  return HTTP_STATUS_TO_TRPC_CODE[httpStatusCode] ?? "INTERNAL_SERVER_ERROR";
+}
+
+interface KrciAuditConfig {
+  apiBaseURL: string;
+  timeoutMs: number;
+}
+
+function loadConfig(): KrciAuditConfig {
+  return {
+    apiBaseURL: process.env.KRCI_AUDIT_URL || "",
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+  };
+}
+
+const config = loadConfig();
+
+export function createKrciAuditClient(): KrciAuditClient {
+  if (!config.apiBaseURL) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "KRCI_AUDIT_URL environment variable is not configured",
+    });
+  }
+
+  return new KrciAuditClient({
+    apiBaseURL: config.apiBaseURL,
+    timeoutMs: config.timeoutMs,
+  });
+}
+
+export interface KrciAuditClientConfig {
+  apiBaseURL: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Client for the krci-audit read API.
+ *
+ * Security model:
+ * - krci-audit v1 is unprotected; access control is network-level only (ClusterIP, no Ingress)
+ * - No authentication headers are sent
+ */
+export class KrciAuditClient {
+  private readonly apiBaseURL: string;
+  private readonly timeoutMs: number;
+
+  constructor(clientConfig: KrciAuditClientConfig) {
+    const { apiBaseURL, timeoutMs = DEFAULT_TIMEOUT_MS } = clientConfig;
+
+    if (!apiBaseURL) {
+      throw new Error("krci-audit API base URL is not configured");
+    }
+
+    this.apiBaseURL = stripTrailingSlash(apiBaseURL);
+    this.timeoutMs = timeoutMs;
+  }
+
+  private buildEndpoint(path: string, params: Record<string, string>): string {
+    const queryString = new URLSearchParams(Object.entries(params).filter(([, value]) => value !== "")).toString();
+    return queryString ? `${path}?${queryString}` : path;
+  }
+
+  private async fetchJson<T>(endpoint: string): Promise<T> {
+    const url = `${this.apiBaseURL}${endpoint}`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        await this.handleErrorResponse(response, url);
+      }
+
+      return (await response.json()) as T;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new TRPCError({
+          code: "TIMEOUT",
+          message: `krci-audit API request timed out after ${this.timeoutMs}ms`,
+        });
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async handleErrorResponse(response: Response, url: string): Promise<never> {
+    let errorText = "";
+    try {
+      errorText = await response.text();
+    } catch {
+      errorText = "Unable to read error response";
+    }
+
+    const errorMessage = `krci-audit API request failed: ${response.status} ${response.statusText}`;
+
+    console.error(`[krci-audit] Error - URL: ${url}`);
+    console.error(`[krci-audit] Status: ${response.status} ${response.statusText}`);
+    if (errorText) {
+      console.error(`[krci-audit] Response Body: ${errorText}`);
+    }
+
+    throw new TRPCError({
+      code: getTRPCErrorCode(response.status),
+      message: errorText ? `${errorMessage}\nResponse: ${errorText}` : errorMessage,
+    });
+  }
+
+  /**
+   * Resolve the CREATE actor for an object, identified either by its `metadata.uid` or by
+   * `kind + namespace + name` (see krci-audit `oapi.yaml` getInitiator).
+   *
+   * Name-based lookup is the correct key for objects surfaced from Tekton Results history,
+   * whose reconstructed `metadata.uid` is the Results aggregator id, not the K8s object uid.
+   *
+   * @returns `{found: false}` if the object was never audited (not an error)
+   */
+  async getInitiator(query: KrciAuditInitiatorQuery): Promise<KrciAuditInitiator> {
+    const endpoint = this.buildEndpoint("/api/v1/audit/initiator", { ...query });
+    const raw = await this.fetchJson<unknown>(endpoint);
+
+    return krciAuditInitiatorSchema.parse(raw);
+  }
+}
+
+export type KrciAuditInitiatorQuery = { objectUid: string } | { kind: string; namespace: string; name: string };

--- a/packages/trpc/src/routers/index.ts
+++ b/packages/trpc/src/routers/index.ts
@@ -5,6 +5,7 @@ import { configRouter } from "./config/index.js";
 import { dependencyTrackRouter } from "./dependencyTrack/index.js";
 import { gitfusionRouter } from "./gitfusion/index.js";
 import { k8sRouter } from "./k8s/index.js";
+import { krciAuditRouter } from "./krciAudit/index.js";
 import { prometheusRouter } from "./prometheus/index.js";
 import { pipelineRunRouter } from "./pipelineRun/index.js";
 import { sonarqubeRouter } from "./sonarqube/index.js";
@@ -16,6 +17,7 @@ export const appRouter = t.router({
   dependencyTrack: dependencyTrackRouter,
   gitfusion: gitfusionRouter,
   k8s: k8sRouter,
+  krciAudit: krciAuditRouter,
   prometheus: prometheusRouter,
   pipelineRun: pipelineRunRouter,
   sonarqube: sonarqubeRouter,

--- a/packages/trpc/src/routers/krciAudit/index.ts
+++ b/packages/trpc/src/routers/krciAudit/index.ts
@@ -1,0 +1,6 @@
+import { t } from "../../trpc.js";
+import { getTriggeredBy } from "./procedures/index.js";
+
+export const krciAuditRouter = t.router({
+  getTriggeredBy,
+});

--- a/packages/trpc/src/routers/krciAudit/procedures/getTriggeredBy/index.test.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/getTriggeredBy/index.test.ts
@@ -1,0 +1,74 @@
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetInitiator = vi.fn();
+
+vi.mock("../../../../clients/krciAudit/index.js", () => ({
+  createKrciAuditClient: () => ({
+    getInitiator: mockGetInitiator,
+  }),
+}));
+
+describe("krciAudit.getTriggeredBy", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("classifies a human OIDC actor and looks it up by kind+namespace+name", async () => {
+    mockGetInitiator.mockResolvedValue({ found: true, actor: "dev@example.com", operation: "CREATE" });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.krciAudit.getTriggeredBy({ namespace: "krci", name: "run-abc" });
+
+    expect(result).toEqual({ actorClass: "human", actor: "dev@example.com", displayName: "dev@example.com" });
+    expect(mockGetInitiator).toHaveBeenCalledWith({ kind: "PipelineRun", namespace: "krci", name: "run-abc" });
+  });
+
+  it("classifies a service-account actor as automation with its short name", async () => {
+    mockGetInitiator.mockResolvedValue({
+      found: true,
+      actor: "system:serviceaccount:krci:krci-admin",
+      operation: "CREATE",
+    });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.krciAudit.getTriggeredBy({ namespace: "krci", name: "run-sa" });
+
+    expect(result).toEqual({
+      actorClass: "automation",
+      actor: "system:serviceaccount:krci:krci-admin",
+      displayName: "krci-admin",
+    });
+  });
+
+  it("returns unknown when the object was never audited (found:false)", async () => {
+    mockGetInitiator.mockResolvedValue({ found: false });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.krciAudit.getTriggeredBy({ namespace: "krci", name: "run-never-audited" });
+
+    expect(result).toEqual({ actorClass: "unknown" });
+  });
+
+  it("degrades (degraded:true, never throws) when krci-audit is unavailable", async () => {
+    mockGetInitiator.mockRejectedValue(new Error("krci-audit unavailable"));
+
+    const caller = createCaller(mockContext);
+    const result = await caller.krciAudit.getTriggeredBy({ namespace: "krci", name: "run-down" });
+
+    expect(result).toEqual({ actorClass: "unknown", degraded: true });
+  });
+
+  it("rejects a missing name", async () => {
+    const caller = createCaller(mockContext);
+
+    await expect(caller.krciAudit.getTriggeredBy({ namespace: "krci", name: "" })).rejects.toThrow();
+  });
+});

--- a/packages/trpc/src/routers/krciAudit/procedures/getTriggeredBy/index.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/getTriggeredBy/index.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import type { TriggeredBy } from "@my-project/shared";
+import { protectedProcedure } from "../../../../procedures/protected/index.js";
+import { createKrciAuditClient } from "../../../../clients/krciAudit/index.js";
+import { classifyTriggeredByActor } from "./utils.js";
+
+// Looked up by kind+namespace+name so Tekton Results history runs resolve too (see getInitiator).
+const PIPELINE_RUN_KIND = "PipelineRun";
+
+export const getTriggeredByProcedure = protectedProcedure
+  .input(
+    z.object({
+      namespace: z.string().min(1),
+      name: z.string().min(1),
+    })
+  )
+  .query(async ({ input }): Promise<TriggeredBy> => {
+    // krci-audit being unavailable or unconfigured must degrade the field to the
+    // "N/A" placeholder, never fail the PipelineRun details page.
+    try {
+      const client = createKrciAuditClient();
+      const initiator = await client.getInitiator({
+        kind: PIPELINE_RUN_KIND,
+        namespace: input.namespace,
+        name: input.name,
+      });
+      return classifyTriggeredByActor(initiator);
+    } catch (error) {
+      console.error(`[krciAudit] getTriggeredBy failed for ${input.namespace}/${input.name}:`, error);
+      return { actorClass: "unknown", degraded: true };
+    }
+  });

--- a/packages/trpc/src/routers/krciAudit/procedures/getTriggeredBy/utils.test.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/getTriggeredBy/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { classifyTriggeredByActor } from "./utils.js";
+
+describe("classifyTriggeredByActor", () => {
+  it("classifies a human OIDC actor", () => {
+    expect(
+      classifyTriggeredByActor({ found: true, actor: "dev@example.com", operation: "CREATE", timestamp: "t" })
+    ).toEqual({ actorClass: "human", actor: "dev@example.com", displayName: "dev@example.com" });
+  });
+
+  it("classifies a service-account actor and extracts its short name", () => {
+    expect(
+      classifyTriggeredByActor({
+        found: true,
+        actor: "system:serviceaccount:tekton-pipelines:tekton-triggers-sa",
+        operation: "CREATE",
+        timestamp: "t",
+      })
+    ).toEqual({
+      actorClass: "automation",
+      actor: "system:serviceaccount:tekton-pipelines:tekton-triggers-sa",
+      displayName: "tekton-triggers-sa",
+    });
+  });
+
+  it("classifies a non-ServiceAccount system principal as automation without a short name", () => {
+    expect(
+      classifyTriggeredByActor({
+        found: true,
+        actor: "system:kube-controller-manager",
+        operation: "CREATE",
+        timestamp: "t",
+      })
+    ).toEqual({
+      actorClass: "automation",
+      actor: "system:kube-controller-manager",
+      displayName: "system:kube-controller-manager",
+    });
+  });
+
+  it("classifies the system:unknown sentinel as unknown", () => {
+    expect(
+      classifyTriggeredByActor({ found: true, actor: "system:unknown", operation: "CREATE", timestamp: "t" })
+    ).toEqual({ actorClass: "unknown" });
+  });
+
+  it("classifies found:false (never audited) as unknown", () => {
+    expect(classifyTriggeredByActor({ found: false })).toEqual({ actorClass: "unknown" });
+  });
+
+  it("classifies an empty actor string as unknown", () => {
+    expect(classifyTriggeredByActor({ found: true, actor: "" })).toEqual({ actorClass: "unknown" });
+  });
+});

--- a/packages/trpc/src/routers/krciAudit/procedures/getTriggeredBy/utils.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/getTriggeredBy/utils.ts
@@ -1,0 +1,31 @@
+import type { KrciAuditInitiator, TriggeredBy } from "@my-project/shared";
+
+// Mirrors the ServiceAccount-username convention already parsed in
+// mapSelfSubjectReviewToOIDCUser, and krci-audit's identity rules
+// (system: prefix => automation, system:unknown => unresolved sentinel).
+const SERVICE_ACCOUNT_PATTERN = /^system:serviceaccount:([^:]+):([^:]+)$/;
+const SYSTEM_PREFIX = "system:";
+const UNKNOWN_SENTINEL = "system:unknown";
+
+/**
+ * Classifies a krci-audit initiator lookup into the Portal's "Triggered By" shape:
+ * human (avatar/initials), automation (robot indicator), or unknown (placeholder).
+ */
+export function classifyTriggeredByActor(initiator: KrciAuditInitiator): TriggeredBy {
+  const { found, actor } = initiator;
+
+  if (!found || !actor || actor === UNKNOWN_SENTINEL) {
+    return { actorClass: "unknown" };
+  }
+
+  const serviceAccountMatch = actor.match(SERVICE_ACCOUNT_PATTERN);
+  if (serviceAccountMatch) {
+    return { actorClass: "automation", actor, displayName: serviceAccountMatch[2] };
+  }
+
+  if (actor.startsWith(SYSTEM_PREFIX)) {
+    return { actorClass: "automation", actor, displayName: actor };
+  }
+
+  return { actorClass: "human", actor, displayName: actor };
+}

--- a/packages/trpc/src/routers/krciAudit/procedures/index.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/index.ts
@@ -1,0 +1,1 @@
+export { getTriggeredByProcedure as getTriggeredBy } from "./getTriggeredBy/index.js";


### PR DESCRIPTION
Add a "Triggered By" field to the PipelineRun details header that resolves the CREATE actor recorded by krci-audit, distinct from the git commit "Author".

- Add a krci-audit read client and a protected getTriggeredBy tRPC procedure that classifies the initiator into human, automation, or unknown
- Human actors render initials with an email tooltip; service accounts and other system principals render an automation indicator; unresolved actors show "N/A"
- Look up by kind+namespace+name so runs reconstructed from Tekton Results history resolve correctly, not just live runs
- Degrade gracefully (never fail the page) when krci-audit is unavailable or unconfigured, refetching transient failures instead of caching the miss
- Configure the read API via the new KRCI_AUDIT_URL environment variable

