### PR TITLE
EPMDEDP-17179: feat: add admin audit events page with role-based access control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,17 @@ OIDC_CODE_CHALLENGE_METHOD=S256
 
 TEKTON_RESULTS_URL = http://tekton-results.tekton-pipelines.svc.cluster.local:8080
 
-# krci-audit read API. Powers the PipelineRun "Triggered By" information.
+# krci-audit read API. Powers the PipelineRun "Triggered By" information and the
+# admin Audit Events view (Administration section).
 KRCI_AUDIT_URL = http://krci-audit-api.krci-audit:8080
+
+# Comma-separated Keycloak group name(s) bound to the "administrator" role, which
+# gates the Administration section (see packages/shared/src/models/role). Optional;
+# defaults to "administrator" when unset. Format is a comma-separated list — a
+# single group is just a list of one.
+#   one group:       PORTAL_ADMIN_GROUPS = administrator
+#   multiple groups: PORTAL_ADMIN_GROUPS = administrator,platform-admins
+# PORTAL_ADMIN_GROUPS = administrator,platform-admins
 
 # Dependency Track Integration
 DEPENDENCY_TRACK_URL=

--- a/apps/client/src/core/auth/provider/context.ts
+++ b/apps/client/src/core/auth/provider/context.ts
@@ -1,5 +1,6 @@
 import {
   OIDCUser,
+  PortalRole,
   LoginOutput,
   LoginCallbackInput,
   LoginCallbackOutput,
@@ -27,6 +28,10 @@ export type LoginWithTokenMutationInput = LoginWithTokenInput;
 
 export type LoginWithSATokenMutationInput = LoginWithSATokenInput;
 
+// `auth.me` extends `OIDCUser` with the server-computed `roles` verdict. Client role
+// checks (`useHasRole`, `requireRole`) read `roles` directly — they never derive them.
+export type AuthUser = OIDCUser & { roles?: PortalRole[] };
+
 export interface AuthContextValue {
   loginMutation: UseMutationResult<AuthLoginOutput, Error, LoginMutationInput> | null;
   loginCallbackMutation: UseMutationResult<AuthCallbackLoginOutput, Error, AuthCallbackLoginInput> | null;
@@ -37,7 +42,7 @@ export interface AuthContextValue {
     LoginWithSATokenMutationInput
   > | null;
   logoutMutation: UseMutationResult<AuthLogoutOutput, Error, void> | null;
-  user: OIDCUser | undefined;
+  user: AuthUser | undefined;
   isLoading: boolean;
   isAuthenticated: boolean;
   authInProgress: boolean;

--- a/apps/client/src/core/auth/requireRole.test.ts
+++ b/apps/client/src/core/auth/requireRole.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { requireRole } from "./requireRole";
+
+const mockRedirect = vi.fn((opts: unknown) => {
+  const error = new Error("redirect");
+  (error as unknown as { isRedirect: boolean; opts: unknown }).isRedirect = true;
+  (error as unknown as { isRedirect: boolean; opts: unknown }).opts = opts;
+  return error;
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  redirect: (opts: unknown) => {
+    throw mockRedirect(opts);
+  },
+}));
+
+function makeContext(authMe: unknown) {
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(["auth.me"], authMe);
+  return { queryClient };
+}
+
+describe("requireRole", () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+  });
+
+  it("allows a user whose server-computed roles include administrator through without redirecting", () => {
+    const context = makeContext({ roles: ["administrator"] });
+
+    expect(() => requireRole("administrator")({ context })).not.toThrow();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("redirects a user without the administrator role to the Forbidden route (never /auth/login)", () => {
+    const context = makeContext({ roles: [] });
+
+    expect(() => requireRole("administrator")({ context })).toThrow();
+    expect(mockRedirect).toHaveBeenCalledWith({ to: "/forbidden" });
+  });
+
+  it("redirects (fail-closed) when there is no cached auth.me data", () => {
+    const context = makeContext(undefined);
+
+    expect(() => requireRole("administrator")({ context })).toThrow();
+    expect(mockRedirect).toHaveBeenCalledWith({ to: "/forbidden" });
+  });
+
+  it("redirects (fail-closed) when roles is undefined on the cached auth.me data", () => {
+    const context = makeContext({});
+
+    expect(() => requireRole("administrator")({ context })).toThrow();
+    expect(mockRedirect).toHaveBeenCalledWith({ to: "/forbidden" });
+  });
+
+  it("allows a user granted administrator via a custom PORTAL_ADMIN_GROUPS binding server-side", () => {
+    // The client never sees the group binding — only the resolved role from auth.me.
+    const context = makeContext({ roles: ["administrator"] });
+
+    expect(() => requireRole("administrator")({ context })).not.toThrow();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/src/core/auth/requireRole.ts
+++ b/apps/client/src/core/auth/requireRole.ts
@@ -1,0 +1,22 @@
+import { redirect } from "@tanstack/react-router";
+import type { PortalRole } from "@my-project/shared";
+import type { QueryClient } from "@tanstack/react-query";
+import { PATH_FORBIDDEN_FULL } from "@/core/router/paths";
+
+interface CachedAuthMe {
+  roles?: PortalRole[];
+}
+
+// Route-guard for a `beforeLoad`: reads the cached `["auth.me"]` `roles` (the server's
+// verdict, no new fetch). A denial redirects to the in-app `Forbidden` page, NEVER
+// `/auth/login` — an authenticated-but-unauthorized user is not a session expiry.
+export function requireRole(role: PortalRole) {
+  return ({ context }: { context: { queryClient: QueryClient } }) => {
+    const authData = context.queryClient.getQueryData<CachedAuthMe | null | undefined>(["auth.me"]);
+    const roles = authData?.roles ?? [];
+
+    if (!roles.includes(role)) {
+      throw redirect({ to: PATH_FORBIDDEN_FULL });
+    }
+  };
+}

--- a/apps/client/src/core/auth/useHasRole.test.ts
+++ b/apps/client/src/core/auth/useHasRole.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useHasRole } from "./useHasRole";
+
+const mockUseAuth = vi.fn();
+
+vi.mock("@/core/auth/provider", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+describe("useHasRole", () => {
+  it("returns true for a user whose server-computed roles include administrator", () => {
+    mockUseAuth.mockReturnValue({ user: { roles: ["administrator"] } });
+
+    const { result } = renderHook(() => useHasRole("administrator"));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false for a user without the administrator role", () => {
+    mockUseAuth.mockReturnValue({ user: { roles: [] } });
+
+    const { result } = renderHook(() => useHasRole("administrator"));
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false (fail-closed) when there is no user", () => {
+    mockUseAuth.mockReturnValue({ user: undefined });
+
+    const { result } = renderHook(() => useHasRole("administrator"));
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false (fail-closed) when roles is undefined", () => {
+    mockUseAuth.mockReturnValue({ user: { roles: undefined } });
+
+    const { result } = renderHook(() => useHasRole("administrator"));
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true for a user granted administrator via a custom PORTAL_ADMIN_GROUPS binding server-side", () => {
+    // The client never sees the group binding — only the resolved role.
+    mockUseAuth.mockReturnValue({ user: { roles: ["administrator"] } });
+
+    const { result } = renderHook(() => useHasRole("administrator"));
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/client/src/core/auth/useHasRole.ts
+++ b/apps/client/src/core/auth/useHasRole.ts
@@ -1,0 +1,11 @@
+import type { PortalRole } from "@my-project/shared";
+import { useAuth } from "@/core/auth/provider";
+
+// UX-only visibility check (hide a nav entry/section) — NOT the authorization boundary;
+// the server-side `authorizedProcedure` is authoritative. Reads the server-computed
+// `roles` off `auth.me`; the client never derives roles itself.
+export function useHasRole(role: PortalRole): boolean {
+  const { user } = useAuth();
+
+  return user?.roles?.includes(role) ?? false;
+}

--- a/apps/client/src/core/components/Forbidden/Forbidden.stories.tsx
+++ b/apps/client/src/core/components/Forbidden/Forbidden.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withAppProviders } from "@sb/index";
+import Forbidden from "./index";
+
+const meta = {
+  title: "Core/Components/Forbidden",
+  component: Forbidden,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [withAppProviders()],
+} satisfies Meta<typeof Forbidden>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/client/src/core/components/Forbidden/index.tsx
+++ b/apps/client/src/core/components/Forbidden/index.tsx
@@ -1,0 +1,45 @@
+import { Link, useRouter } from "@tanstack/react-router";
+import { ArrowLeft, Home, ShieldOff } from "lucide-react";
+import { Button } from "@/core/components/ui/button";
+import { Badge } from "@/core/components/ui/badge";
+
+function Forbidden() {
+  const router = useRouter();
+
+  return (
+    <div className="flex min-h-[60vh] w-full flex-col items-center justify-center gap-6 p-8 text-center">
+      <div className="bg-muted flex h-20 w-20 items-center justify-center rounded-full">
+        <ShieldOff className="text-muted-foreground h-10 w-10" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h1 className="text-foreground text-3xl font-bold">Access denied</h1>
+        <p className="text-muted-foreground mx-auto max-w-sm text-sm">
+          You don&apos;t have permission to view this page.
+        </p>
+      </div>
+
+      <Badge variant="neutral" className="font-mono">
+        403 &middot; Forbidden
+      </Badge>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+        <Button asChild>
+          <Link to="/home">
+            <Home className="h-4 w-4" />
+            Back to home
+          </Link>
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => (router.history.canGoBack() ? router.history.back() : router.navigate({ to: "/home" }))}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Go back
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default Forbidden;

--- a/apps/client/src/core/components/app-sidebar.tsx
+++ b/apps/client/src/core/components/app-sidebar.tsx
@@ -16,6 +16,7 @@ import { SidebarPinnedSection } from "./sidebar/SidebarPinnedSection";
 import { ModeSwitcher, type Mode } from "@/modules/k8s/components/ModeSwitcher";
 import { K8sSidebar } from "@/modules/k8s/components/K8sSidebar";
 import { useMatches } from "@tanstack/react-router";
+import { useHasRole } from "@/core/auth/useHasRole";
 
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 
@@ -61,7 +62,11 @@ export function AppSidebar() {
     [clusterName]
   );
 
-  const nav = useMemo(() => createNavigationConfig(clusterName, defaultNamespace), [clusterName, defaultNamespace]);
+  const isAdmin = useHasRole("administrator");
+  const nav = useMemo(
+    () => createNavigationConfig(clusterName, defaultNamespace, isAdmin),
+    [clusterName, defaultNamespace, isAdmin]
+  );
 
   const { isMenuOpen, toggleMenu, openMenu, closeMenusExcept } = useSidebarMenu(nav, matches);
 

--- a/apps/client/src/core/components/sidebar/navigationConfig.test.ts
+++ b/apps/client/src/core/components/sidebar/navigationConfig.test.ts
@@ -31,4 +31,41 @@ describe("navigationConfig icon coverage", () => {
     const missing = routes.filter((to) => !PATH_TO_ICON_TYPE[to]);
     expect(missing).toEqual([]);
   });
+
+  it("every KRCI nav route has a PATH_TO_ICON_TYPE entry when the Administration section is included", () => {
+    const items = createNavigationConfig("test-cluster", "test-namespace", true);
+
+    interface NavNode {
+      route?: { to?: string };
+      children?: NavNode[];
+    }
+
+    const routes: string[] = [];
+    const collectRoutes = (nodes: NavNode[]) => {
+      for (const node of nodes) {
+        if (node.route?.to) routes.push(node.route.to);
+        if (node.children?.length) collectRoutes(node.children);
+      }
+    };
+    collectRoutes(items as NavNode[]);
+
+    expect(routes).toContain("/administration/audit-events");
+
+    const missing = routes.filter((to) => !PATH_TO_ICON_TYPE[to]);
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("createNavigationConfig — Administration section", () => {
+  it("omits the Administration section by default (non-admin)", () => {
+    const items = createNavigationConfig("test-cluster", "test-namespace");
+
+    expect(items.some((item) => item.title === "Administration")).toBe(false);
+  });
+
+  it("includes the Administration section when isAdmin is true", () => {
+    const items = createNavigationConfig("test-cluster", "test-namespace", true);
+
+    expect(items.some((item) => item.title === "Administration")).toBe(true);
+  });
 });

--- a/apps/client/src/core/components/sidebar/navigationConfig.ts
+++ b/apps/client/src/core/components/sidebar/navigationConfig.ts
@@ -25,7 +25,7 @@ import {
   Webhook,
   Zap,
 } from "lucide-react";
-import { routeCICD, routeConfiguration, routeObservability, routeSecurity } from "@/core/router";
+import { adminLayoutRoute, routeCICD, routeConfiguration, routeObservability, routeSecurity } from "@/core/router";
 import { PATH_OVERVIEW_FULL } from "@/modules/platform/overview/pages/details/route";
 import { PATH_PIPELINE_METRICS_FULL } from "@/modules/platform/observability/pages/pipeline-metrics/route";
 import { PATH_SCA_FULL } from "@/modules/platform/security/pages/sca/route";
@@ -65,15 +65,16 @@ import { PATH_CONFIG_DEPENDENCY_TRACK_FULL } from "@/modules/platform/configurat
 import { PATH_CONFIG_SONAR_FULL } from "@/modules/platform/configuration/modules/sonar/route";
 import { PATH_CONFIG_GITSERVERS_FULL } from "@/modules/platform/configuration/modules/gitservers/route";
 import { PATH_CONFIG_JIRA_FULL } from "@/modules/platform/configuration/modules/jira/route";
+import { PATH_ADMIN_AUDIT_EVENTS_FULL } from "@/modules/administration/pages/audit-events/route";
 import type { NavItem } from "./types";
 
-export function createNavigationConfig(clusterName: string, namespace: string): NavItem[] {
+export function createNavigationConfig(clusterName: string, namespace: string, isAdmin = false): NavItem[] {
   const clusterDefaultParams = {
     clusterName,
     namespace,
   };
 
-  return [
+  const navItems: NavItem[] = [
     {
       title: "Overview",
       icon: PanelsTopLeft,
@@ -473,5 +474,29 @@ export function createNavigationConfig(clusterName: string, namespace: string): 
         },
       ],
     },
-  ] as const satisfies NavItem[];
+  ];
+
+  // Visibility only — the server-side procedures are the authoritative gate. Extensible
+  // group: add more admin pages as children here (and under the `_admin` route).
+  if (isAdmin) {
+    navItems.push({
+      title: "Administration",
+      icon: ShieldCheck,
+      defaultRoute: {
+        to: PATH_ADMIN_AUDIT_EVENTS_FULL,
+      },
+      groupRoute: adminLayoutRoute,
+      children: [
+        {
+          title: "Audit Events",
+          icon: FileText,
+          route: {
+            to: PATH_ADMIN_AUDIT_EVENTS_FULL,
+          },
+        },
+      ],
+    });
+  }
+
+  return navItems;
 }

--- a/apps/client/src/core/constants/page-icons.ts
+++ b/apps/client/src/core/constants/page-icons.ts
@@ -102,6 +102,9 @@ export const PAGE_ICONS = {
   // Configuration - Management Tool
   "config-jira": FileText,
 
+  // Administration
+  "audit-events": ShieldCheck,
+
   // Detail pages (from ENTITY_ICON)
   project: Box,
   deployment: CloudUpload,
@@ -189,6 +192,9 @@ export const PATH_TO_ICON_TYPE: Record<string, PageIconType> = {
 
   // Configuration - Management Tool
   "/c/$clusterName/configuration/jira": "config-jira",
+
+  // Administration
+  "/administration/audit-events": "audit-events",
 };
 
 /**

--- a/apps/client/src/core/router/index.ts
+++ b/apps/client/src/core/router/index.ts
@@ -13,6 +13,7 @@ import { routeProjectDetails } from "../../modules/platform/codebases/pages/deta
 import {
   authRoute,
   contentLayoutRoute,
+  adminLayoutRoute,
   indexRoute,
   routeCluster,
   routeCICD,
@@ -21,6 +22,8 @@ import {
   routeConfiguration,
   routeK8sMode,
 } from "./routes";
+import { routeForbidden } from "../../modules/administration/pages/forbidden/route";
+import { routeAdminAuditEvents } from "../../modules/administration/pages/audit-events/route";
 import { routeK8sOverview } from "@/modules/k8s/pages/overview/route";
 import { routeK8sList } from "@/modules/k8s/pages/list/route";
 import { routeK8sDetailNamespaced } from "@/modules/k8s/pages/detail-namespaced/route";
@@ -47,6 +50,7 @@ contentLayoutRoute.update({
 export {
   authRoute,
   contentLayoutRoute,
+  adminLayoutRoute,
   indexRoute,
   routeCluster,
   routeCICD,
@@ -124,6 +128,8 @@ const routeTree = rootRoute.addChildren([
     indexRoute,
     routeHome,
     routeSettingsTours,
+    routeForbidden,
+    adminLayoutRoute.addChildren([routeAdminAuditEvents]),
     routeCluster.addChildren([
       routeOverviewDetails,
       routeProjectList,

--- a/apps/client/src/core/router/paths.ts
+++ b/apps/client/src/core/router/paths.ts
@@ -1,0 +1,5 @@
+// Path constants that must be importable from both `routes.ts` (route tree) and
+// `@/core/auth` (route guards) without creating a circular import between them.
+
+export const PATH_FORBIDDEN = "forbidden" as const;
+export const PATH_FORBIDDEN_FULL = "/forbidden" as const;

--- a/apps/client/src/core/router/routes.ts
+++ b/apps/client/src/core/router/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, redirect } from "@tanstack/react-router";
 import { rootRoute } from "./_root";
 import { useClusterStore } from "@/k8s/store";
+import { requireRole } from "@/core/auth/requireRole";
 
 // Route path constants
 export const PATH_AUTH = "auth" as const;
@@ -18,6 +19,14 @@ export const authRoute = createRoute({
 export const contentLayoutRoute = createRoute({
   getParentRoute: () => rootRoute,
   id: "_layout",
+});
+
+// Pathless layout route: one guard gates the whole Administration section; nested
+// admin pages inherit it (parent-first: auth → role).
+export const adminLayoutRoute = createRoute({
+  getParentRoute: () => contentLayoutRoute,
+  id: "_admin",
+  beforeLoad: requireRole("administrator"),
 });
 
 // Index route to redirect "/" to "/home"

--- a/apps/client/src/modules/administration/constants/tables.ts
+++ b/apps/client/src/modules/administration/constants/tables.ts
@@ -1,0 +1,1 @@
+export const TABLE_ID_ADMIN_AUDIT_EVENTS = "admin-audit-events" as const;

--- a/apps/client/src/modules/administration/pages/audit-events/AdminAuditEventsPage.stories.tsx
+++ b/apps/client/src/modules/administration/pages/audit-events/AdminAuditEventsPage.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withAppProviders } from "@sb/index";
+import type { KrciAuditEvent, KrciAuditEventsResponse } from "@my-project/shared";
+import AdminAuditEventsPage from "./page";
+import { defaultAuditEventFilterValues } from "./components/AuditEventFilter/constants";
+import { toAuditEventsQueryInput } from "./hooks/useAuditEvents";
+
+const sampleEvents: KrciAuditEvent[] = [
+  {
+    eventUid: "event-1",
+    receivedAt: "2026-07-08T10:00:00Z",
+    operation: "CREATE",
+    apiGroup: "tekton.dev",
+    apiVersion: "v1",
+    resource: "pipelineruns",
+    kind: "PipelineRun",
+    namespace: "krci",
+    name: "build-test-go-app-main-8a2c",
+    username: "kubernetes-admin",
+    dryRun: false,
+  },
+  {
+    eventUid: "event-2",
+    receivedAt: "2026-07-08T09:00:00Z",
+    operation: "UPDATE",
+    apiGroup: "v2.edp.epam.com",
+    apiVersion: "v1",
+    resource: "codebases",
+    kind: "Codebase",
+    namespace: "krci",
+    name: "test-go-app",
+    username: "system:serviceaccount:krci:krci-admin",
+    dryRun: false,
+  },
+];
+
+function seedAuditEvents(response: KrciAuditEventsResponse) {
+  return (queryClient: import("@tanstack/react-query").QueryClient) => {
+    const queryInput = toAuditEventsQueryInput(defaultAuditEventFilterValues);
+    queryClient.setQueryData(["krciAudit", "getAuditEvents", queryInput], response);
+  };
+}
+
+const meta = {
+  title: "Modules/Administration/AdminAuditEventsPage",
+  component: AdminAuditEventsPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof AdminAuditEventsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithEvents: Story = {
+  decorators: [
+    withAppProviders({
+      seedQueryCache: seedAuditEvents({ data: sampleEvents, pagination: { total: 2, page: 1, perPage: 100 } }),
+    }),
+  ],
+};
+
+export const Empty: Story = {
+  decorators: [
+    withAppProviders({
+      seedQueryCache: seedAuditEvents({ data: [], pagination: { total: 0, page: 1, perPage: 100 } }),
+    }),
+  ],
+};

--- a/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/AuditEventFilter.stories.tsx
+++ b/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/AuditEventFilter.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { withAppProviders } from "@sb/index";
+import { FilterProvider } from "@/core/providers/Filter";
+import type { KrciAuditFacetsResponse } from "@my-project/shared";
+import { AuditEventFilter } from "./index";
+import { defaultAuditEventFilterValues, matchFunctions } from "./constants";
+
+const AUDIT_FACETS_QUERY_KEY = ["krciAudit", "getAuditFacets", ["namespace", "kind", "actor"]];
+
+function seedAuditFacets(response: KrciAuditFacetsResponse) {
+  return (queryClient: import("@tanstack/react-query").QueryClient) => {
+    queryClient.setQueryData(AUDIT_FACETS_QUERY_KEY, response);
+  };
+}
+
+const lowCardinalityFacets: KrciAuditFacetsResponse = {
+  namespace: { values: ["default", "krci", "krci-e2e"], truncated: false },
+  kind: { values: ["PipelineRun", "Codebase", "CDPipeline"], truncated: false },
+  actor: { values: ["kubernetes-admin", "system:serviceaccount:krci:krci-admin"], truncated: false },
+};
+
+const meta = {
+  title: "Modules/Administration/AuditEventFilter",
+  component: AuditEventFilter,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    withAppProviders({
+      contentWrapper: ({ children }) => (
+        <FilterProvider matchFunctions={matchFunctions} defaultValues={defaultAuditEventFilterValues}>
+          <div className="grid grid-cols-12 gap-4">{children}</div>
+        </FilterProvider>
+      ),
+      seedQueryCache: seedAuditFacets(lowCardinalityFacets),
+    }),
+  ],
+} satisfies Meta<typeof AuditEventFilter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Low-cardinality facets (truncated: false) — namespace/kind/actor render as searchable
+// single-select dropdowns sourced from the audit trail.
+export const Default: Story = {};
+
+// Shows the filter fields pre-populated with example values, covering the "filtered"
+// visual state of this component per the repo's .tsx→Storybook convention (see
+// AdminAuditEventsPage.stories.tsx for the corresponding table states).
+export const Filtered: Story = {
+  decorators: [
+    withAppProviders({
+      contentWrapper: ({ children }) => (
+        <FilterProvider
+          matchFunctions={matchFunctions}
+          defaultValues={{
+            ...defaultAuditEventFilterValues,
+            kind: "PipelineRun",
+            namespace: "krci",
+            operation: "CREATE",
+            actor: "kubernetes-admin",
+          }}
+        >
+          <div className="grid grid-cols-12 gap-4">{children}</div>
+        </FilterProvider>
+      ),
+      seedQueryCache: seedAuditFacets(lowCardinalityFacets),
+    }),
+  ],
+};
+
+// A truncated facet (> 50 distinct values) falls back to free text instead of a partial
+// dropdown that would omit the caller's value.
+export const TruncatedFacetsFallBackToFreeText: Story = {
+  decorators: [
+    withAppProviders({
+      contentWrapper: ({ children }) => (
+        <FilterProvider matchFunctions={matchFunctions} defaultValues={defaultAuditEventFilterValues}>
+          <div className="grid grid-cols-12 gap-4">{children}</div>
+        </FilterProvider>
+      ),
+      seedQueryCache: seedAuditFacets({
+        namespace: { values: ["default", "krci"], truncated: false },
+        kind: { values: [], truncated: true },
+        actor: { values: [], truncated: true },
+      }),
+    }),
+  ],
+};

--- a/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/constants.ts
+++ b/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/constants.ts
@@ -1,0 +1,34 @@
+import { MatchFunctions } from "@/core/providers/Filter";
+import type { KrciAuditEvent } from "@my-project/shared";
+import type { AuditEventListFilterValues } from "./types";
+
+export const auditEventFilterControlNames = {
+  KIND: "kind",
+  NAMESPACE: "namespace",
+  OPERATION: "operation",
+  ACTOR: "actor",
+  FROM: "from",
+  TO: "to",
+} as const;
+
+export const defaultAuditEventFilterValues: AuditEventListFilterValues = {
+  [auditEventFilterControlNames.KIND]: "",
+  [auditEventFilterControlNames.NAMESPACE]: "",
+  [auditEventFilterControlNames.OPERATION]: "all",
+  [auditEventFilterControlNames.ACTOR]: "",
+  [auditEventFilterControlNames.FROM]: "",
+  [auditEventFilterControlNames.TO]: "",
+};
+
+export const auditOperationValues = ["CREATE", "UPDATE", "DELETE", "CONNECT"] as const;
+
+// Intentionally no-ops: filtering is done server-side by krci-audit, so the DataTable
+// must NOT re-filter the already-filtered page it receives.
+export const matchFunctions: MatchFunctions<KrciAuditEvent, AuditEventListFilterValues> = {
+  [auditEventFilterControlNames.KIND]: () => true,
+  [auditEventFilterControlNames.NAMESPACE]: () => true,
+  [auditEventFilterControlNames.OPERATION]: () => true,
+  [auditEventFilterControlNames.ACTOR]: () => true,
+  [auditEventFilterControlNames.FROM]: () => true,
+  [auditEventFilterControlNames.TO]: () => true,
+};

--- a/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/hooks/useAuditEventFilter.ts
+++ b/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/hooks/useAuditEventFilter.ts
@@ -1,0 +1,13 @@
+import { useFilterContext } from "@/core/providers/Filter";
+import { useStore } from "@tanstack/react-form";
+import { useDebouncedValue } from "@/core/hooks/useDebouncedValue";
+import type { KrciAuditEvent } from "@my-project/shared";
+import type { AuditEventListFilterValues } from "../types";
+
+export const useAuditEventFilter = () => useFilterContext<KrciAuditEvent, AuditEventListFilterValues>();
+
+export const useDebouncedAuditEventFilterValues = (): AuditEventListFilterValues => {
+  const { form } = useAuditEventFilter();
+  const values = useStore(form.store, (state) => state.values);
+  return useDebouncedValue(values, 300);
+};

--- a/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/index.tsx
+++ b/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/index.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { X } from "lucide-react";
+import { Button } from "@/core/components/ui/button";
+import { Label } from "@/core/components/ui/label";
+import type { SelectOption } from "@/core/components/form";
+import type { KrciAuditFacet } from "@my-project/shared";
+import { auditEventFilterControlNames, auditOperationValues } from "./constants";
+import { useAuditEventFilter } from "./hooks/useAuditEventFilter";
+import { useAuditFacets } from "../../hooks/useAuditFacets";
+
+function toFacetOptions(facet: KrciAuditFacet): SelectOption[] {
+  return facet.values.map((value) => ({ label: value, value }));
+}
+
+export function AuditEventFilter() {
+  const { form, reset, isDefaultValue } = useAuditEventFilter();
+  const facets = useAuditFacets();
+
+  const operationOptions: SelectOption[] = React.useMemo(
+    () => [{ label: "All", value: "all" }, ...auditOperationValues.map((value) => ({ label: value, value }))],
+    []
+  );
+
+  const kindOptions = React.useMemo(() => toFacetOptions(facets.kind), [facets.kind]);
+  const namespaceOptions = React.useMemo(() => toFacetOptions(facets.namespace), [facets.namespace]);
+  const actorOptions = React.useMemo(() => toFacetOptions(facets.actor), [facets.actor]);
+
+  return (
+    <>
+      <div className="col-span-2">
+        <form.AppField name={auditEventFilterControlNames.KIND}>
+          {(field) =>
+            facets.kind.truncated ? (
+              <field.FormTextField label="Kind" placeholder="e.g. PipelineRun" />
+            ) : (
+              <field.FormCombobox label="Kind" placeholder="Select kind" options={kindOptions} />
+            )
+          }
+        </form.AppField>
+      </div>
+
+      <div className="col-span-2">
+        <form.AppField name={auditEventFilterControlNames.NAMESPACE}>
+          {(field) =>
+            facets.namespace.truncated ? (
+              <field.FormTextField label="Namespace" placeholder="Namespace" />
+            ) : (
+              <field.FormCombobox label="Namespace" placeholder="Select namespace" options={namespaceOptions} />
+            )
+          }
+        </form.AppField>
+      </div>
+
+      <div className="col-span-2">
+        <form.AppField name={auditEventFilterControlNames.OPERATION}>
+          {(field) => <field.FormSelect label="Operation" options={operationOptions} placeholder="Select operation" />}
+        </form.AppField>
+      </div>
+
+      <div className="col-span-2">
+        <form.AppField name={auditEventFilterControlNames.ACTOR}>
+          {(field) =>
+            facets.actor.truncated ? (
+              <field.FormTextField label="Actor" placeholder="Username" />
+            ) : (
+              <field.FormCombobox label="Actor" placeholder="Select actor" options={actorOptions} />
+            )
+          }
+        </form.AppField>
+      </div>
+
+      <div className="col-span-2">
+        <form.AppField name={auditEventFilterControlNames.FROM}>
+          {(field) => <field.FormTextField label="From" placeholder="e.g. 2026-07-01T00:00:00Z" />}
+        </form.AppField>
+      </div>
+
+      <div className="col-span-2">
+        <form.AppField name={auditEventFilterControlNames.TO}>
+          {(field) => <field.FormTextField label="To" placeholder="e.g. 2026-07-08T00:00:00Z" />}
+        </form.AppField>
+      </div>
+
+      {!isDefaultValue && (
+        <div className="col-span-1 flex flex-col gap-2">
+          <Label> </Label>
+          <Button variant="secondary" onClick={reset} size="sm" className="mt-0.5">
+            <X size={16} />
+            Clear
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/types.ts
+++ b/apps/client/src/modules/administration/pages/audit-events/components/AuditEventFilter/types.ts
@@ -1,0 +1,13 @@
+import { ValueOf } from "@/core/types/global";
+import { auditEventFilterControlNames } from "./constants";
+
+export type AuditEventFilterNames = ValueOf<typeof auditEventFilterControlNames>;
+
+export type AuditEventListFilterValues = {
+  [auditEventFilterControlNames.KIND]: string;
+  [auditEventFilterControlNames.NAMESPACE]: string;
+  [auditEventFilterControlNames.OPERATION]: string;
+  [auditEventFilterControlNames.ACTOR]: string;
+  [auditEventFilterControlNames.FROM]: string;
+  [auditEventFilterControlNames.TO]: string;
+};

--- a/apps/client/src/modules/administration/pages/audit-events/hooks/useAuditEvents.test.tsx
+++ b/apps/client/src/modules/administration/pages/audit-events/hooks/useAuditEvents.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { AUDIT_EVENTS_DEFAULT_PER_PAGE, useAuditEvents } from "./useAuditEvents";
+import { defaultAuditEventFilterValues } from "../components/AuditEventFilter/constants";
+import type { KrciAuditEventsResponse } from "@my-project/shared";
+
+const mockQuery = vi.fn();
+
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({
+    krciAudit: {
+      getAuditEvents: { query: mockQuery },
+    },
+  }),
+}));
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { Wrapper };
+}
+
+describe("useAuditEvents", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("requests with default filters mapped to undefined (no server-side over-filtering)", async () => {
+    const response: KrciAuditEventsResponse = { data: [], pagination: { total: 0, page: 1, perPage: 20 } };
+    mockQuery.mockResolvedValue(response);
+
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useAuditEvents(defaultAuditEventFilterValues), { wrapper: Wrapper });
+
+    await waitFor(() => expect(mockQuery).toHaveBeenCalled());
+    expect(mockQuery).toHaveBeenCalledWith({
+      kind: undefined,
+      namespace: undefined,
+      operation: undefined,
+      actor: undefined,
+      from: undefined,
+      to: undefined,
+      page: 1,
+      perPage: AUDIT_EVENTS_DEFAULT_PER_PAGE,
+    });
+  });
+
+  it("passes the requested page and page size straight through to krci-audit (server-side paging)", async () => {
+    mockQuery.mockResolvedValue({ data: [], pagination: { total: 250, page: 3, perPage: 50 } });
+
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useAuditEvents(defaultAuditEventFilterValues, 3, 50), { wrapper: Wrapper });
+
+    await waitFor(() => expect(mockQuery).toHaveBeenCalled());
+    expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ page: 3, perPage: 50 }));
+  });
+
+  it("passes non-empty filter values through, mapping the 'all' operation sentinel to undefined", async () => {
+    mockQuery.mockResolvedValue({ data: [], pagination: { total: 0, page: 1, perPage: 100 } });
+
+    const { Wrapper } = makeWrapper();
+    renderHook(
+      () =>
+        useAuditEvents({
+          kind: "PipelineRun",
+          namespace: "krci",
+          operation: "CREATE",
+          actor: "kubernetes-admin",
+          from: "2026-07-01T00:00:00Z",
+          to: "2026-07-08T00:00:00Z",
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await waitFor(() => expect(mockQuery).toHaveBeenCalled());
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "PipelineRun",
+        namespace: "krci",
+        operation: "CREATE",
+        actor: "kubernetes-admin",
+        from: "2026-07-01T00:00:00Z",
+        to: "2026-07-08T00:00:00Z",
+      })
+    );
+  });
+
+  it("exposes the parsed events and total from the response", async () => {
+    const response: KrciAuditEventsResponse = {
+      data: [
+        {
+          eventUid: "event-1",
+          receivedAt: "2026-07-08T00:00:00Z",
+          operation: "CREATE",
+          apiGroup: "tekton.dev",
+          apiVersion: "v1",
+          resource: "pipelineruns",
+          kind: "PipelineRun",
+          namespace: "krci",
+          name: "run-1",
+          username: "kubernetes-admin",
+          dryRun: false,
+        },
+      ],
+      pagination: { total: 1, page: 1, perPage: 100 },
+    };
+    mockQuery.mockResolvedValue(response);
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuditEvents(defaultAuditEventFilterValues), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.events).toHaveLength(1));
+    expect(result.current.total).toBe(1);
+  });
+});

--- a/apps/client/src/modules/administration/pages/audit-events/hooks/useAuditEvents.ts
+++ b/apps/client/src/modules/administration/pages/audit-events/hooks/useAuditEvents.ts
@@ -1,0 +1,67 @@
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useQuery } from "@tanstack/react-query";
+import type { KrciAuditEvent, KrciAuditOperation } from "@my-project/shared";
+import type { AuditEventListFilterValues } from "../components/AuditEventFilter/types";
+
+export const AUDIT_EVENTS_DEFAULT_PER_PAGE = 20;
+
+// krci-audit rejects perPage > 100 (oapi.yaml); callers clamp to this before querying.
+export const AUDIT_EVENTS_MAX_PER_PAGE = 100;
+
+interface UseAuditEventsResult {
+  events: KrciAuditEvent[];
+  total: number;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+function toOperationFilter(value: string): KrciAuditOperation | undefined {
+  return value === "all" || value === "" ? undefined : (value as KrciAuditOperation);
+}
+
+function toStringFilter(value: string): string | undefined {
+  return value === "" ? undefined : value;
+}
+
+// Exported so tests/stories can reconstruct the exact query cache key this hook uses.
+export function toAuditEventsQueryInput(
+  filterValues: AuditEventListFilterValues,
+  page: number = 1,
+  perPage: number = AUDIT_EVENTS_DEFAULT_PER_PAGE
+) {
+  return {
+    kind: toStringFilter(filterValues.kind),
+    namespace: toStringFilter(filterValues.namespace),
+    operation: toOperationFilter(filterValues.operation),
+    actor: toStringFilter(filterValues.actor),
+    from: toStringFilter(filterValues.from),
+    to: toStringFilter(filterValues.to),
+    page,
+    perPage,
+  };
+}
+
+export function useAuditEvents(
+  filterValues: AuditEventListFilterValues,
+  page: number = 1,
+  perPage: number = AUDIT_EVENTS_DEFAULT_PER_PAGE
+): UseAuditEventsResult {
+  const trpc = useTRPCClient();
+
+  const queryInput = toAuditEventsQueryInput(filterValues, page, perPage);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["krciAudit", "getAuditEvents", queryInput],
+    queryFn: () => trpc.krciAudit.getAuditEvents.query(queryInput),
+    // Keep the current page visible while the next page loads so paging doesn't flash
+    // an empty table between fetches.
+    placeholderData: (previousData) => previousData,
+  });
+
+  return {
+    events: data?.data ?? [],
+    total: data?.pagination.total ?? 0,
+    isLoading,
+    error: error as Error | null,
+  };
+}

--- a/apps/client/src/modules/administration/pages/audit-events/hooks/useAuditFacets.test.tsx
+++ b/apps/client/src/modules/administration/pages/audit-events/hooks/useAuditFacets.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useAuditFacets } from "./useAuditFacets";
+import type { KrciAuditFacetsResponse } from "@my-project/shared";
+
+const mockQuery = vi.fn();
+
+vi.mock("@/core/providers/trpc", () => ({
+  useTRPCClient: () => ({
+    krciAudit: {
+      getAuditFacets: { query: mockQuery },
+    },
+  }),
+}));
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { Wrapper };
+}
+
+describe("useAuditFacets", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("requests all three fields", async () => {
+    const response: KrciAuditFacetsResponse = {
+      namespace: { values: ["default", "krci"], truncated: false },
+      kind: { values: ["PipelineRun"], truncated: false },
+      actor: { values: ["kubernetes-admin"], truncated: false },
+    };
+    mockQuery.mockResolvedValue(response);
+
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useAuditFacets(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(mockQuery).toHaveBeenCalled());
+    expect(mockQuery).toHaveBeenCalledWith({ fields: ["namespace", "kind", "actor"] });
+  });
+
+  it("exposes the parsed per-field facets once resolved", async () => {
+    const response: KrciAuditFacetsResponse = {
+      namespace: { values: ["default", "krci"], truncated: false },
+      kind: { values: ["PipelineRun", "Codebase"], truncated: false },
+      actor: { values: ["kubernetes-admin"], truncated: false },
+    };
+    mockQuery.mockResolvedValue(response);
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuditFacets(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.namespace).toEqual({ values: ["default", "krci"], truncated: false });
+    expect(result.current.kind).toEqual({ values: ["PipelineRun", "Codebase"], truncated: false });
+    expect(result.current.actor).toEqual({ values: ["kubernetes-admin"], truncated: false });
+  });
+
+  it("surfaces a truncated field as empty values with truncated:true (free-text fallback)", async () => {
+    const response: KrciAuditFacetsResponse = {
+      namespace: { values: ["default", "krci"], truncated: false },
+      kind: { values: [], truncated: true },
+      actor: { values: [], truncated: true },
+    };
+    mockQuery.mockResolvedValue(response);
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuditFacets(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.kind).toEqual({ values: [], truncated: true });
+    expect(result.current.actor).toEqual({ values: [], truncated: true });
+  });
+
+  it("degrades to empty (non-truncated) facets while loading, so the UI never crashes", () => {
+    mockQuery.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuditFacets(), { wrapper: Wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.namespace).toEqual({ values: [], truncated: false });
+    expect(result.current.kind).toEqual({ values: [], truncated: false });
+    expect(result.current.actor).toEqual({ values: [], truncated: false });
+  });
+
+  it("degrades to empty (non-truncated) facets on a query error", async () => {
+    mockQuery.mockRejectedValue(new Error("boom"));
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useAuditFacets(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.namespace).toEqual({ values: [], truncated: false });
+    expect(result.current.kind).toEqual({ values: [], truncated: false });
+    expect(result.current.actor).toEqual({ values: [], truncated: false });
+  });
+});

--- a/apps/client/src/modules/administration/pages/audit-events/hooks/useAuditFacets.ts
+++ b/apps/client/src/modules/administration/pages/audit-events/hooks/useAuditFacets.ts
@@ -1,0 +1,40 @@
+import { useTRPCClient } from "@/core/providers/trpc";
+import { useQuery } from "@tanstack/react-query";
+import type { KrciAuditFacet, KrciAuditFacetField } from "@my-project/shared";
+
+// The filter always needs the same three fields; `operation` is a fixed enum, not a facet.
+const AUDIT_FACET_FIELDS: KrciAuditFacetField[] = ["namespace", "kind", "actor"];
+
+// Facets change slowly (they reflect the historical audit trail, not live state), so cache
+// aggressively rather than re-fetching every time the filter is opened.
+const AUDIT_FACETS_STALE_TIME_MS = 5 * 60 * 1000;
+const AUDIT_FACETS_GC_TIME_MS = 10 * 60 * 1000;
+
+// Empty-but-not-truncated is the "degrade gracefully" default: while loading or on error the
+// filter still renders a (empty) dropdown for the field instead of crashing.
+const EMPTY_FACET: KrciAuditFacet = { values: [], truncated: false };
+
+export interface UseAuditFacetsResult {
+  namespace: KrciAuditFacet;
+  kind: KrciAuditFacet;
+  actor: KrciAuditFacet;
+  isLoading: boolean;
+}
+
+export function useAuditFacets(): UseAuditFacetsResult {
+  const trpc = useTRPCClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["krciAudit", "getAuditFacets", AUDIT_FACET_FIELDS],
+    queryFn: () => trpc.krciAudit.getAuditFacets.query({ fields: AUDIT_FACET_FIELDS }),
+    staleTime: AUDIT_FACETS_STALE_TIME_MS,
+    gcTime: AUDIT_FACETS_GC_TIME_MS,
+  });
+
+  return {
+    namespace: data?.namespace ?? EMPTY_FACET,
+    kind: data?.kind ?? EMPTY_FACET,
+    actor: data?.actor ?? EMPTY_FACET,
+    isLoading,
+  };
+}

--- a/apps/client/src/modules/administration/pages/audit-events/hooks/useColumns.tsx
+++ b/apps/client/src/modules/administration/pages/audit-events/hooks/useColumns.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import { Tooltip } from "@/core/components/ui/tooltip";
+import { TextWithTooltip } from "@/core/components/TextWithTooltip";
+import { formatTimestamp, formatUnixTimestamp } from "@/core/utils/date-humanize";
+import type { TableColumn } from "@/core/components/Table/types";
+import type { KrciAuditEvent } from "@my-project/shared";
+
+export function useColumns(): TableColumn<KrciAuditEvent>[] {
+  return useMemo(
+    () => [
+      {
+        id: "receivedAt",
+        label: "Timestamp",
+        data: {
+          render: ({ data }) => {
+            if (!data.receivedAt) return "—";
+            return (
+              <Tooltip title={formatUnixTimestamp(data.receivedAt)} delayDuration={500}>
+                <span className="text-sm whitespace-nowrap">{formatTimestamp(data.receivedAt)}</span>
+              </Tooltip>
+            );
+          },
+          columnSortableValuePath: "receivedAt",
+        },
+        cell: { baseWidth: 13 },
+      },
+      {
+        id: "username",
+        label: "Actor",
+        data: {
+          render: ({ data }) => <TextWithTooltip text={data.username ?? "—"} />,
+          columnSortableValuePath: "username",
+        },
+        cell: { baseWidth: 18 },
+      },
+      {
+        id: "operation",
+        label: "Operation",
+        data: {
+          render: ({ data }) => data.operation ?? "—",
+          columnSortableValuePath: "operation",
+        },
+        cell: { baseWidth: 10 },
+      },
+      {
+        id: "kind",
+        label: "Kind",
+        data: {
+          render: ({ data }) => <TextWithTooltip text={data.kind ?? "—"} />,
+          columnSortableValuePath: "kind",
+        },
+        cell: { baseWidth: 14 },
+      },
+      {
+        id: "namespace",
+        label: "Namespace",
+        data: {
+          render: ({ data }) => <TextWithTooltip text={data.namespace ?? "—"} />,
+          columnSortableValuePath: "namespace",
+        },
+        cell: { baseWidth: 14 },
+      },
+      {
+        id: "name",
+        label: "Name",
+        data: {
+          render: ({ data }) => <TextWithTooltip text={data.name ?? "—"} />,
+          columnSortableValuePath: "name",
+        },
+        cell: { baseWidth: 20 },
+      },
+    ],
+    []
+  );
+}

--- a/apps/client/src/modules/administration/pages/audit-events/page.tsx
+++ b/apps/client/src/modules/administration/pages/audit-events/page.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useRef } from "react";
+import { ShieldCheck } from "lucide-react";
+import { EmptyList } from "@/core/components/EmptyList";
+import { PageContentWrapper } from "@/core/components/PageContentWrapper";
+import { PageWrapper } from "@/core/components/PageWrapper";
+import { DataTable } from "@/core/components/Table";
+import { TablePagination } from "@/core/components/Table/components/TablePagination";
+import { FilterProvider } from "@/core/providers/Filter";
+import { usePagination } from "@/core/hooks/usePagination";
+import type { KrciAuditEvent } from "@my-project/shared";
+import { TABLE_ID_ADMIN_AUDIT_EVENTS } from "../../constants/tables";
+import { AuditEventFilter } from "./components/AuditEventFilter";
+import { defaultAuditEventFilterValues, matchFunctions } from "./components/AuditEventFilter/constants";
+import { useDebouncedAuditEventFilterValues } from "./components/AuditEventFilter/hooks/useAuditEventFilter";
+import { AUDIT_EVENTS_DEFAULT_PER_PAGE, AUDIT_EVENTS_MAX_PER_PAGE, useAuditEvents } from "./hooks/useAuditEvents";
+import { useColumns } from "./hooks/useColumns";
+
+export default function AdminAuditEventsPage() {
+  return (
+    <FilterProvider matchFunctions={matchFunctions} syncWithUrl defaultValues={defaultAuditEventFilterValues}>
+      <AdminAuditEventsContent />
+    </FilterProvider>
+  );
+}
+
+function AdminAuditEventsContent() {
+  const columns = useColumns();
+  const filterValues = useDebouncedAuditEventFilterValues();
+
+  // Server-driven pagination: page/perPage go to krci-audit; the DataTable's own client
+  // pager is disabled (it renders just the returned page) and the footer pager below is
+  // sized off the server's true total, so trails larger than one page page properly.
+  const { page, rowsPerPage, handleChangePage, handleChangeRowsPerPage } = usePagination({
+    initialPage: 0,
+    initialRowsPerPage: AUDIT_EVENTS_DEFAULT_PER_PAGE,
+  });
+  const perPage = Math.min(rowsPerPage, AUDIT_EVENTS_MAX_PER_PAGE);
+
+  const { events, total, isLoading, error } = useAuditEvents(filterValues, page + 1, perPage);
+
+  // A filter change shrinks/changes the result set; snap back to the first page so the
+  // user is never stranded on a now-out-of-range page (which the API returns empty).
+  const filterKey = JSON.stringify(filterValues);
+  const prevFilterKey = useRef(filterKey);
+  useEffect(() => {
+    if (prevFilterKey.current !== filterKey) {
+      prevFilterKey.current = filterKey;
+      if (page !== 0) {
+        handleChangePage(null, 0);
+      }
+    }
+  }, [filterKey, page, handleChangePage]);
+
+  const tableSlots = useMemo(
+    () => ({
+      header: {
+        component: <AuditEventFilter />,
+      },
+      footer: {
+        component: (
+          <div className="m-0 px-5 pb-5">
+            <TablePagination
+              dataCount={total}
+              page={page}
+              rowsPerPage={perPage}
+              handleChangePage={handleChangePage}
+              handleChangeRowsPerPage={handleChangeRowsPerPage}
+            />
+          </div>
+        ),
+      },
+    }),
+    [total, page, perPage, handleChangePage, handleChangeRowsPerPage]
+  );
+
+  return (
+    <PageWrapper breadcrumbs={[{ label: "Administration" }, { label: "Audit Events" }]}>
+      <PageContentWrapper
+        icon={ShieldCheck}
+        title="Audit Events"
+        description="Review the audit trail of who created, updated, and deleted resources across the platform."
+      >
+        <DataTable<KrciAuditEvent>
+          id={TABLE_ID_ADMIN_AUDIT_EVENTS}
+          data={events}
+          columns={columns}
+          isLoading={isLoading}
+          errors={error ? [error] : null}
+          slots={tableSlots}
+          pagination={{ show: false }}
+          emptyListComponent={<EmptyList customText="No audit events found" />}
+        />
+      </PageContentWrapper>
+    </PageWrapper>
+  );
+}

--- a/apps/client/src/modules/administration/pages/audit-events/route.lazy.ts
+++ b/apps/client/src/modules/administration/pages/audit-events/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_ADMIN_AUDIT_EVENTS } from "./route";
+import AdminAuditEventsPage from "./page";
+
+const AdminAuditEventsRoute = createLazyRoute(ROUTE_ID_ADMIN_AUDIT_EVENTS)({
+  component: AdminAuditEventsPage,
+});
+
+export default AdminAuditEventsRoute;

--- a/apps/client/src/modules/administration/pages/audit-events/route.ts
+++ b/apps/client/src/modules/administration/pages/audit-events/route.ts
@@ -1,0 +1,16 @@
+import { createRoute } from "@tanstack/react-router";
+import { adminLayoutRoute } from "@/core/router/routes";
+
+export const PATH_ADMIN_AUDIT_EVENTS = "administration/audit-events" as const;
+export const PATH_ADMIN_AUDIT_EVENTS_FULL = "/administration/audit-events" as const;
+export const ROUTE_ID_ADMIN_AUDIT_EVENTS = "/_layout/_admin/administration/audit-events" as const;
+
+// Nested under the `_admin` pathless layout route: the role guard runs once on the
+// parent (`requireRole("administrator")`), so this route needs no guard of its own.
+export const routeAdminAuditEvents = createRoute({
+  getParentRoute: () => adminLayoutRoute,
+  path: PATH_ADMIN_AUDIT_EVENTS,
+  head: () => ({
+    meta: [{ title: "Audit Events | KRCI" }],
+  }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/client/src/modules/administration/pages/forbidden/route.lazy.ts
+++ b/apps/client/src/modules/administration/pages/forbidden/route.lazy.ts
@@ -1,0 +1,9 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { ROUTE_ID_FORBIDDEN } from "./route";
+import Forbidden from "@/core/components/Forbidden";
+
+const ForbiddenRoute = createLazyRoute(ROUTE_ID_FORBIDDEN)({
+  component: Forbidden,
+});
+
+export default ForbiddenRoute;

--- a/apps/client/src/modules/administration/pages/forbidden/route.ts
+++ b/apps/client/src/modules/administration/pages/forbidden/route.ts
@@ -1,0 +1,14 @@
+import { createRoute } from "@tanstack/react-router";
+import { contentLayoutRoute } from "@/core/router/routes";
+import { PATH_FORBIDDEN } from "@/core/router/paths";
+
+export { PATH_FORBIDDEN };
+export const ROUTE_ID_FORBIDDEN = "/_layout/forbidden" as const;
+
+export const routeForbidden = createRoute({
+  getParentRoute: () => contentLayoutRoute,
+  path: PATH_FORBIDDEN,
+  head: () => ({
+    meta: [{ title: "Access Denied | KRCI" }],
+  }),
+}).lazy(() => import("./route.lazy").then((res) => res.default));

--- a/apps/server/env.d.ts
+++ b/apps/server/env.d.ts
@@ -30,6 +30,12 @@ declare global {
 
       GITFUSION_URL: string;
 
+      KRCI_AUDIT_URL: string;
+
+      // Comma-separated Keycloak group name(s) bound to the "administrator" role
+      // (see packages/shared/src/models/role). Optional; defaults to "administrator".
+      PORTAL_ADMIN_GROUPS?: string;
+
       DEPLOY_CLIENT_DIST_DIR?: string;
     }
   }

--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -33,6 +33,7 @@ A Helm chart for KubeRocketCI Portal
 | configEnv.DEPENDENCY_TRACK_URL | string | `"https://deptrack.example.com"` |  |
 | configEnv.DEPLOY_CLIENT_DIST_DIR | string | `"/app/static"` |  |
 | configEnv.GITFUSION_URL | string | `"http://gitfusion.krci:8080"` |  |
+| configEnv.KRCI_AUDIT_URL | string | `"http://krci-audit-api.krci-audit:8080"` |  |
 | configEnv.OIDC_CLIENT_ID | string | `"portal"` |  |
 | configEnv.OIDC_CODE_CHALLENGE_METHOD | string | `"S256"` |  |
 | configEnv.OIDC_ISSUER_URL | string | `"https://keycloak.example.com/realms/shared"` |  |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -47,6 +47,15 @@ configEnv:
   DEPENDENCY_TRACK_URL: https://deptrack.example.com
   # DEPENDENCY_TRACK_WEB_URL: https://deptrack-public.example.com
   GITFUSION_URL: http://gitfusion.krci:8080
+  # KRCI_AUDIT_URL is used by the backend to read the audit trail (krci-audit) for
+  # the "Triggered By" field and the admin Audit Events view.
+  KRCI_AUDIT_URL: http://krci-audit-api.krci-audit:8080
+  # PORTAL_ADMIN_GROUPS is a comma-separated list of Keycloak group name(s) bound to
+  # the "administrator" role (gates the Administration section). Optional; defaults
+  # to "administrator" when unset. A single group is just a list of one.
+  #   one group:       PORTAL_ADMIN_GROUPS: administrator
+  #   multiple groups: PORTAL_ADMIN_GROUPS: administrator,platform-admins
+  # PORTAL_ADMIN_GROUPS: administrator,platform-admins
   # PROMETHEUS_URL is the cluster-local Prometheus base URL used by the Monitoring.
   # When unset, the tab returns PRECONDITION_FAILED.
   # Example (in-cluster): http://prometheus.monitoring.svc:9090

--- a/packages/shared/src/models/auth/schema.ts
+++ b/packages/shared/src/models/auth/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { OIDCUserSchema } from "../user/schema.js";
+import { portalRoleSchema } from "../role/schema.js";
 
 export const loginInputSchema = z.string().startsWith("/");
 
@@ -8,11 +9,14 @@ export const loginCallbackInputSchema = z.string();
 // Shared success-output shape for login procedures that establish a session
 // (callback, direct token, SA token): success flag, resolved user identity
 // (with optional OIDC issuer URL), and the client-side redirect query.
+// `roles` mirrors `auth.me` so the client caches a role-aware user right after login
+// and role guards don't fail closed until the next background refetch.
 export const loginSuccessOutputSchema = z
   .object({
     success: z.boolean(),
     userInfo: OIDCUserSchema.extend({
       issuerUrl: z.string().optional(),
+      roles: z.array(portalRoleSchema),
     }).optional(),
     clientSearch: z.string().optional(),
   })

--- a/packages/shared/src/models/index.ts
+++ b/packages/shared/src/models/index.ts
@@ -7,3 +7,4 @@ export * from "./sonarqube/index.js";
 export * from "./user/index.js";
 export * from "./tektonResults/index.js";
 export * from "./krciAudit/index.js";
+export * from "./role/index.js";

--- a/packages/shared/src/models/krciAudit/schemas.ts
+++ b/packages/shared/src/models/krciAudit/schemas.ts
@@ -1,10 +1,49 @@
 import { z } from "zod";
 
+const krciAuditOperationSchema = z.enum(["CREATE", "UPDATE", "DELETE", "CONNECT"]);
+
 /** Runtime guard for krci-audit's `GET /api/v1/audit/initiator` response, so a schema drift
  *  on krci-audit's side fails loudly (and degrades to "N/A") instead of silently misclassifying. */
 export const krciAuditInitiatorSchema = z.object({
   found: z.boolean(),
   actor: z.string().optional(),
-  operation: z.enum(["CREATE", "UPDATE", "DELETE", "CONNECT"]).optional(),
+  operation: krciAuditOperationSchema.optional(),
   timestamp: z.string().optional(),
+});
+
+export const krciAuditEventSchema = z.object({
+  eventUid: z.string(),
+  receivedAt: z.string(),
+  operation: krciAuditOperationSchema,
+  apiGroup: z.string(),
+  apiVersion: z.string(),
+  resource: z.string(),
+  kind: z.string(),
+  subResource: z.string().nullable().optional(),
+  namespace: z.string(),
+  name: z.string(),
+  objectUid: z.string().nullable().optional(),
+  username: z.string(),
+  dryRun: z.boolean(),
+});
+
+export const krciAuditEventsResponseSchema = z.object({
+  data: z.array(krciAuditEventSchema),
+  pagination: z.object({
+    total: z.number(),
+    page: z.number(),
+    perPage: z.number(),
+  }),
+});
+
+/** Runtime guard for krci-audit's `Facet` schema: `{values, truncated}` (both required). */
+export const krciAuditFacetSchema = z.object({
+  values: z.array(z.string()),
+  truncated: z.boolean(),
+});
+
+export const krciAuditFacetsResponseSchema = z.object({
+  namespace: krciAuditFacetSchema.optional(),
+  kind: krciAuditFacetSchema.optional(),
+  actor: krciAuditFacetSchema.optional(),
 });

--- a/packages/shared/src/models/krciAudit/types.ts
+++ b/packages/shared/src/models/krciAudit/types.ts
@@ -1,6 +1,47 @@
 /** Admission operation recorded by krci-audit on an event. */
 export type KrciAuditOperation = "CREATE" | "UPDATE" | "DELETE" | "CONNECT";
 
+// Mirrors krci-audit's oapi.yaml `AuditEvent` (the lifted, searchable columns).
+export interface KrciAuditEvent {
+  eventUid: string;
+  receivedAt: string;
+  operation: KrciAuditOperation;
+  apiGroup: string;
+  apiVersion: string;
+  resource: string;
+  kind: string;
+  subResource?: string | null;
+  namespace: string;
+  name: string;
+  objectUid?: string | null;
+  username: string;
+  dryRun: boolean;
+}
+
+export interface KrciAuditEventsResponse {
+  data: KrciAuditEvent[];
+  pagination: {
+    total: number;
+    page: number;
+    perPage: number;
+  };
+}
+
+export interface KrciAuditEventsQuery {
+  actor?: string;
+  operation?: KrciAuditOperation;
+  group?: string;
+  resource?: string;
+  kind?: string;
+  namespace?: string;
+  name?: string;
+  objectUid?: string;
+  from?: string;
+  to?: string;
+  page?: number;
+  perPage?: number;
+}
+
 /**
  * Raw shape of krci-audit's `GET /api/v1/audit/initiator` response
  * (the `Initiator` schema). `found: false` means the object was never audited — not an error.
@@ -10,6 +51,26 @@ export interface KrciAuditInitiator {
   actor?: string;
   operation?: KrciAuditOperation;
   timestamp?: string;
+}
+
+/** Facet fields krci-audit can compute distinct values for (`operation` is a fixed enum, not a facet). */
+export type KrciAuditFacetField = "namespace" | "kind" | "actor";
+
+/**
+ * Mirrors krci-audit's oapi.yaml `Facet` schema for one field's distinct values.
+ * When `truncated` is true (> 50 distinct values), `values` is empty by design —
+ * a partial dropdown that omits the caller's value would be worse than free text.
+ */
+export interface KrciAuditFacet {
+  values: string[];
+  truncated: boolean;
+}
+
+/** Mirrors krci-audit's `AuditFacetsResponse`: only the requested fields are present. */
+export interface KrciAuditFacetsResponse {
+  namespace?: KrciAuditFacet;
+  kind?: KrciAuditFacet;
+  actor?: KrciAuditFacet;
 }
 
 export type TriggeredByActorClass = "human" | "automation" | "unknown";

--- a/packages/shared/src/models/role/config.ts
+++ b/packages/shared/src/models/role/config.ts
@@ -1,0 +1,31 @@
+import type { PortalRole, RoleGroupsConfig } from "./types.js";
+
+const DEFAULT_ADMIN_GROUPS = ["administrator"];
+
+// The `typeof process` guard is load-bearing: this module is also bundled into the
+// browser, where `process` is undefined. The client falling back to the default is
+// safe — browser role checks are UX-only; the server is the authoritative gate.
+function readGroupsFromEnv(envVar: string, fallback: string[]): string[] {
+  const raw = typeof process !== "undefined" ? process.env?.[envVar] : undefined;
+
+  if (!raw) {
+    return fallback;
+  }
+
+  const groups = raw
+    .split(",")
+    .map((group) => group.trim())
+    .filter(Boolean);
+
+  return groups.length > 0 ? groups : fallback;
+}
+
+// `PORTAL_ADMIN_GROUPS` (comma-separated) overrides the admin binding so a deployment
+// can rename its admin group without a code change; default is `administrator`.
+export const ROLE_GROUPS: RoleGroupsConfig = {
+  administrator: readGroupsFromEnv("PORTAL_ADMIN_GROUPS", DEFAULT_ADMIN_GROUPS),
+};
+
+export function getRoleGroups(role: PortalRole): string[] {
+  return ROLE_GROUPS[role] ?? [];
+}

--- a/packages/shared/src/models/role/hasRole.test.ts
+++ b/packages/shared/src/models/role/hasRole.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { hasRole, resolvePortalRoles, resolveRoles } from "./hasRole.js";
+
+describe("hasRole", () => {
+  it("returns true when the caller is in the admin group and role is administrator", () => {
+    expect(hasRole(["administrator"], "administrator")).toBe(true);
+  });
+
+  it("returns true when the caller is an administrator, satisfying any role check", () => {
+    // Today "administrator" is the only role, but the admin-superset rule must hold
+    // regardless of which role is being checked (verified against the role itself here;
+    // the superset behavior is exercised again once a second role exists).
+    expect(hasRole(["administrator", "some-other-group"], "administrator")).toBe(true);
+  });
+
+  it("returns false for a caller with unrelated groups (fail-closed)", () => {
+    expect(hasRole(["group-1", "group-2"], "administrator")).toBe(false);
+  });
+
+  it("returns false for an empty groups array (fail-closed)", () => {
+    expect(hasRole([], "administrator")).toBe(false);
+  });
+
+  it("returns false for undefined groups (fail-closed)", () => {
+    expect(hasRole(undefined, "administrator")).toBe(false);
+  });
+
+  it("resolves a configured non-default group name via PORTAL_ADMIN_GROUPS", async () => {
+    const previous = process.env.PORTAL_ADMIN_GROUPS;
+    process.env.PORTAL_ADMIN_GROUPS = "platform-admins";
+
+    try {
+      // Re-import to pick up the env var read at module init.
+      vi.resetModules();
+      const { hasRole: hasRoleWithCustomConfig } = await import("./hasRole.js");
+
+      expect(hasRoleWithCustomConfig(["platform-admins"], "administrator")).toBe(true);
+      expect(hasRoleWithCustomConfig(["administrator"], "administrator")).toBe(false);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PORTAL_ADMIN_GROUPS;
+      } else {
+        process.env.PORTAL_ADMIN_GROUPS = previous;
+      }
+      vi.resetModules();
+    }
+  });
+});
+
+describe("resolveRoles", () => {
+  it("resolves administrator for a caller in the admin group", () => {
+    expect(resolveRoles(["administrator"])).toEqual(["administrator"]);
+  });
+
+  it("resolves no roles for a caller with unrelated groups (fail-closed)", () => {
+    expect(resolveRoles(["group-1"])).toEqual([]);
+  });
+
+  it("resolves no roles for undefined groups (fail-closed)", () => {
+    expect(resolveRoles(undefined)).toEqual([]);
+  });
+
+  it("resolves administrator via a custom PORTAL_ADMIN_GROUPS binding", async () => {
+    const previous = process.env.PORTAL_ADMIN_GROUPS;
+    process.env.PORTAL_ADMIN_GROUPS = "administrator,system:serviceaccounts:krci";
+
+    try {
+      vi.resetModules();
+      const { resolveRoles: resolveRolesWithCustomConfig } = await import("./hasRole.js");
+
+      expect(resolveRolesWithCustomConfig(["system:serviceaccounts:krci"])).toEqual(["administrator"]);
+      expect(resolveRolesWithCustomConfig(["group-1"])).toEqual([]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PORTAL_ADMIN_GROUPS;
+      } else {
+        process.env.PORTAL_ADMIN_GROUPS = previous;
+      }
+      vi.resetModules();
+    }
+  });
+});
+
+describe("resolvePortalRoles", () => {
+  it("resolves roles from group claims for an oidc identity", () => {
+    expect(resolvePortalRoles("oidc", ["administrator"])).toEqual(["administrator"]);
+  });
+
+  it("resolves no roles for an oidc identity with unrelated groups (fail-closed)", () => {
+    expect(resolvePortalRoles("oidc", ["group-1"])).toEqual([]);
+  });
+
+  it("resolves no roles for a serviceaccount identity, regardless of its groups", () => {
+    // The whole point of the decoupling: an SA is never privileged in the portal even
+    // if its Kubernetes groups happen to match an admin binding.
+    expect(resolvePortalRoles("serviceaccount", ["administrator"])).toEqual([]);
+    expect(resolvePortalRoles("serviceaccount", ["system:masters"])).toEqual([]);
+    expect(resolvePortalRoles("serviceaccount", undefined)).toEqual([]);
+  });
+
+  it("resolves no roles for a serviceaccount even when PORTAL_ADMIN_GROUPS would match its groups", async () => {
+    const previous = process.env.PORTAL_ADMIN_GROUPS;
+    process.env.PORTAL_ADMIN_GROUPS = "system:serviceaccounts:krci";
+
+    try {
+      vi.resetModules();
+      const { resolvePortalRoles: resolvePortalRolesWithCustomConfig } = await import("./hasRole.js");
+
+      // Even if an operator binds admin to a K8s group name, the source gate wins.
+      expect(resolvePortalRolesWithCustomConfig("serviceaccount", ["system:serviceaccounts:krci"])).toEqual([]);
+      expect(resolvePortalRolesWithCustomConfig("oidc", ["system:serviceaccounts:krci"])).toEqual(["administrator"]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PORTAL_ADMIN_GROUPS;
+      } else {
+        process.env.PORTAL_ADMIN_GROUPS = previous;
+      }
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/shared/src/models/role/hasRole.ts
+++ b/packages/shared/src/models/role/hasRole.ts
@@ -1,0 +1,41 @@
+import { getRoleGroups } from "./config.js";
+import { ALL_ROLES } from "./types.js";
+import type { AuthSource, PortalRole } from "./types.js";
+
+const ADMIN_ROLE: PortalRole = "administrator";
+
+function isInGroups(callerGroups: string[], role: PortalRole): boolean {
+  const groupsForRole = getRoleGroups(role);
+  return callerGroups.some((group) => groupsForRole.includes(group));
+}
+
+// `administrator` is a superset of every role (an admin satisfies any check without
+// being in that role's group). Fail-closed: undefined/empty groups → no roles → denied.
+// Server-only: `getRoleGroups` reads `PORTAL_ADMIN_GROUPS` from `process.env`, which is
+// undefined in the browser. Client code must never call this directly — it reads the
+// server-computed `roles` on `auth.me` instead (see `resolveRoles` below).
+export function hasRole(groups: string[] | undefined, role: PortalRole): boolean {
+  const callerGroups = groups ?? [];
+
+  if (isInGroups(callerGroups, ADMIN_ROLE)) {
+    return true;
+  }
+
+  return isInGroups(callerGroups, role);
+}
+
+// Server-side derivation of a user's roles from their Kubernetes `groups`, computed once
+// and attached to `auth.me`. The admin-superset rule is preserved because `hasRole`
+// applies it internally for each role checked.
+export function resolveRoles(groups: string[] | undefined): PortalRole[] {
+  return ALL_ROLES.filter((role) => hasRole(groups, role));
+}
+
+// Authorization boundary between authN and authZ: portal roles come from Keycloak
+// (OIDC) group claims ONLY. A `serviceaccount` session authenticates against the
+// cluster (its K8s API access is governed by K8s RBAC), but carries no portal roles —
+// so it is non-privileged in the portal by construction, regardless of its K8s group
+// names. This is the single place role resolution is gated on identity source.
+export function resolvePortalRoles(authSource: AuthSource, groups: string[] | undefined): PortalRole[] {
+  return authSource === "oidc" ? resolveRoles(groups) : [];
+}

--- a/packages/shared/src/models/role/index.ts
+++ b/packages/shared/src/models/role/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./config.js";
+export * from "./hasRole.js";
+export * from "./schema.js";

--- a/packages/shared/src/models/role/schema.ts
+++ b/packages/shared/src/models/role/schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { ALL_ROLES, type PortalRole } from "./types.js";
+
+// Validates the `roles` array returned on `auth.me` — the server-computed verdict the
+// client reads (`user.roles.includes(role)`) instead of re-deriving roles from raw
+// group claims.
+export const portalRoleSchema = z.enum(ALL_ROLES as [PortalRole, ...PortalRole[]]);

--- a/packages/shared/src/models/role/types.ts
+++ b/packages/shared/src/models/role/types.ts
@@ -1,0 +1,14 @@
+// Named `PortalRole`, not `Role`, to avoid colliding with the Kubernetes RBAC `Role`
+// resource type already exported from `@my-project/shared`.
+export type PortalRole = "administrator";
+
+export type RoleGroupsConfig = Record<PortalRole, string[]>;
+
+// How a session's identity was established. Portal roles are authoritative only for
+// `oidc` (Keycloak) identities; `serviceaccount` sessions authenticate against the
+// cluster but never carry portal roles (see `resolvePortalRoles`).
+export type AuthSource = "oidc" | "serviceaccount";
+
+// Every known portal role. Used server-side to derive a user's `roles` from their
+// Kubernetes groups (see `resolveRoles`) and to build `portalRoleSchema`.
+export const ALL_ROLES: PortalRole[] = ["administrator"];

--- a/packages/trpc/src/__mocks__/session.ts
+++ b/packages/trpc/src/__mocks__/session.ts
@@ -21,6 +21,7 @@ export const mockSession = {
       email: "john_doe@world.com",
       picture: "test-picture",
     },
+    authSource: "oidc" as const,
     secret: {
       accessToken: "mockAccessToken",
       accessTokenExpiresAt: Date.now() + 24 * 60 * 60 * 1000, // 24 hours from now

--- a/packages/trpc/src/clients/krciAudit/index.test.ts
+++ b/packages/trpc/src/clients/krciAudit/index.test.ts
@@ -133,3 +133,109 @@ describe("KrciAuditClient.getInitiator", () => {
     });
   });
 });
+
+describe("KrciAuditClient.getAuditEvents", () => {
+  const sampleEvent = {
+    eventUid: "event-1",
+    receivedAt: "2026-07-08T00:00:00Z",
+    operation: "CREATE",
+    apiGroup: "tekton.dev",
+    apiVersion: "v1",
+    resource: "pipelineruns",
+    kind: "PipelineRun",
+    namespace: "krci",
+    name: "run-1",
+    username: "kubernetes-admin",
+    dryRun: false,
+  };
+
+  it("requests with filter/pagination params serialized as query strings", async () => {
+    mockFetchOnce({ data: [sampleEvent], pagination: { total: 1, page: 1, perPage: 20 } });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    const result = await client.getAuditEvents({ kind: "PipelineRun", namespace: "krci", page: 1, perPage: 20 });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.pagination).toEqual({ total: 1, page: 1, perPage: 20 });
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      `${BASE}/api/v1/audit/events?kind=PipelineRun&namespace=krci&page=1&perPage=20`
+    );
+  });
+
+  it("omits undefined filters from the query string", async () => {
+    mockFetchOnce({ data: [], pagination: { total: 0, page: 1, perPage: 20 } });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await client.getAuditEvents({ kind: undefined, actor: "kubernetes-admin" });
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(`${BASE}/api/v1/audit/events?actor=kubernetes-admin`);
+  });
+
+  it("returns an empty list when there is no match (not an error)", async () => {
+    mockFetchOnce({ data: [], pagination: { total: 0, page: 1, perPage: 20 } });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    const result = await client.getAuditEvents({ actor: "no-such-user" });
+
+    expect(result.data).toEqual([]);
+  });
+
+  it("throws when the response shape is invalid (missing required event fields)", async () => {
+    mockFetchOnce({ data: [{ eventUid: "event-1" }], pagination: { total: 1, page: 1, perPage: 20 } });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await expect(client.getAuditEvents({})).rejects.toThrow();
+  });
+
+  it("throws a TRPCError for a 403 response (remapped to FORBIDDEN)", async () => {
+    mockFetchOnce({ code: "forbidden", message: "denied" }, 403);
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await expect(client.getAuditEvents({})).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("KrciAuditClient.getFacets", () => {
+  it("builds a comma-separated fields query string and parses the response", async () => {
+    mockFetchOnce({
+      namespace: { values: ["default", "krci"], truncated: false },
+      kind: { values: ["PipelineRun"], truncated: false },
+      actor: { values: [], truncated: true },
+    });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    const result = await client.getFacets(["namespace", "kind", "actor"]);
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(`${BASE}/api/v1/audit/facets?fields=namespace%2Ckind%2Cactor`);
+    expect(result).toEqual({
+      namespace: { values: ["default", "krci"], truncated: false },
+      kind: { values: ["PipelineRun"], truncated: false },
+      actor: { values: [], truncated: true },
+    });
+  });
+
+  it("omits fields not requested, mirroring the response krci-audit returns for a subset", async () => {
+    mockFetchOnce({ namespace: { values: ["krci"], truncated: false } });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    const result = await client.getFacets(["namespace"]);
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(`${BASE}/api/v1/audit/facets?fields=namespace`);
+    expect(result).toEqual({ namespace: { values: ["krci"], truncated: false } });
+    expect(result.kind).toBeUndefined();
+  });
+
+  it("throws when the response shape is invalid (missing required `truncated`)", async () => {
+    mockFetchOnce({ namespace: { values: ["krci"] } });
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await expect(client.getFacets(["namespace"])).rejects.toThrow();
+  });
+
+  it("throws a TRPCError for a 403 response (remapped to FORBIDDEN)", async () => {
+    mockFetchOnce({ code: "forbidden", message: "denied" }, 403);
+    const client = new KrciAuditClient({ apiBaseURL: BASE });
+
+    await expect(client.getFacets(["namespace", "kind", "actor"])).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/packages/trpc/src/clients/krciAudit/index.ts
+++ b/packages/trpc/src/clients/krciAudit/index.ts
@@ -1,6 +1,16 @@
 import { TRPCError } from "@trpc/server";
 import type { TRPC_ERROR_CODE_KEY } from "@trpc/server/rpc";
-import { KrciAuditInitiator, krciAuditInitiatorSchema, stripTrailingSlash } from "@my-project/shared";
+import {
+  KrciAuditEventsResponse,
+  KrciAuditEventsQuery,
+  KrciAuditFacetField,
+  KrciAuditFacetsResponse,
+  KrciAuditInitiator,
+  krciAuditEventsResponseSchema,
+  krciAuditFacetsResponseSchema,
+  krciAuditInitiatorSchema,
+  stripTrailingSlash,
+} from "@my-project/shared";
 
 const DEFAULT_TIMEOUT_MS = 10_000; // single-object lookup, keep it snappy
 
@@ -146,6 +156,33 @@ export class KrciAuditClient {
 
     return krciAuditInitiatorSchema.parse(raw);
   }
+
+  async getAuditEvents(query: KrciAuditEventsQuery): Promise<KrciAuditEventsResponse> {
+    const endpoint = this.buildEndpoint("/api/v1/audit/events", toQueryParamStrings(query));
+    const raw = await this.fetchJson<unknown>(endpoint);
+
+    return krciAuditEventsResponseSchema.parse(raw);
+  }
+
+  /**
+   * Fetch the bounded (≤50, see `Facet.truncated`) set of distinct values krci-audit has
+   * observed for each requested field, so the portal can offer a dropdown instead of free text.
+   */
+  async getFacets(fields: KrciAuditFacetField[]): Promise<KrciAuditFacetsResponse> {
+    const endpoint = this.buildEndpoint("/api/v1/audit/facets", { fields: fields.join(",") });
+    const raw = await this.fetchJson<unknown>(endpoint);
+
+    return krciAuditFacetsResponseSchema.parse(raw);
+  }
 }
 
 export type KrciAuditInitiatorQuery = { objectUid: string } | { kind: string; namespace: string; name: string };
+
+function toQueryParamStrings(query: KrciAuditEventsQuery): Record<string, string> {
+  return Object.entries(query).reduce<Record<string, string>>((params, [key, value]) => {
+    if (value !== undefined && value !== null) {
+      params[key] = String(value);
+    }
+    return params;
+  }, {});
+}

--- a/packages/trpc/src/context/types.ts
+++ b/packages/trpc/src/context/types.ts
@@ -1,5 +1,5 @@
 import type { FastifySessionObject } from "@fastify/session";
-import type { ISessionStore, OIDCUser } from "@my-project/shared";
+import type { AuthSource, ISessionStore, OIDCUser } from "@my-project/shared";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { OIDCConfig } from "../clients/oidc/index.js";
 
@@ -17,6 +17,9 @@ export type CustomSession = FastifySessionObject & {
   user:
     | {
         data: OIDCUser | undefined;
+        // Which identity provider established this session. Gates portal-role
+        // resolution: only `oidc` sessions carry roles (see `resolvePortalRoles`).
+        authSource: AuthSource;
         secret: {
           idToken: string;
           idTokenExpiresAt: number;

--- a/packages/trpc/src/procedures/authorized/errors.ts
+++ b/packages/trpc/src/procedures/authorized/errors.ts
@@ -1,0 +1,11 @@
+import { TRPCError } from "@trpc/server";
+
+// FORBIDDEN, never UNAUTHORIZED: the global client error handler redirects to the
+// OIDC login flow only on UNAUTHORIZED (see apps/client/src/core/providers/trpc/utils.ts
+// isAuthError). A role denial is not a session expiry and must not bounce an
+// authenticated-but-unauthorized user back through Keycloak.
+export const ERROR_ROLE_FORBIDDEN: TRPCError = {
+  name: "TRPCError",
+  code: "FORBIDDEN",
+  message: "You do not have permission to perform this action.",
+};

--- a/packages/trpc/src/procedures/authorized/index.test.ts
+++ b/packages/trpc/src/procedures/authorized/index.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { t } from "../../trpc.js";
+import { createMockedContext } from "../../__mocks__/context.js";
+import { adminProcedure, authorizedProcedure } from "./index.js";
+
+// Local router — isolates this test from the shared __mocks__/router.ts, which
+// is also exercised by protected/index.test.ts.
+const downstreamBody = vi.fn(() => "downstream-called");
+
+const testRouter = t.router({
+  testAdmin: adminProcedure.query(downstreamBody),
+  testDeveloper: authorizedProcedure("administrator").query(downstreamBody),
+});
+
+const createCaller = t.createCallerFactory(testRouter);
+
+describe("authorizedProcedure / adminProcedure", () => {
+  it("allows an administrator through and runs the procedure body", async () => {
+    downstreamBody.mockClear();
+    const mockContext = createMockedContext();
+    mockContext.session.user!.data!.groups = ["administrator"];
+
+    const caller = createCaller(mockContext);
+    const result = await caller.testAdmin();
+
+    expect(result).toBe("downstream-called");
+    expect(downstreamBody).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a serviceaccount session even when its groups match the admin binding", async () => {
+    // Server enforcement is source-gated identically to auth.me: an SA never satisfies a
+    // role check, so K8s groups that happen to match PORTAL_ADMIN_GROUPS grant nothing.
+    downstreamBody.mockClear();
+    const mockContext = createMockedContext();
+    mockContext.session.user!.authSource = "serviceaccount";
+    mockContext.session.user!.data!.groups = ["administrator"];
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.testAdmin()).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(downstreamBody).not.toHaveBeenCalled();
+  });
+
+  it("rejects an authenticated non-member with FORBIDDEN and never runs the body", async () => {
+    downstreamBody.mockClear();
+    const mockContext = createMockedContext();
+    mockContext.session.user!.data!.groups = ["group-1", "group-2"];
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.testAdmin()).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(downstreamBody).not.toHaveBeenCalled();
+  });
+
+  it("rejects when groups is undefined (fail-closed) and never runs the body", async () => {
+    downstreamBody.mockClear();
+    const mockContext = createMockedContext();
+    mockContext.session.user!.data!.groups = undefined;
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.testAdmin()).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(downstreamBody).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller with UNAUTHORIZED (delegates to protectedProcedure)", async () => {
+    const mockContext = createMockedContext();
+    mockContext.session.user = undefined;
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.testAdmin()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});

--- a/packages/trpc/src/procedures/authorized/index.ts
+++ b/packages/trpc/src/procedures/authorized/index.ts
@@ -1,0 +1,24 @@
+import { TRPCError } from "@trpc/server";
+import { resolvePortalRoles, type PortalRole } from "@my-project/shared";
+import { protectedProcedure } from "../protected/index.js";
+import { ERROR_ROLE_FORBIDDEN } from "./errors.js";
+
+// Server-side enforcement gate. Roles are resolved through the SAME source-aware path
+// as `auth.me`/login (`resolvePortalRoles`): only OIDC identities carry roles, so an SA
+// session is denied regardless of its Kubernetes groups. `protectedProcedure` does NOT
+// narrow `ctx.session.user`, so an absent user/authSource fail-closes to "serviceaccount"
+// → no roles → denied. As tRPC middleware, the check runs before the procedure body.
+export function authorizedProcedure(role: PortalRole) {
+  return protectedProcedure.use(async ({ ctx, next }) => {
+    const user = ctx.session.user;
+    const roles = resolvePortalRoles(user?.authSource ?? "serviceaccount", user?.data?.groups);
+
+    if (!roles.includes(role)) {
+      throw new TRPCError(ERROR_ROLE_FORBIDDEN);
+    }
+
+    return next({ ctx });
+  });
+}
+
+export const adminProcedure = authorizedProcedure("administrator");

--- a/packages/trpc/src/procedures/protected/index.test.ts
+++ b/packages/trpc/src/procedures/protected/index.test.ts
@@ -109,6 +109,7 @@ describe("protected procedure", () => {
       expect(mockValidateTokenAndGetTokenInfo).toHaveBeenCalledWith("valid-jwt-token");
       expect(mockContext.session.user).toEqual({
         data: mockUserInfo,
+        authSource: "oidc",
         secret: mockTokenInfo,
       });
     });
@@ -163,6 +164,7 @@ describe("protected procedure", () => {
           given_name: "Cookie",
           family_name: "User",
         },
+        authSource: "oidc",
         secret: {
           idToken: "cookie-id-token",
           idTokenExpiresAt: 1800000000000,
@@ -256,7 +258,8 @@ describe("protected procedure", () => {
       expect(result).toBe(true);
       expect(mockAuthenticateSA).toHaveBeenCalledWith("any-sa-token");
       expect(mockDiscoverOrThrow).not.toHaveBeenCalled();
-      expect(mockContext.session.user).toEqual(saResult);
+      // Bearer SA path tags the session so role resolution treats it as non-privileged.
+      expect(mockContext.session.user).toEqual({ ...saResult, authSource: "serviceaccount" });
     });
 
     it("routes to the SA path when the token issuer differs from the OIDC issuer", async () => {

--- a/packages/trpc/src/procedures/protected/index.ts
+++ b/packages/trpc/src/procedures/protected/index.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import type { Configuration } from "openid-client";
 import type { FastifyRequest } from "fastify";
-import { type OIDCUser, stripTrailingSlash } from "@my-project/shared";
+import { type AuthSource, type OIDCUser, stripTrailingSlash } from "@my-project/shared";
 import { ERROR_NO_SESSION_FOUND, ERROR_TOKEN_EXPIRED } from "../../routers/auth/errors/index.js";
 import { OIDCClient, type OIDCConfig } from "../../clients/oidc/index.js";
 import { getJwtPayloadClaim } from "../../utils/jwt/index.js";
@@ -119,9 +119,7 @@ function shouldUseOidc(token: string, oidcConfig: OIDCConfig): boolean {
     iss = getJwtPayloadClaim(token, "iss");
   } catch {
     // Not a JWT (e.g. an opaque OIDC access token) — route to OIDC, which
-    // validates it via userinfo. Legacy Secret-based SA tokens (pre-1.22,
-    // non-expiring) are also opaque and would land here; they are unsupported
-    // (SelfSubjectReview requires 1.28+) and correctly surface as UNAUTHORIZED.
+    // validates it via userinfo.
     return true;
   }
 
@@ -135,20 +133,21 @@ function shouldUseOidc(token: string, oidcConfig: OIDCConfig): boolean {
 export async function authenticateBearerToken(
   token: string,
   oidcConfig: OIDCConfig
-): Promise<{ data: OIDCUser; secret: TokenInfo }> {
+): Promise<{ data: OIDCUser; secret: TokenInfo; authSource: AuthSource }> {
   if (shouldUseOidc(token, oidcConfig)) {
     const { client, config } = await getOrRefreshDiscovery(oidcConfig);
 
     const data = await client.validateTokenAndGetUserInfo(config, token);
     const secret = client.validateTokenAndGetTokenInfo(token);
 
-    return { data, secret };
+    return { data, secret, authSource: "oidc" };
   }
 
   // Service Account token (or any token in an OIDC-less deployment): validate
   // against the cluster via SelfSubjectReview. CLI clients can therefore present
-  // an SA token in the Authorization header in any configuration.
-  return authenticateServiceAccountToken(token);
+  // an SA token in the Authorization header in any configuration. SA identities
+  // authenticate but carry no portal roles (see `resolvePortalRoles`).
+  return { ...(await authenticateServiceAccountToken(token)), authSource: "serviceaccount" };
 }
 
 export const protectedProcedure = t.procedure.use(async ({ ctx, next }) => {
@@ -176,6 +175,7 @@ export const protectedProcedure = t.procedure.use(async ({ ctx, next }) => {
 
         session.user = {
           data: sessionUser.data,
+          authSource: sessionUser.authSource,
           secret: newTokens,
         };
       } catch (err) {

--- a/packages/trpc/src/routers/auth/procedures/loginCallback/index.test.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginCallback/index.test.ts
@@ -75,14 +75,28 @@ describe("authLoginCallbackProcedure", () => {
         issuerUrl: mockContext.oidcConfig.issuerURL,
       })
     );
+    // Non-admin groups resolve to no roles — the client caches a role-aware user.
+    expect(result.userInfo?.roles).toEqual([]);
     expect(result.clientSearch).toBe("?redirect=/pipelines");
     expect(mockContext.session.user).toEqual({
       data: mockUserInfo,
+      authSource: "oidc",
       secret: mockNormalizedTokens,
     });
     expect(mockContext.session.login).toBeUndefined();
     expect(mockExchangeCodeForTokens).toHaveBeenCalled();
     expect(mockResolveUser).toHaveBeenCalled();
+  });
+
+  it("resolves administrator role for a user in the admin group", async () => {
+    const adminUserInfo = { ...mockUserInfo, groups: ["administrator"] };
+    mockExchangeCodeForTokens.mockResolvedValue({ access_token: "access-token", claims: () => adminUserInfo });
+    mockResolveUser.mockResolvedValue(adminUserInfo);
+    const caller = createCaller(mockContext);
+
+    const result = await caller.auth.loginCallback(VALID_CALLBACK_URL);
+
+    expect(result.userInfo?.roles).toEqual(["administrator"]);
   });
 
   it("should reject callback URL with wrong origin", async () => {

--- a/packages/trpc/src/routers/auth/procedures/loginCallback/index.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginCallback/index.ts
@@ -1,5 +1,5 @@
 import { publicProcedure } from "../../../../procedures/public/index.js";
-import { loginCallbackInputSchema, loginCallbackOutputSchema } from "@my-project/shared";
+import { loginCallbackInputSchema, loginCallbackOutputSchema, resolvePortalRoles } from "@my-project/shared";
 import { OIDCClient } from "../../../../clients/oidc/index.js";
 import { TRPCError } from "@trpc/server";
 
@@ -42,6 +42,7 @@ export const authLoginCallbackProcedure = publicProcedure
 
     ctx.session.user = {
       data: userInfo,
+      authSource: "oidc",
       secret: normalizedTokens,
     };
 
@@ -50,6 +51,7 @@ export const authLoginCallbackProcedure = publicProcedure
       userInfo: {
         ...userInfo,
         issuerUrl: ctx.oidcConfig.issuerURL || undefined,
+        roles: resolvePortalRoles("oidc", userInfo.groups),
       },
       clientSearch,
     };

--- a/packages/trpc/src/routers/auth/procedures/loginWithServiceAccountToken/index.test.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginWithServiceAccountToken/index.test.ts
@@ -49,8 +49,24 @@ describe("authLoginWithServiceAccountTokenProcedure", () => {
       name: "edp-admin",
       default_namespace: "edp",
     });
+    expect(result.userInfo?.roles).toEqual([]);
     expect(result.clientSearch).toBe("");
-    expect(mockContext.session.user).toEqual({ data, secret });
+    expect(mockContext.session.user).toEqual({ data, authSource: "serviceaccount", secret });
+  });
+
+  it("assigns no portal roles even when the SA's Kubernetes groups match an admin binding", async () => {
+    // Decoupling guarantee: SA identities authenticate but are never privileged in the
+    // portal, so a K8s group named like an admin group must NOT grant a role.
+    mockAuthSA.mockResolvedValueOnce({
+      data: { ...data, groups: ["administrator", "system:masters"] },
+      secret,
+    });
+    const caller = createCaller(mockContext);
+
+    const result = await caller.auth.loginWithServiceAccountToken({ token: "sa-token" });
+
+    expect(result.userInfo?.roles).toEqual([]);
+    expect(mockContext.session.user?.authSource).toBe("serviceaccount");
   });
 
   it("includes redirect in clientSearch when redirectSearchParam is provided", async () => {

--- a/packages/trpc/src/routers/auth/procedures/loginWithServiceAccountToken/index.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginWithServiceAccountToken/index.ts
@@ -1,5 +1,5 @@
 import { publicProcedure } from "../../../../procedures/public/index.js";
-import { loginWithSATokenInputSchema, loginWithSATokenOutputSchema } from "@my-project/shared";
+import { loginWithSATokenInputSchema, loginWithSATokenOutputSchema, resolvePortalRoles } from "@my-project/shared";
 import { authenticateServiceAccountToken } from "../../../../utils/authenticateServiceAccountToken/index.js";
 
 export const authLoginWithServiceAccountTokenProcedure = publicProcedure
@@ -12,13 +12,18 @@ export const authLoginWithServiceAccountTokenProcedure = publicProcedure
     // the session identity + token info. Fully OIDC-independent.
     const { data, secret } = await authenticateServiceAccountToken(token);
 
-    ctx.session.user = { data, secret };
+    ctx.session.user = { data, authSource: "serviceaccount", secret };
 
     const clientSearch = redirectSearchParam ? `?redirect=${redirectSearchParam}` : "";
 
     return {
       success: true,
-      userInfo: data,
+      userInfo: {
+        ...data,
+        // SA sessions authenticate but never carry portal roles — authorization for
+        // them is the cluster's job (K8s RBAC). Always [] regardless of K8s groups.
+        roles: resolvePortalRoles("serviceaccount", data.groups),
+      },
       clientSearch,
     };
   });

--- a/packages/trpc/src/routers/auth/procedures/loginWithToken/index.test.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginWithToken/index.test.ts
@@ -61,9 +61,11 @@ describe("authLoginWithTokenProcedure", () => {
         issuerUrl: mockContext.oidcConfig.issuerURL,
       })
     );
+    expect(result.userInfo?.roles).toEqual([]);
     expect(result.clientSearch).toBe("");
     expect(mockContext.session.user).toEqual({
       data: mockUserInfo,
+      authSource: "oidc",
       secret: mockTokenInfo,
     });
     expect(mockValidateTokenAndGetUserInfo).toHaveBeenCalled();

--- a/packages/trpc/src/routers/auth/procedures/loginWithToken/index.ts
+++ b/packages/trpc/src/routers/auth/procedures/loginWithToken/index.ts
@@ -1,5 +1,5 @@
 import { publicProcedure } from "../../../../procedures/public/index.js";
-import { loginWithTokenInputSchema, loginWithTokenOutputSchema } from "@my-project/shared";
+import { loginWithTokenInputSchema, loginWithTokenOutputSchema, resolvePortalRoles } from "@my-project/shared";
 import { OIDCClient } from "../../../../clients/oidc/index.js";
 
 export const authLoginWithTokenProcedure = publicProcedure
@@ -16,6 +16,7 @@ export const authLoginWithTokenProcedure = publicProcedure
 
     ctx.session.user = {
       data: userInfo,
+      authSource: "oidc",
       secret: tokenInfo,
     };
 
@@ -26,6 +27,7 @@ export const authLoginWithTokenProcedure = publicProcedure
       userInfo: {
         ...userInfo,
         issuerUrl: ctx.oidcConfig.issuerURL || undefined,
+        roles: resolvePortalRoles("oidc", userInfo.groups),
       },
       clientSearch,
     };

--- a/packages/trpc/src/routers/auth/procedures/me/index.test.ts
+++ b/packages/trpc/src/routers/auth/procedures/me/index.test.ts
@@ -1,15 +1,23 @@
 import { createMockedContext } from "../../../../__mocks__/context.js";
 import { mockSession } from "../../../../__mocks__/session.js";
 import { createCaller } from "../../../../routers/index.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ERROR_NO_SESSION_FOUND } from "../../errors/index.js";
 import { TRPCError } from "@trpc/server";
+
+// `createMockedContext` wires `session` directly to the shared `mockSession` singleton
+// (no clone), so a test that mutates `mockContext.session.user` (e.g. the "no session"
+// case below) leaks that mutation into every later test in this file. Snapshot the
+// original user once and restore it before each test so tests stay order-independent.
+const originalMockSessionUser = structuredClone(mockSession.user);
 
 describe("authMeProcedure", () => {
   let mockContext: ReturnType<typeof createMockedContext>;
   let caller: ReturnType<typeof createCaller>;
 
   beforeEach(() => {
+    mockSession.user = structuredClone(originalMockSessionUser);
+
     // Create mocked context
     mockContext = createMockedContext();
 
@@ -20,17 +28,72 @@ describe("authMeProcedure", () => {
     caller = createCaller(mockContext);
   });
 
-  it("should successfully return user data", async () => {
+  it("should successfully return user data with server-computed roles", async () => {
     const result = await caller.auth.me();
 
     expect(result).toEqual({
       ...mockSession.user.data,
       issuerUrl: "https://mock-issuer.example.com",
+      // mockSession.user.data.groups is ["group-1", "group-2"] — not the admin group.
+      roles: [],
     });
   });
 
   it("should throw error if session is not found", async () => {
     mockContext.session.user = undefined;
     await expect(caller.auth.me()).rejects.toThrow(new TRPCError(ERROR_NO_SESSION_FOUND));
+  });
+
+  it("should resolve the administrator role for a user in the default admin group", async () => {
+    mockContext.session.user!.data!.groups = ["administrator"];
+
+    const result = await caller.auth.me();
+
+    expect(result?.roles).toEqual(["administrator"]);
+  });
+
+  it("resolves no roles for a serviceaccount session, even with admin-matching groups", async () => {
+    // Roles are a Keycloak (OIDC) concern; an SA identity is never privileged in the
+    // portal regardless of its Kubernetes groups.
+    mockContext.session.user!.authSource = "serviceaccount";
+    mockContext.session.user!.data!.groups = ["administrator"];
+
+    const result = await caller.auth.me();
+
+    expect(result?.roles).toEqual([]);
+  });
+
+  describe("with a custom PORTAL_ADMIN_GROUPS binding", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      vi.resetModules();
+      process.env = { ...originalEnv, PORTAL_ADMIN_GROUPS: "administrator,system:serviceaccounts:krci" };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+      vi.resetModules();
+    });
+
+    it("resolves the administrator role for a user in the custom admin group", async () => {
+      const { createCaller: createCallerWithCustomConfig } = await import("../../../../routers/index.js");
+      mockContext.session.user!.data!.groups = ["system:serviceaccounts:krci"];
+      const callerWithCustomConfig = createCallerWithCustomConfig(mockContext);
+
+      const result = await callerWithCustomConfig.auth.me();
+
+      expect(result?.roles).toEqual(["administrator"]);
+    });
+
+    it("resolves no roles for a user not in any configured admin group", async () => {
+      const { createCaller: createCallerWithCustomConfig } = await import("../../../../routers/index.js");
+      mockContext.session.user!.data!.groups = ["group-1"];
+      const callerWithCustomConfig = createCallerWithCustomConfig(mockContext);
+
+      const result = await callerWithCustomConfig.auth.me();
+
+      expect(result?.roles).toEqual([]);
+    });
   });
 });

--- a/packages/trpc/src/routers/auth/procedures/me/index.ts
+++ b/packages/trpc/src/routers/auth/procedures/me/index.ts
@@ -1,4 +1,4 @@
-import { MeOutput, OIDCUserSchema } from "@my-project/shared";
+import { MeOutput, OIDCUserSchema, portalRoleSchema, resolvePortalRoles } from "@my-project/shared";
 import { z } from "zod";
 import { protectedProcedure } from "../../../../procedures/protected/index.js";
 
@@ -6,16 +6,23 @@ export const authMeProcedure = protectedProcedure
   .output(
     OIDCUserSchema.extend({
       issuerUrl: z.string().optional(),
+      // Server-computed verdict. Sourced ONLY from Keycloak (OIDC) group claims via
+      // `PORTAL_ADMIN_GROUPS`; SA sessions always resolve to `[]` (see resolvePortalRoles).
+      // The client reads this directly (`roles.includes(role)`) — it never re-derives
+      // roles from raw group claims and never sees the group→role binding.
+      roles: z.array(portalRoleSchema),
     }).optional()
   )
   .query(async ({ ctx }) => {
-    const userData = ctx.session.user?.data satisfies MeOutput;
-    if (!userData) {
+    const sessionUser = ctx.session.user;
+    const userData = sessionUser?.data satisfies MeOutput;
+    if (!userData || !sessionUser) {
       return undefined;
     }
 
     return {
       ...userData,
       issuerUrl: ctx.oidcConfig.issuerURL || undefined,
+      roles: resolvePortalRoles(sessionUser.authSource, userData.groups),
     };
   });

--- a/packages/trpc/src/routers/krciAudit/index.ts
+++ b/packages/trpc/src/routers/krciAudit/index.ts
@@ -1,6 +1,8 @@
 import { t } from "../../trpc.js";
-import { getTriggeredBy } from "./procedures/index.js";
+import { getTriggeredBy, getAuditEvents, getAuditFacets } from "./procedures/index.js";
 
 export const krciAuditRouter = t.router({
   getTriggeredBy,
+  getAuditEvents,
+  getAuditFacets,
 });

--- a/packages/trpc/src/routers/krciAudit/procedures/getAuditEvents/index.test.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/getAuditEvents/index.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+
+const mockGetAuditEvents = vi.fn();
+
+vi.mock("../../../../clients/krciAudit/index.js", () => ({
+  createKrciAuditClient: () => ({
+    getAuditEvents: mockGetAuditEvents,
+  }),
+}));
+
+describe("krciAudit.getAuditEvents", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows an administrator and returns the krci-audit response", async () => {
+    mockContext.session.user!.data!.groups = ["administrator"];
+    mockGetAuditEvents.mockResolvedValue({ data: [], pagination: { total: 0, page: 1, perPage: 20 } });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.krciAudit.getAuditEvents({ kind: "PipelineRun" });
+
+    expect(result).toEqual({ data: [], pagination: { total: 0, page: 1, perPage: 20 } });
+    expect(mockGetAuditEvents).toHaveBeenCalledWith(expect.objectContaining({ kind: "PipelineRun" }));
+  });
+
+  it("denies an authenticated non-administrator with FORBIDDEN, never calling krci-audit", async () => {
+    mockContext.session.user!.data!.groups = ["group-1"];
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.krciAudit.getAuditEvents({})).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mockGetAuditEvents).not.toHaveBeenCalled();
+  });
+
+  it("denies when groups is undefined (fail-closed), never calling krci-audit", async () => {
+    mockContext.session.user!.data!.groups = undefined;
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.krciAudit.getAuditEvents({})).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mockGetAuditEvents).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller with UNAUTHORIZED, never calling krci-audit", async () => {
+    mockContext.session.user = undefined;
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.krciAudit.getAuditEvents({})).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    expect(mockGetAuditEvents).not.toHaveBeenCalled();
+  });
+});

--- a/packages/trpc/src/routers/krciAudit/procedures/getAuditEvents/index.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/getAuditEvents/index.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import type { KrciAuditEventsResponse } from "@my-project/shared";
+import { adminProcedure } from "../../../../procedures/authorized/index.js";
+import { createKrciAuditClient } from "../../../../clients/krciAudit/index.js";
+
+const auditOperationSchema = z.enum(["CREATE", "UPDATE", "DELETE", "CONNECT"]);
+
+export const getAuditEventsInputSchema = z.object({
+  actor: z.string().optional(),
+  operation: auditOperationSchema.optional(),
+  kind: z.string().optional(),
+  namespace: z.string().optional(),
+  name: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  page: z.number().int().min(1).optional(),
+  perPage: z.number().int().min(1).max(100).optional(),
+});
+
+export const getAuditEventsProcedure = adminProcedure
+  .input(getAuditEventsInputSchema)
+  .query(async ({ input }): Promise<KrciAuditEventsResponse> => {
+    const client = createKrciAuditClient();
+
+    return client.getAuditEvents(input);
+  });

--- a/packages/trpc/src/routers/krciAudit/procedures/getAuditFacets/index.test.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/getAuditFacets/index.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockedContext } from "../../../../__mocks__/context.js";
+import { createCaller } from "../../../../routers/index.js";
+
+const mockGetFacets = vi.fn();
+
+vi.mock("../../../../clients/krciAudit/index.js", () => ({
+  createKrciAuditClient: () => ({
+    getFacets: mockGetFacets,
+  }),
+}));
+
+describe("krciAudit.getAuditFacets", () => {
+  let mockContext: ReturnType<typeof createMockedContext>;
+
+  beforeEach(() => {
+    mockContext = createMockedContext();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows an administrator and returns the krci-audit facets response", async () => {
+    mockContext.session.user!.data!.groups = ["administrator"];
+    mockGetFacets.mockResolvedValue({
+      namespace: { values: ["default", "krci"], truncated: false },
+      kind: { values: ["PipelineRun"], truncated: false },
+      actor: { values: [], truncated: true },
+    });
+
+    const caller = createCaller(mockContext);
+    const result = await caller.krciAudit.getAuditFacets({ fields: ["namespace", "kind", "actor"] });
+
+    expect(result).toEqual({
+      namespace: { values: ["default", "krci"], truncated: false },
+      kind: { values: ["PipelineRun"], truncated: false },
+      actor: { values: [], truncated: true },
+    });
+    expect(mockGetFacets).toHaveBeenCalledWith(["namespace", "kind", "actor"]);
+  });
+
+  it("defaults to all three fields when none are requested", async () => {
+    mockContext.session.user!.data!.groups = ["administrator"];
+    mockGetFacets.mockResolvedValue({});
+
+    const caller = createCaller(mockContext);
+    await caller.krciAudit.getAuditFacets({});
+
+    expect(mockGetFacets).toHaveBeenCalledWith(["namespace", "kind", "actor"]);
+  });
+
+  it("denies an authenticated non-administrator with FORBIDDEN, never calling krci-audit", async () => {
+    mockContext.session.user!.data!.groups = ["group-1"];
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.krciAudit.getAuditFacets({})).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mockGetFacets).not.toHaveBeenCalled();
+  });
+
+  it("denies when groups is undefined (fail-closed), never calling krci-audit", async () => {
+    mockContext.session.user!.data!.groups = undefined;
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.krciAudit.getAuditFacets({})).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mockGetFacets).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller with UNAUTHORIZED, never calling krci-audit", async () => {
+    mockContext.session.user = undefined;
+
+    const caller = createCaller(mockContext);
+
+    await expect(caller.krciAudit.getAuditFacets({})).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    expect(mockGetFacets).not.toHaveBeenCalled();
+  });
+});

--- a/packages/trpc/src/routers/krciAudit/procedures/getAuditFacets/index.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/getAuditFacets/index.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import type { KrciAuditFacetField, KrciAuditFacetsResponse } from "@my-project/shared";
+import { adminProcedure } from "../../../../procedures/authorized/index.js";
+import { createKrciAuditClient } from "../../../../clients/krciAudit/index.js";
+
+const auditFacetFieldSchema = z.enum(["namespace", "kind", "actor"]);
+
+// `operation` is deliberately excluded: it's a fixed 4-value enum the client already has,
+// not a value krci-audit needs to compute distinct values for.
+const DEFAULT_FACET_FIELDS: KrciAuditFacetField[] = ["namespace", "kind", "actor"];
+
+export const getAuditFacetsInputSchema = z.object({
+  fields: z.array(auditFacetFieldSchema).optional(),
+});
+
+export const getAuditFacetsProcedure = adminProcedure
+  .input(getAuditFacetsInputSchema)
+  .query(async ({ input }): Promise<KrciAuditFacetsResponse> => {
+    const client = createKrciAuditClient();
+
+    return client.getFacets(input.fields ?? DEFAULT_FACET_FIELDS);
+  });

--- a/packages/trpc/src/routers/krciAudit/procedures/index.ts
+++ b/packages/trpc/src/routers/krciAudit/procedures/index.ts
@@ -1,1 +1,3 @@
 export { getTriggeredByProcedure as getTriggeredBy } from "./getTriggeredBy/index.js";
+export { getAuditEventsProcedure as getAuditEvents } from "./getAuditEvents/index.js";
+export { getAuditFacetsProcedure as getAuditFacets } from "./getAuditFacets/index.js";


### PR DESCRIPTION
- Introduce a portal role model (models/role) that resolves OIDC group membership into portal roles, failing closed and never granting roles to service-account sessions
- Add server-side adminProcedure (built on protectedProcedure) and gate the new getAuditEvents/getAuditFacets krci-audit endpoints behind it
- Propagate authSource and resolved roles through the login and me flows so the client can render UX-only role guards
- Add client requireRole route guard, useHasRole hook, and a Forbidden page, plus the Administration audit events page with filtering, columns, and facets
- Wire the KRCI_AUDIT_URL config into env.d.ts, .env.example, and deploy values

