### PR TITLE
EPMDEDP-17227: fix: restyle notification toasts and close notification interaction gaps

### DIFF
--- a/apps/client/src/core/components/NotificationBell/components/NotificationListRow/NotificationListRow.stories.tsx
+++ b/apps/client/src/core/components/NotificationBell/components/NotificationListRow/NotificationListRow.stories.tsx
@@ -53,8 +53,17 @@ export const Read: Story = {
   },
 };
 
-export const WithoutLinkIsNotClickable: Story = {
+export const UnreadWithoutLinkMarksReadOnClick: Story = {
   args: { notification: { ...baseNotification, link: undefined } },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    canvas.getByRole("button").click();
+    await expect(args.onOpen).toHaveBeenCalledWith({ ...baseNotification, link: undefined });
+  },
+};
+
+export const ReadWithoutLinkIsNotClickable: Story = {
+  args: { notification: { ...baseNotification, link: undefined, read: true } },
   play: async ({ canvasElement }) => {
     await expect(within(canvasElement).queryByRole("button")).not.toBeInTheDocument();
   },

--- a/apps/client/src/core/components/NotificationBell/components/NotificationListRow/index.tsx
+++ b/apps/client/src/core/components/NotificationBell/components/NotificationListRow/index.tsx
@@ -23,14 +23,16 @@ export function NotificationListRow({ notification, onOpen }: NotificationListRo
     </div>
   );
 
-  if (!link) {
+  const interactive = Boolean(link) || !read;
+
+  if (!interactive) {
     return <div className="px-2">{content}</div>;
   }
 
   return (
     <button
       type="button"
-      className="hover:bg-accent w-full rounded-md px-2 text-left transition-colors"
+      className="hover:bg-accent w-full cursor-pointer rounded-md px-2 text-left transition-colors"
       onClick={() => onOpen(notification)}
     >
       {content}

--- a/apps/client/src/core/components/NotificationBell/components/NotificationSeverityIcon/index.tsx
+++ b/apps/client/src/core/components/NotificationBell/components/NotificationSeverityIcon/index.tsx
@@ -1,25 +1,9 @@
-import { CircleCheck, CircleX, Info, TriangleAlert } from "lucide-react";
-import type { ComponentType } from "react";
 import type { NotificationSeverity } from "@my-project/shared";
 import { cn } from "@/core/utils/classname";
-
-const ICON_BY_SEVERITY: Record<NotificationSeverity, ComponentType<{ className?: string }>> = {
-  success: CircleCheck,
-  error: CircleX,
-  warning: TriangleAlert,
-  info: Info,
-};
-
-// Same status color tokens as the Badge severity variants.
-const COLOR_CLASS_BY_SEVERITY: Record<NotificationSeverity, string> = {
-  success: "text-status-success",
-  error: "text-status-error",
-  warning: "text-status-missing",
-  info: "text-status-in-progress",
-};
+import { SEVERITY_ICON, SEVERITY_ICON_COLOR_CLASS } from "@/core/utils/severity";
 
 export function NotificationSeverityIcon({ severity }: { severity: NotificationSeverity }) {
-  const Icon = ICON_BY_SEVERITY[severity];
+  const Icon = SEVERITY_ICON[severity];
 
-  return <Icon className={cn("h-4 w-4 shrink-0", COLOR_CLASS_BY_SEVERITY[severity])} aria-hidden="true" />;
+  return <Icon className={cn("h-4 w-4 shrink-0", SEVERITY_ICON_COLOR_CLASS[severity])} aria-hidden="true" />;
 }

--- a/apps/client/src/core/components/NotificationBell/hooks/useNotificationsMutations.ts
+++ b/apps/client/src/core/components/NotificationBell/hooks/useNotificationsMutations.ts
@@ -18,6 +18,9 @@ export function useMarkNotificationsRead() {
         current?.map((item) => (ids.includes(item.id) ? { ...item, read: true } : item))
       );
     },
+    onError: (error) => {
+      console.error("[useMarkNotificationsRead] markRead failed", error);
+    },
   });
 }
 
@@ -32,6 +35,9 @@ export function useMarkAllNotificationsRead() {
       queryClient.setQueryData<NotificationListItem[]>(notificationsListQueryKey, (current) =>
         current?.map((item) => ({ ...item, read: true }))
       );
+    },
+    onError: (error) => {
+      console.error("[useMarkAllNotificationsRead] markAllRead failed", error);
     },
   });
 }

--- a/apps/client/src/core/components/NotificationBell/index.tsx
+++ b/apps/client/src/core/components/NotificationBell/index.tsx
@@ -37,10 +37,10 @@ export function NotificationBell() {
         <Button
           variant="ghost"
           size="icon"
-          className="relative h-8 w-8 rounded-full text-white hover:bg-white/10"
+          className="relative text-white hover:bg-white/20 hover:text-white"
           title="Notifications"
         >
-          <Bell className="h-4 w-4" />
+          <Bell className="h-5 w-5" />
           {unreadCount > 0 && (
             <Badge
               variant="destructive"

--- a/apps/client/src/core/components/NotificationBell/notificationsSubscriptionRegistry.test.ts
+++ b/apps/client/src/core/components/NotificationBell/notificationsSubscriptionRegistry.test.ts
@@ -35,6 +35,7 @@ describe("notificationsSubscriptionRegistry", () => {
   let handlers: SubscriptionHandlers | null;
   let subscribeSpy: ReturnType<typeof vi.fn>;
   let unsubscribeSpy: ReturnType<typeof vi.fn>;
+  let markReadSpy: ReturnType<typeof vi.fn>;
   let trpcClient: TRPCClient<AppRouter>;
   // The registry is a module singleton — collect cleanups so a failing test
   // can't leak an active subscription into the next one.
@@ -49,8 +50,12 @@ describe("notificationsSubscriptionRegistry", () => {
       handlers = opts;
       return { unsubscribe: unsubscribeSpy };
     });
+    markReadSpy = vi.fn().mockResolvedValue(undefined);
     trpcClient = {
-      notifications: { subscribe: { subscribe: subscribeSpy } },
+      notifications: {
+        subscribe: { subscribe: subscribeSpy },
+        markRead: { mutate: markReadSpy },
+      },
     } as unknown as TRPCClient<AppRouter>;
     cleanups = [];
 
@@ -100,7 +105,11 @@ describe("notificationsSubscriptionRegistry", () => {
     const cached = queryClient.getQueryData<NotificationListItem[]>(notificationsListQueryKey);
     expect(cached?.map((item) => item.id)).toEqual(["evt-new", "evt-old"]);
     expect(cached?.[0].read).toBe(false);
-    expect(showToast).toHaveBeenCalledWith("Build pipeline failed", "error", expect.anything());
+    expect(showToast).toHaveBeenCalledWith(
+      "Build pipeline failed",
+      "error",
+      expect.objectContaining({ id: "evt-new" })
+    );
   });
 
   it("deduplicates a re-delivered event id in the cache", () => {
@@ -111,6 +120,21 @@ describe("notificationsSubscriptionRegistry", () => {
 
     const cached = queryClient.getQueryData<NotificationListItem[]>(notificationsListQueryKey);
     expect(cached).toHaveLength(1);
+  });
+
+  it("marks the event read when the toast link is followed", async () => {
+    join();
+
+    handlers!.onData(buildEvent("evt-1"));
+
+    const options = vi.mocked(showToast).mock.calls[0][2] as { onNavigate?: () => void };
+    options.onNavigate!();
+    await vi.waitFor(() => expect(markReadSpy).toHaveBeenCalledWith({ ids: ["evt-1"] }));
+
+    await vi.waitFor(() => {
+      const cached = queryClient.getQueryData<NotificationListItem[]>(notificationsListQueryKey);
+      expect(cached?.[0].read).toBe(true);
+    });
   });
 
   it("re-arms the subscription after an error while subscribers remain", () => {

--- a/apps/client/src/core/components/NotificationBell/notificationsSubscriptionRegistry.ts
+++ b/apps/client/src/core/components/NotificationBell/notificationsSubscriptionRegistry.ts
@@ -112,10 +112,31 @@ class NotificationsSubscriptionRegistry {
       return [{ ...event, read: false }, ...existing];
     });
 
+    // Same-id replays update the existing toast instead of stacking a duplicate.
     showToast(event.title, event.severity, {
+      id: event.id,
       description: event.body,
       route: event.link ? notificationLinkToRoute(event.link) : undefined,
+      onNavigate: () => this.markEventRead(event.id),
     });
+  }
+
+  // Mirrors useMarkNotificationsRead, which needs React context the registry lacks.
+  private markEventRead(id: string) {
+    if (!this.trpcClient || !this.queryClient) {
+      return;
+    }
+    void this.queryClient.cancelQueries({ queryKey: notificationsListQueryKey });
+    this.trpcClient.notifications.markRead
+      .mutate({ ids: [id] })
+      .then(() => {
+        this.queryClient?.setQueryData<NotificationListItem[]>(notificationsListQueryKey, (current) =>
+          current?.map((item) => (item.id === id ? { ...item, read: true } : item))
+        );
+      })
+      .catch((error) => {
+        console.error("[NotificationsSubscriptionRegistry] markRead failed", error);
+      });
   }
 }
 

--- a/apps/client/src/core/components/Snackbar/index.tsx
+++ b/apps/client/src/core/components/Snackbar/index.tsx
@@ -1,74 +1,41 @@
 import { RouteParams } from "@/core/router/types";
-import { STATUS_COLOR } from "@/k8s/constants/colors";
 import { LoadingSpinner } from "@/core/components/ui/LoadingSpinner";
+import { cn } from "@/core/utils/classname";
+import { Severity, SEVERITY_ICON, SEVERITY_ICON_COLOR_CLASS } from "@/core/utils/severity";
 import { Link } from "@tanstack/react-router";
-import { ChevronDown, ChevronRight, CircleCheck, CircleX, Info, TriangleAlert, X } from "lucide-react";
+import { X } from "lucide-react";
 import { ExternalToast, toast } from "sonner";
-import { useState } from "react";
 
-export type ToastVariant = "success" | "error" | "warning" | "info" | "loading";
+export type ToastVariant = Severity | "loading";
 
-export interface ToastOptions extends ExternalToast {
-  route?: RouteParams;
-  externalLink?: {
-    url: string;
-    text: string;
-  };
-  description?: string;
+interface ExternalLink {
+  url: string;
+  text: string;
 }
 
-// Helper to get variant-specific icon
-const getVariantIcon = (variant: ToastVariant) => {
-  switch (variant) {
-    case "success":
-      return <CircleCheck size={20} />;
-    case "error":
-      return <CircleX size={20} />;
-    case "warning":
-      return <TriangleAlert size={20} />;
-    case "loading":
-      return <LoadingSpinner size={20} />;
-    case "info":
-    default:
-      return <Info size={20} />;
-  }
+// A toast navigates either in-app or externally, never both: with both set the
+// external anchor would nest inside the route Link (invalid HTML, double-fire).
+type ToastLinkOptions = { route?: RouteParams; externalLink?: never } | { route?: never; externalLink?: ExternalLink };
+
+export type ToastOptions = ExternalToast &
+  ToastLinkOptions & {
+    description?: string;
+    /** Called when the user follows the toast's route link. */
+    onNavigate?: () => void;
+  };
+
+const ICON_COLOR_BY_VARIANT: Record<ToastVariant, string> = {
+  ...SEVERITY_ICON_COLOR_CLASS,
+  loading: "text-status-in-progress",
 };
 
-// Helper to get variant-specific styling
-const getVariantStyles = (variant: ToastVariant) => {
-  switch (variant) {
-    case "success":
-      return {
-        backgroundColor: STATUS_COLOR.SUCCESS,
-        borderColor: STATUS_COLOR.SUCCESS,
-        color: "#FFFFFF",
-      };
-    case "error":
-      return {
-        backgroundColor: STATUS_COLOR.ERROR,
-        borderColor: STATUS_COLOR.ERROR,
-        color: "#FFFFFF",
-      };
-    case "warning":
-      return {
-        backgroundColor: STATUS_COLOR.MISSING,
-        borderColor: STATUS_COLOR.MISSING,
-        color: "#FFFFFF",
-      };
-    case "loading":
-      return {
-        backgroundColor: STATUS_COLOR.IN_PROGRESS,
-        borderColor: STATUS_COLOR.IN_PROGRESS,
-        color: "#FFFFFF",
-      };
-    case "info":
-    default:
-      return {
-        backgroundColor: STATUS_COLOR.IN_PROGRESS,
-        borderColor: STATUS_COLOR.IN_PROGRESS,
-        color: "#FFFFFF",
-      };
+// eslint-disable-next-line react-refresh/only-export-components
+const VariantIcon = ({ variant }: { variant: ToastVariant }) => {
+  if (variant === "loading") {
+    return <LoadingSpinner size={16} />;
   }
+  const Icon = SEVERITY_ICON[variant];
+  return <Icon className="h-4 w-4" aria-hidden="true" />;
 };
 
 // Fully custom toast component (Headless approach)
@@ -80,74 +47,66 @@ const CustomToast = ({
   route,
   externalLink,
   description,
+  onNavigate,
 }: {
   id: string | number;
   message: string;
   variant: ToastVariant;
-  route?: RouteParams;
-  externalLink?: { url: string; text: string };
   description?: string;
-}) => {
-  const variantStyles = getVariantStyles(variant);
-  const variantIcon = getVariantIcon(variant);
-  const [isExpanded, setIsExpanded] = useState(false);
+  onNavigate?: () => void;
+} & ToastLinkOptions) => {
+  const content = (
+    <div className="flex items-start gap-3">
+      <span className={cn("mt-0.5 shrink-0", ICON_COLOR_BY_VARIANT[variant])}>
+        <VariantIcon variant={variant} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium group-hover:underline">{message}</p>
+        {description && (
+          <p title={description} className="text-muted-foreground mt-0.5 line-clamp-2 text-xs break-words">
+            {description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
 
   return (
-    <div
-      className="flex max-w-[600px] min-w-[400px] flex-col rounded-lg border px-4 py-3 shadow-lg"
-      style={variantStyles}
-    >
-      <div className="flex items-center gap-3">
-        <div className="shrink-0 text-white">{variantIcon}</div>
-        <div className="flex-1">
-          <p className="text-sm font-medium text-white">{message}</p>
-        </div>
-        {description && (
-          <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            className="flex h-6 w-6 cursor-pointer items-center justify-center p-1 text-white transition-opacity hover:opacity-70"
-            aria-label={isExpanded ? "Collapse details" : "Expand details"}
+    <div className="bg-popover text-popover-foreground flex w-[356px] max-w-[90vw] flex-col rounded-lg border p-3 shadow-lg">
+      <div className="flex items-start gap-2">
+        {route?.to ? (
+          <Link
+            to={route.to}
+            params={route.params}
+            className="group min-w-0 flex-1 text-left"
+            onClick={() => {
+              onNavigate?.();
+              toast.dismiss(id);
+            }}
           >
-            {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-          </button>
+            {content}
+          </Link>
+        ) : (
+          <div className="min-w-0 flex-1">{content}</div>
         )}
-        {(route?.to || externalLink) && (
-          <div className="flex items-center gap-2">
-            {route?.to && (
-              <Link
-                to={route.to}
-                params={route.params}
-                className="text-xs font-medium text-white underline underline-offset-4 hover:no-underline"
-                onClick={() => toast.dismiss()}
-              >
-                Go to page
-              </Link>
-            )}
-            {externalLink && (
-              <a
-                href={externalLink.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs font-medium text-white underline underline-offset-4 hover:no-underline"
-                onClick={() => toast.dismiss()}
-              >
-                {externalLink.text}
-              </a>
-            )}
-          </div>
-        )}
-        <div className={description ? "ml-0" : "ml-4"}>
-          <button
-            onClick={() => toast.dismiss(id)}
-            className="flex h-6 w-6 cursor-pointer items-center justify-center p-1 text-white transition-opacity hover:opacity-70"
-            aria-label="Close toast"
-          >
-            <X size={16} />
-          </button>
-        </div>
+        <button
+          onClick={() => toast.dismiss(id)}
+          className="text-muted-foreground hover:text-foreground -m-1 flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md p-1 transition-colors"
+          aria-label="Dismiss"
+        >
+          <X size={14} />
+        </button>
       </div>
-      {description && isExpanded && (
-        <div className="mt-2 ml-11 text-xs break-words text-white opacity-90">{description}</div>
+      {externalLink && (
+        <a
+          href={externalLink.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary mt-1 ml-7 self-start text-xs font-medium underline underline-offset-4 hover:no-underline"
+          onClick={() => toast.dismiss(id)}
+        >
+          {externalLink.text}
+        </a>
       )}
     </div>
   );
@@ -155,7 +114,7 @@ const CustomToast = ({
 
 // Helper to show toast with optional links
 export const showToast = (message: string, variant: ToastVariant, options?: ToastOptions) => {
-  const { route, externalLink, description, ...sonnerOptions } = options || {};
+  const { route, externalLink, description, onNavigate, ...sonnerOptions } = options || {};
 
   return toast.custom(
     (id) => (
@@ -163,9 +122,9 @@ export const showToast = (message: string, variant: ToastVariant, options?: Toas
         id={id}
         message={message}
         variant={variant}
-        route={route}
-        externalLink={externalLink}
         description={description}
+        onNavigate={onNavigate}
+        {...(route ? { route } : { externalLink })}
       />
     ),
     {

--- a/apps/client/src/core/router/components/root.tsx
+++ b/apps/client/src/core/router/components/root.tsx
@@ -18,7 +18,7 @@ export default function Root() {
             <Outlet />
           </SidebarProvider>
         </div>
-        <Toaster position="top-right" offset="80px" />
+        <Toaster position="top-right" offset={{ top: "calc(var(--header-height) + 8px)", right: 16 }} />
         <K8sRelatedIconsSVGSprite />
         <Scripts />
       </DialogContextProvider>

--- a/apps/client/src/core/utils/severity.ts
+++ b/apps/client/src/core/utils/severity.ts
@@ -1,0 +1,19 @@
+import { CircleCheck, CircleX, Info, TriangleAlert } from "lucide-react";
+import type { ComponentType } from "react";
+
+export type Severity = "success" | "error" | "warning" | "info";
+
+export const SEVERITY_ICON: Record<Severity, ComponentType<{ className?: string }>> = {
+  success: CircleCheck,
+  error: CircleX,
+  warning: TriangleAlert,
+  info: Info,
+};
+
+// Same status color tokens as the Badge severity variants.
+export const SEVERITY_ICON_COLOR_CLASS: Record<Severity, string> = {
+  success: "text-status-success",
+  error: "text-status-error",
+  warning: "text-status-missing",
+  info: "text-status-in-progress",
+};

--- a/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.tsx
+++ b/apps/client/src/k8s/api/hooks/useResourceCRUDMutation/index.tsx
@@ -156,8 +156,9 @@ export const useResourceCRUDMutation = <KubeObjectData extends KubeObjectDraft, 
           showToast(successMessage, "success", {
             id: loadingToastId,
             duration: resolvedSuccessOptions?.duration || 5000,
-            route: resolvedSuccessOptions?.route,
-            externalLink: resolvedSuccessOptions?.externalLink,
+            ...(resolvedSuccessOptions?.route
+              ? { route: resolvedSuccessOptions.route }
+              : { externalLink: resolvedSuccessOptions?.externalLink }),
           });
         })
         .catch((err) => {


### PR DESCRIPTION


- replace the oversized solid-fill toast with a compact neutral-surface design: severity carried by the icon only, description clamped inline instead of behind an expand toggle, whole toast navigates when a link exists
- dedupe reconnect-replayed toasts by event id and mark the notification read on toast navigation, matching the popover row behavior
- make unread linkless notification rows clickable to mark them read; read linkless rows stay inert
- keep the bell icon visible on hover by using the same hover treatment as the other header buttons
- anchor the toaster directly below the header and near the right viewport edge via per-side offsets

