### PR TITLE
EPMDEDP-17203: feat: render cancelled PipelineRuns as a neutral state instead of failed

### DIFF
--- a/apps/client/src/k8s/api/groups/Tekton/PipelineRun/utils/getStatusIcon/index.test.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/PipelineRun/utils/getStatusIcon/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { getStatusIcon } from "./index";
 import { pipelineRunStatus, pipelineRunReason } from "@my-project/shared";
 import { STATUS_COLOR } from "@/k8s/constants/colors";
-import { CircleCheck, CircleX, LoaderCircle, ShieldQuestion } from "lucide-react";
+import { CircleCheck, CircleSlash, CircleX, LoaderCircle, ShieldQuestion } from "lucide-react";
 import type { PipelineRun } from "@my-project/shared";
 
 describe("getStatusIcon", () => {
@@ -78,7 +78,26 @@ describe("getStatusIcon", () => {
     expect(result.isSpinning).toBe(true);
   });
 
-  test("returns suspended icon for unknown status with cancelled reason", () => {
+  test("returns cancelled icon for false status with cancelled reason", () => {
+    const pipelineRun: PipelineRun = {
+      status: {
+        conditions: [
+          {
+            status: pipelineRunStatus.false,
+            reason: pipelineRunReason.cancelled,
+            message: 'PipelineRun "review-foo" was cancelled',
+          },
+        ],
+      },
+    } as unknown as PipelineRun;
+
+    const result = getStatusIcon(pipelineRun);
+
+    expect(result.component).toBe(CircleSlash);
+    expect(result.color).toBe(STATUS_COLOR.CANCELLED);
+  });
+
+  test("returns cancelled icon for unknown status with cancelled reason", () => {
     const pipelineRun: PipelineRun = {
       status: {
         conditions: [{ status: pipelineRunStatus.unknown, reason: pipelineRunReason.cancelled }],
@@ -87,8 +106,47 @@ describe("getStatusIcon", () => {
 
     const result = getStatusIcon(pipelineRun);
 
-    expect(result.component).toBe(CircleX);
-    expect(result.color).toBe(STATUS_COLOR.SUSPENDED);
+    expect(result.component).toBe(CircleSlash);
+    expect(result.color).toBe(STATUS_COLOR.CANCELLED);
+  });
+
+  test("returns cancelled icon for cancelledRunningFinally reason", () => {
+    const pipelineRun: PipelineRun = {
+      status: {
+        conditions: [{ status: pipelineRunStatus.false, reason: pipelineRunReason.cancelledrunningfinally }],
+      },
+    } as unknown as PipelineRun;
+
+    const result = getStatusIcon(pipelineRun);
+
+    expect(result.component).toBe(CircleSlash);
+    expect(result.color).toBe(STATUS_COLOR.CANCELLED);
+  });
+
+  test("returns cancelled icon for stoppedRunningFinally reason", () => {
+    const pipelineRun: PipelineRun = {
+      status: {
+        conditions: [{ status: pipelineRunStatus.false, reason: pipelineRunReason.stoppedrunningfinally }],
+      },
+    } as unknown as PipelineRun;
+
+    const result = getStatusIcon(pipelineRun);
+
+    expect(result.component).toBe(CircleSlash);
+    expect(result.color).toBe(STATUS_COLOR.CANCELLED);
+  });
+
+  test("returns cancelled icon for pipelineRunStopping reason", () => {
+    const pipelineRun: PipelineRun = {
+      status: {
+        conditions: [{ status: pipelineRunStatus.unknown, reason: pipelineRunReason.pipelinerunstopping }],
+      },
+    } as unknown as PipelineRun;
+
+    const result = getStatusIcon(pipelineRun);
+
+    expect(result.component).toBe(CircleSlash);
+    expect(result.color).toBe(STATUS_COLOR.CANCELLED);
   });
 
   test("returns unknown icon for unknown status with unknown reason", () => {

--- a/apps/client/src/k8s/api/groups/Tekton/PipelineRun/utils/getStatusIcon/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/PipelineRun/utils/getStatusIcon/index.ts
@@ -1,10 +1,25 @@
 import { STATUS_COLOR } from "@/k8s/constants/colors";
 import { K8sResourceStatusIcon } from "@/k8s/types";
-import { getPipelineRunStatus, PipelineRun, pipelineRunReason, pipelineRunStatus } from "@my-project/shared";
-import { CircleCheck, CircleX, LoaderCircle, ShieldQuestion } from "lucide-react";
+import {
+  getPipelineRunStatus,
+  isPipelineRunCancelledReason,
+  PipelineRun,
+  pipelineRunReason,
+  pipelineRunStatus,
+} from "@my-project/shared";
+import { CircleCheck, CircleSlash, CircleX, LoaderCircle, ShieldQuestion } from "lucide-react";
 
 export const getStatusIcon = (pipelineRun: PipelineRun | undefined): K8sResourceStatusIcon => {
   const { status, reason } = getPipelineRunStatus(pipelineRun);
+
+  // A cancelled/stopped run is reported by Tekton with condition status "False",
+  // but it is not a failure — render it neutrally (grey) rather than as an error.
+  if (isPipelineRunCancelledReason(reason)) {
+    return {
+      component: CircleSlash,
+      color: STATUS_COLOR.CANCELLED,
+    };
+  }
 
   switch (status) {
     case pipelineRunStatus.unknown:
@@ -21,13 +36,6 @@ export const getStatusIcon = (pipelineRun: PipelineRun | undefined): K8sResource
           component: LoaderCircle,
           color: STATUS_COLOR.IN_PROGRESS,
           isSpinning: true,
-        };
-      }
-
-      if (reason === pipelineRunReason.cancelled) {
-        return {
-          component: CircleX,
-          color: STATUS_COLOR.SUSPENDED,
         };
       }
 

--- a/apps/client/src/k8s/constants/colors.ts
+++ b/apps/client/src/k8s/constants/colors.ts
@@ -5,6 +5,9 @@ export const MAIN_COLOR = {
   GREEN: "#18BE94",
   RED: "#FF005C",
   GREY: "#A2A7B7",
+  // Darker neutral gray used only for the cancelled donut slice, so it stays
+  // separable from the lighter "unknown" grey in that color-only context.
+  DARK_GREY: "#6B7280",
 } as const;
 
 export const STATUS_COLOR = {
@@ -14,6 +17,9 @@ export const STATUS_COLOR = {
   IN_PROGRESS: MAIN_COLOR.BLUE,
   MISSING: MAIN_COLOR.ORANGE,
   UNKNOWN: MAIN_COLOR.GREY,
+  // Light grey for badges/icons: a cancelled run is a non-event and must read as
+  // muted — never more prominent than a green "Succeeded".
+  CANCELLED: MAIN_COLOR.GREY,
 } as const;
 
 export const CHART_STATUS_COLOR = {
@@ -22,4 +28,5 @@ export const CHART_STATUS_COLOR = {
   SUSPENDED: MAIN_COLOR.DARK_PURPLE,
   IN_PROGRESS: MAIN_COLOR.BLUE,
   UNKNOWN: MAIN_COLOR.GREY,
+  CANCELLED: MAIN_COLOR.DARK_GREY,
 } as const;

--- a/apps/client/src/modules/platform/codebases/pages/details/components/BranchList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/details/components/BranchList/hooks/useColumns.tsx
@@ -16,8 +16,11 @@ import { useCodebaseWatch, useGitServerWatch } from "../../../hooks/data";
 import {
   checkIsDefaultBranch,
   codebaseBranchStatus,
+  getPipelineRunReasonLabel,
   getPipelineRunStatus,
+  isPipelineRunCancelledReason,
   pipelineRunReason,
+  type PipelineRunReason,
 } from "@my-project/shared";
 import { Link } from "@tanstack/react-router";
 import { GitBranch, Pin, SquareArrowOutUpRight } from "lucide-react";
@@ -29,9 +32,10 @@ import { PipelineActionsGroup } from "../components/PipelineActionsGroup";
 import { columnNames } from "../constants";
 import { EnrichedBranch } from "../types";
 
-function formatBuildStatusText(reason: string | undefined): string {
+function formatBuildStatusText(reason: PipelineRunReason | undefined): string {
   if (!reason) return "Unknown";
   if (reason === pipelineRunReason.running) return "In progress";
+  if (isPipelineRunCancelledReason(reason)) return getPipelineRunReasonLabel(reason);
   return reason.charAt(0).toUpperCase() + reason.slice(1);
 }
 

--- a/apps/client/src/modules/platform/overview/pages/details/components/PipelineRunsGraph/hooks/usePipelineRunsGraphData.ts
+++ b/apps/client/src/modules/platform/overview/pages/details/components/PipelineRunsGraph/hooks/usePipelineRunsGraphData.ts
@@ -1,5 +1,10 @@
 import { usePipelineRunWatchList } from "@/k8s/api/groups/Tekton/PipelineRun";
-import { getPipelineRunStatus, pipelineRunReason, pipelineRunStatus } from "@my-project/shared";
+import {
+  getPipelineRunStatus,
+  isPipelineRunCancelledReason,
+  pipelineRunReason,
+  pipelineRunStatus,
+} from "@my-project/shared";
 import React from "react";
 
 interface GraphData {
@@ -8,7 +13,7 @@ interface GraphData {
   error: number;
   inProgress: number;
   unknown: number;
-  suspended: number;
+  cancelled: number;
 }
 
 export const usePipelineRunsGraphData = () => {
@@ -22,7 +27,7 @@ export const usePipelineRunsGraphData = () => {
         error: null,
         inProgress: null,
         unknown: null,
-        suspended: null,
+        cancelled: null,
       };
     }
 
@@ -33,14 +38,16 @@ export const usePipelineRunsGraphData = () => {
         const _status = status.toLowerCase();
         const _reason = reason?.toLowerCase() ?? "";
 
+        if (isPipelineRunCancelledReason(reason)) {
+          acc.cancelled++;
+          acc.total++;
+          return acc;
+        }
+
         switch (_status) {
           case pipelineRunStatus.unknown:
             if (_reason === pipelineRunReason.started || _reason === pipelineRunReason.running) {
               acc.inProgress++;
-            }
-
-            if (_reason === pipelineRunReason.cancelled) {
-              acc.suspended++;
             }
             break;
           case pipelineRunStatus.true:
@@ -64,7 +71,7 @@ export const usePipelineRunsGraphData = () => {
         error: 0,
         inProgress: 0,
         unknown: 0,
-        suspended: 0,
+        cancelled: 0,
       }
     );
   }, [pipelineRunListWatch.data.array, pipelineRunListWatch.query.data, pipelineRunListWatch.query.isFetching]);

--- a/apps/client/src/modules/platform/overview/pages/details/components/PipelineRunsGraph/index.tsx
+++ b/apps/client/src/modules/platform/overview/pages/details/components/PipelineRunsGraph/index.tsx
@@ -27,6 +27,11 @@ export const PipelineRunsGraph = () => {
           fill: CHART_STATUS_COLOR.ERROR,
         },
         {
+          name: "Cancelled",
+          value: graphData.cancelled!,
+          fill: CHART_STATUS_COLOR.CANCELLED,
+        },
+        {
           name: "Unknown",
           value: graphData.unknown!,
           fill: CHART_STATUS_COLOR.UNKNOWN,
@@ -39,8 +44,8 @@ export const PipelineRunsGraph = () => {
           {!!graphData.error && (
             <LegendListItem color={CHART_STATUS_COLOR.ERROR} number={graphData.error} label="Failed" />
           )}
-          {!!graphData.suspended && (
-            <LegendListItem color={CHART_STATUS_COLOR.SUSPENDED} number={graphData.suspended} label="Suspended" />
+          {!!graphData.cancelled && (
+            <LegendListItem color={CHART_STATUS_COLOR.CANCELLED} number={graphData.cancelled} label="Cancelled" />
           )}
           {!!graphData.inProgress && (
             <LegendListItem color={CHART_STATUS_COLOR.IN_PROGRESS} number={graphData.inProgress} label="In Progress" />

--- a/apps/client/src/modules/platform/overview/pages/details/utils/pipelineRunStatusDisplay.test.ts
+++ b/apps/client/src/modules/platform/overview/pages/details/utils/pipelineRunStatusDisplay.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import { PipelineRun } from "@my-project/shared";
+import { CheckCircle2, CircleSlash, XCircle, PlayCircle, Clock } from "lucide-react";
+import { getStatusDisplay } from "./pipelineRunStatusDisplay";
+
+const makeRun = (status: string, reason?: string): PipelineRun =>
+  ({
+    metadata: { name: "x", namespace: "ns", labels: {}, annotations: {} },
+    spec: {},
+    status: { conditions: [{ status, reason }] },
+  }) as unknown as PipelineRun;
+
+describe("getStatusDisplay", () => {
+  test("succeeded run", () => {
+    expect(getStatusDisplay(makeRun("True", "Succeeded"))).toEqual({
+      label: "Succeeded",
+      variant: "success",
+      icon: CheckCircle2,
+    });
+  });
+
+  test("failed run", () => {
+    expect(getStatusDisplay(makeRun("False", "Failed"))).toEqual({
+      label: "Failed",
+      variant: "error",
+      icon: XCircle,
+    });
+  });
+
+  test("running run", () => {
+    expect(getStatusDisplay(makeRun("Unknown", "Running"))).toEqual({
+      label: "Running",
+      variant: "info",
+      icon: PlayCircle,
+    });
+  });
+
+  test.each(["Cancelled", "CancelledRunningFinally", "StoppedRunningFinally"])(
+    "cancelled run (%s, status False) is neutral, not a failure",
+    (reason) => {
+      expect(getStatusDisplay(makeRun("False", reason))).toEqual({
+        label: "Cancelled",
+        variant: "neutral",
+        icon: CircleSlash,
+      });
+    }
+  );
+
+  test("stopping run (Unknown + PipelineRunStopping) is treated as cancelled", () => {
+    expect(getStatusDisplay(makeRun("Unknown", "PipelineRunStopping"))).toEqual({
+      label: "Cancelled",
+      variant: "neutral",
+      icon: CircleSlash,
+    });
+  });
+
+  test("unknown reason falls back to pending", () => {
+    expect(getStatusDisplay(makeRun("Unknown", "SomethingElse"))).toEqual({
+      label: "Pending",
+      variant: "neutral",
+      icon: Clock,
+    });
+  });
+});

--- a/apps/client/src/modules/platform/overview/pages/details/utils/pipelineRunStatusDisplay.ts
+++ b/apps/client/src/modules/platform/overview/pages/details/utils/pipelineRunStatusDisplay.ts
@@ -1,5 +1,11 @@
-import { getPipelineRunStatus, pipelineRunStatus, pipelineRunReason, type PipelineRun } from "@my-project/shared";
-import { CheckCircle2, XCircle, PlayCircle, Clock } from "lucide-react";
+import {
+  getPipelineRunStatus,
+  isPipelineRunCancelledReason,
+  pipelineRunStatus,
+  pipelineRunReason,
+  type PipelineRun,
+} from "@my-project/shared";
+import { CheckCircle2, CircleSlash, XCircle, PlayCircle, Clock } from "lucide-react";
 
 export type StatusVariant = "success" | "error" | "info" | "neutral";
 
@@ -12,6 +18,10 @@ export function getStatusDisplay(run: PipelineRun): {
   const s = status.toLowerCase();
   const r = reason?.toLowerCase() ?? "";
 
+  // Must precede the "False" → Failed branch: a cancelled run also reports status "False".
+  if (isPipelineRunCancelledReason(reason)) {
+    return { label: "Cancelled", variant: "neutral", icon: CircleSlash };
+  }
   if (s === pipelineRunStatus.true) {
     return { label: "Succeeded", variant: "success", icon: CheckCircle2 };
   }
@@ -21,9 +31,6 @@ export function getStatusDisplay(run: PipelineRun): {
   if (s === pipelineRunStatus.unknown) {
     if (r === pipelineRunReason.started || r === pipelineRunReason.running) {
       return { label: "Running", variant: "info", icon: PlayCircle };
-    }
-    if (r === pipelineRunReason.cancelled) {
-      return { label: "Cancelled", variant: "neutral", icon: Clock };
     }
   }
   return { label: "Pending", variant: "neutral", icon: Clock };

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.test.ts
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.test.ts
@@ -3,6 +3,7 @@ import { PipelineRun, pipelineRunLabels, pipelineType, tektonResultAnnotations }
 import { matchFunctions, pipelineRunFilterControlNames } from "./constants";
 
 const codebasesMatch = matchFunctions[pipelineRunFilterControlNames.CODEBASES]!;
+const statusMatch = matchFunctions[pipelineRunFilterControlNames.STATUS]!;
 
 interface PrOverrides {
   type?: string;
@@ -26,6 +27,15 @@ const makeRun = ({ type, codebaseLabel, appsPayload, isHistory }: PrOverrides): 
     spec: params ? { params } : {},
   } as unknown as PipelineRun;
 };
+
+const makeRunWithCondition = (status: string, reason?: string): PipelineRun =>
+  ({
+    metadata: { name: "x", namespace: "ns", labels: {}, annotations: {} },
+    spec: {},
+    status: {
+      conditions: [{ status, reason }],
+    },
+  }) as unknown as PipelineRun;
 
 describe("matchFunctions.codebases", () => {
   test("empty selection passes everything", () => {
@@ -82,5 +92,48 @@ describe("matchFunctions.codebases", () => {
     const item = makeRun({ type: pipelineType.build, codebaseLabel: "alpha" });
     expect(codebasesMatch(item, ["alpha", "beta"])).toBe(true);
     expect(codebasesMatch(item, ["beta", "gamma"])).toBe(false);
+  });
+});
+
+describe("matchFunctions.status", () => {
+  test("'all' matches every status", () => {
+    expect(statusMatch(makeRunWithCondition("True"), "all")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "Failed"), "all")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "Cancelled"), "all")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("Unknown", "Running"), "all")).toBe(true);
+  });
+
+  test("'true' matches only succeeded runs", () => {
+    expect(statusMatch(makeRunWithCondition("True"), "true")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "Failed"), "true")).toBe(false);
+  });
+
+  test("'unknown' matches only running/pending runs", () => {
+    expect(statusMatch(makeRunWithCondition("Unknown", "Running"), "unknown")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "Failed"), "unknown")).toBe(false);
+  });
+
+  test("a stopping run (Unknown + PipelineRunStopping) counts as cancelled, not unknown", () => {
+    // Regression: Tekton reports an in-flight stop as condition status "Unknown".
+    // It renders as grey "Cancelled" everywhere, so the filter must agree.
+    expect(statusMatch(makeRunWithCondition("Unknown", "PipelineRunStopping"), "cancelled")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("Unknown", "PipelineRunStopping"), "unknown")).toBe(false);
+  });
+
+  test("'false' matches failed runs but excludes cancelled/stopped runs", () => {
+    expect(statusMatch(makeRunWithCondition("False", "Failed"), "false")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "Cancelled"), "false")).toBe(false);
+    expect(statusMatch(makeRunWithCondition("False", "CancelledRunningFinally"), "false")).toBe(false);
+    expect(statusMatch(makeRunWithCondition("False", "StoppedRunningFinally"), "false")).toBe(false);
+    expect(statusMatch(makeRunWithCondition("False", "PipelineRunStopping"), "false")).toBe(false);
+  });
+
+  test("'cancelled' matches only cancelled/stopped runs", () => {
+    expect(statusMatch(makeRunWithCondition("False", "Cancelled"), "cancelled")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "CancelledRunningFinally"), "cancelled")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "StoppedRunningFinally"), "cancelled")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "PipelineRunStopping"), "cancelled")).toBe(true);
+    expect(statusMatch(makeRunWithCondition("False", "Failed"), "cancelled")).toBe(false);
+    expect(statusMatch(makeRunWithCondition("True"), "cancelled")).toBe(false);
   });
 });

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.ts
@@ -6,6 +6,7 @@ import {
   getPipelineRunAnnotation,
   tektonResultAnnotations,
   isHistoryPipelineRun,
+  isPipelineRunCancelledReason,
 } from "@my-project/shared";
 import { isCodebaseInPayloadType } from "@/modules/platform/tekton/utils/celFilters";
 import { PipelineRunListFilterValues } from "./types";
@@ -78,7 +79,21 @@ export const matchFunctions: MatchFunctions<PipelineRun, PipelineRunListFilterVa
       return true;
     }
 
-    return getPipelineRunStatus(item).status === value;
+    const status = getPipelineRunStatus(item);
+    // A cancelled/stopped run is treated as its own category regardless of the
+    // underlying condition status (it can be "False" once cancelled or "Unknown"
+    // while stopping), matching how it is rendered everywhere else.
+    const isCancelled = isPipelineRunCancelledReason(status.reason);
+
+    if (value === "cancelled") {
+      return isCancelled;
+    }
+
+    if (isCancelled) {
+      return false;
+    }
+
+    return status.status === value;
   },
   [pipelineRunFilterControlNames.PIPELINE_TYPE]: (item, value) => {
     if (value === "all") {

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/index.tsx
@@ -82,6 +82,7 @@ export const PipelineRunFilter = ({
         label: pipelineRunStatusLabels[v] ?? capitalizeFirstLetter(String(v)),
         value: String(v),
       })),
+      { label: "Cancelled", value: "cancelled" },
     ],
     []
   );

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/types.ts
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/types.ts
@@ -9,7 +9,7 @@ export type PipelineRunListFilterValues = {
   [pipelineRunFilterControlNames.SEARCH]: string;
   [pipelineRunFilterControlNames.CODEBASES]: string[];
   [pipelineRunFilterControlNames.CODEBASE_BRANCHES]: string[];
-  [pipelineRunFilterControlNames.STATUS]: FilterTypeWithOptionAll<PipelineRunStatus>;
+  [pipelineRunFilterControlNames.STATUS]: FilterTypeWithOptionAll<PipelineRunStatus> | "cancelled";
   [pipelineRunFilterControlNames.PIPELINE_TYPE]: FilterTypeWithOptionAll<PipelineType>;
   [pipelineRunFilterControlNames.NAMESPACES]: string[];
 };

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/columns/Status.tsx
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/columns/Status.tsx
@@ -2,13 +2,21 @@ import { StatusIcon } from "@/core/components/StatusIcon";
 import { Badge } from "@/core/components/ui/badge";
 import { Tooltip } from "@/core/components/ui/tooltip";
 import { getPipelineRunStatusIcon } from "@/k8s/api/groups/Tekton/PipelineRun/utils";
-import { PipelineRun, getPipelineRunStatus } from "@my-project/shared";
+import {
+  PipelineRun,
+  getPipelineRunReasonLabel,
+  getPipelineRunStatus,
+  isPipelineRunCancelledReason,
+} from "@my-project/shared";
 
 export const StatusColumn = ({ pipelineRun }: { pipelineRun: PipelineRun }) => {
   const statusIcon = getPipelineRunStatusIcon(pipelineRun);
   const status = getPipelineRunStatus(pipelineRun);
 
-  const errorMessage = status.status === "false" && status.message !== "No message" ? status.message : undefined;
+  const errorMessage =
+    status.status === "false" && !isPipelineRunCancelledReason(status.reason) && status.message !== "No message"
+      ? status.message
+      : undefined;
 
   const badge = (
     <Badge
@@ -23,7 +31,7 @@ export const StatusColumn = ({ pipelineRun }: { pipelineRun: PipelineRun }) => {
           width={12}
         />
       </span>
-      <span className="min-w-0 flex-1 truncate capitalize">{status.reason}</span>
+      <span className="min-w-0 flex-1 truncate capitalize">{getPipelineRunReasonLabel(status.reason)}</span>
     </Badge>
   );
 

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/view.tsx
@@ -10,7 +10,9 @@ import { formatDuration, formatTimestamp } from "@/core/utils/date-humanize";
 import { useCodebaseBranchWatchItem } from "@/k8s/api/groups/KRCI/CodebaseBranch";
 import { getPipelineRunStatusIcon } from "@/k8s/api/groups/Tekton/PipelineRun/utils";
 import {
+  getPipelineRunReasonLabel,
   getPipelineRunStatus,
+  isPipelineRunCancelledReason,
   PipelineRun,
   pipelineRunLabels,
   tektonResultAnnotations,
@@ -118,7 +120,7 @@ function HeaderMetadata() {
               color={pipelineRunStatusIcon.color}
               width={12}
             />
-            <span className="capitalize">{pipelineRunStatus.reason}</span>
+            <span className="capitalize">{getPipelineRunReasonLabel(pipelineRunStatus.reason)}</span>
           </Badge>
         </div>
 
@@ -236,13 +238,15 @@ function HeaderMetadata() {
         )}
       </div>
 
-      {pipelineRunStatus.status === "false" && pipelineRunStatus.message !== "No message" && (
-        <div className="flex w-full items-center gap-2">
-          <AlertCircle className="text-muted-foreground size-4 shrink-0" />
-          <span className="text-muted-foreground shrink-0 text-sm">Error:</span>
-          <span className="text-foreground text-sm break-all">{pipelineRunStatus.message}</span>
-        </div>
-      )}
+      {pipelineRunStatus.status === "false" &&
+        !isPipelineRunCancelledReason(pipelineRunStatus.reason) &&
+        pipelineRunStatus.message !== "No message" && (
+          <div className="flex w-full items-center gap-2">
+            <AlertCircle className="text-muted-foreground size-4 shrink-0" />
+            <span className="text-muted-foreground shrink-0 text-sm">Error:</span>
+            <span className="text-foreground text-sm break-all">{pipelineRunStatus.message}</span>
+          </div>
+        )}
     </div>
   );
 }

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/constants.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/constants.ts
@@ -1,5 +1,6 @@
 import { K8sResourceConfig } from "../../../common/index.js";
 import { pipelineRunReasonEnum, pipelineRunSpecStatusEnum, pipelineRunStatusEnum } from "./schema.js";
+import type { PipelineRunReason } from "./types.js";
 import { pipelineRunLabels } from "./labels.js";
 
 export const k8sPipelineRunConfig = {
@@ -15,3 +16,32 @@ export const pipelineRunReason = pipelineRunReasonEnum.enum;
 export const pipelineRunStatus = pipelineRunStatusEnum.enum;
 /** Values for PipelineRun spec.status — used to cancel or pause a run. */
 export const pipelineRunSpecStatus = pipelineRunSpecStatusEnum.enum;
+
+/**
+ * Terminal/transitional reasons that mean a run was cancelled or stopped by a
+ * user (or by the platform, e.g. edp-tekton superseding a review run) rather
+ * than failing. Tekton reports these with condition status "False", so without
+ * special-casing they would otherwise be rendered as failures.
+ */
+export const pipelineRunCancelledReasons: readonly PipelineRunReason[] = [
+  pipelineRunReason.cancelled,
+  pipelineRunReason.cancelledrunningfinally,
+  pipelineRunReason.stoppedrunningfinally,
+  pipelineRunReason.pipelinerunstopping,
+];
+
+export const isPipelineRunCancelledReason = (reason: PipelineRunReason | undefined): boolean =>
+  reason !== undefined && pipelineRunCancelledReasons.includes(reason);
+
+/**
+ * Human-friendly label for a PipelineRun condition reason. Collapses the several
+ * cancel/stop reasons into a single "Cancelled" label; other reasons fall back
+ * to their raw value (callers typically capitalize it for display).
+ */
+export const getPipelineRunReasonLabel = (reason: PipelineRunReason | undefined): string => {
+  if (isPipelineRunCancelledReason(reason)) {
+    return "Cancelled";
+  }
+
+  return reason ?? "Unknown";
+};


### PR DESCRIPTION


edp-tekton can now cancel PipelineRuns, which Tekton reports with condition status "False" (reason "cancelled") or "Unknown" (reason "PipelineRunStopping") while stopping. The portal previously showed these as a red "Failed" error, misrepresenting a deliberate cancellation as a failure.

- Treat cancel/stop reasons as their own neutral "Cancelled" category across the status icon, list and details badges, branch build tooltip, and the Overview donut graph and recent-activity util
- Render it with a grey slash icon and muted label so it never reads as more prominent than "Succeeded"
- Suppress the "Error:" detail row for cancelled runs and add a dedicated "Cancelled" status filter option, excluding cancelled runs from the "Failed" filter
- Add shared isPipelineRunCancelledReason/getPipelineRunReasonLabel helpers with unit coverage

