### PR TITLE
EPMDEDP-17203: fix: render archived PipelineRuns

### DIFF
--- a/apps/client/src/k8s/api/groups/Tekton/PipelineRun/utils/getStatusIcon/index.test.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/PipelineRun/utils/getStatusIcon/index.test.ts
@@ -78,6 +78,21 @@ describe("getStatusIcon", () => {
     expect(result.isSpinning).toBe(true);
   });
 
+  test("returns in-progress icon for unknown status with pending reason", () => {
+    // Tekton keeps a pending run at status "Unknown", so it must spin, not render grey.
+    const pipelineRun: PipelineRun = {
+      status: {
+        conditions: [{ status: pipelineRunStatus.unknown, reason: pipelineRunReason.pipelinerunpending }],
+      },
+    } as unknown as PipelineRun;
+
+    const result = getStatusIcon(pipelineRun);
+
+    expect(result.component).toBe(LoaderCircle);
+    expect(result.color).toBe(STATUS_COLOR.IN_PROGRESS);
+    expect(result.isSpinning).toBe(true);
+  });
+
   test("returns cancelled icon for false status with cancelled reason", () => {
     const pipelineRun: PipelineRun = {
       status: {
@@ -149,10 +164,26 @@ describe("getStatusIcon", () => {
     expect(result.color).toBe(STATUS_COLOR.CANCELLED);
   });
 
-  test("returns unknown icon for unknown status with unknown reason", () => {
+  test("returns in-progress icon for unknown status with any (even unrecognized) reason", () => {
+    // "Unknown" + any reason means a live in-flight run, recognized or not.
     const pipelineRun: PipelineRun = {
       status: {
-        conditions: [{ status: pipelineRunStatus.unknown, reason: "unknown-reason" }],
+        conditions: [{ status: pipelineRunStatus.unknown, reason: "some-future-running-reason" }],
+      },
+    } as unknown as PipelineRun;
+
+    const result = getStatusIcon(pipelineRun);
+
+    expect(result.component).toBe(LoaderCircle);
+    expect(result.color).toBe(STATUS_COLOR.IN_PROGRESS);
+    expect(result.isSpinning).toBe(true);
+  });
+
+  test("returns neutral unknown icon for a reasonless unknown status (loading / unfinalized archive)", () => {
+    // No reason => not live (matches an archived, unfinalized record). Must not spin.
+    const pipelineRun: PipelineRun = {
+      status: {
+        conditions: [{ status: pipelineRunStatus.unknown }],
       },
     } as unknown as PipelineRun;
 
@@ -160,5 +191,6 @@ describe("getStatusIcon", () => {
 
     expect(result.component).toBe(ShieldQuestion);
     expect(result.color).toBe(STATUS_COLOR.UNKNOWN);
+    expect(result.isSpinning).toBeFalsy();
   });
 });

--- a/apps/client/src/k8s/api/groups/Tekton/PipelineRun/utils/getStatusIcon/index.ts
+++ b/apps/client/src/k8s/api/groups/Tekton/PipelineRun/utils/getStatusIcon/index.ts
@@ -3,8 +3,8 @@ import { K8sResourceStatusIcon } from "@/k8s/types";
 import {
   getPipelineRunStatus,
   isPipelineRunCancelledReason,
+  isPipelineRunInProgress,
   PipelineRun,
-  pipelineRunReason,
   pipelineRunStatus,
 } from "@my-project/shared";
 import { CircleCheck, CircleSlash, CircleX, LoaderCircle, ShieldQuestion } from "lucide-react";
@@ -21,28 +21,17 @@ export const getStatusIcon = (pipelineRun: PipelineRun | undefined): K8sResource
     };
   }
 
+  // A reasonless "Unknown" (loading, or an archived unfinalized record) is not in
+  // progress and falls through to the neutral icon below. See isPipelineRunInProgress.
+  if (isPipelineRunInProgress(pipelineRun)) {
+    return {
+      component: LoaderCircle,
+      color: STATUS_COLOR.IN_PROGRESS,
+      isSpinning: true,
+    };
+  }
+
   switch (status) {
-    case pipelineRunStatus.unknown:
-      if (reason === pipelineRunReason.started) {
-        return {
-          component: LoaderCircle,
-          color: STATUS_COLOR.IN_PROGRESS,
-          isSpinning: true,
-        };
-      }
-
-      if (reason === pipelineRunReason.running) {
-        return {
-          component: LoaderCircle,
-          color: STATUS_COLOR.IN_PROGRESS,
-          isSpinning: true,
-        };
-      }
-
-      return {
-        component: ShieldQuestion,
-        color: STATUS_COLOR.UNKNOWN,
-      };
     case pipelineRunStatus.true:
       return {
         component: CircleCheck,

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.test.ts
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.test.ts
@@ -28,14 +28,18 @@ const makeRun = ({ type, codebaseLabel, appsPayload, isHistory }: PrOverrides): 
   } as unknown as PipelineRun;
 };
 
-const makeRunWithCondition = (status: string, reason?: string): PipelineRun =>
-  ({
-    metadata: { name: "x", namespace: "ns", labels: {}, annotations: {} },
+const makeRunWithCondition = (status: string, reason?: string, isHistory?: boolean): PipelineRun => {
+  const annotations: Record<string, string> = {};
+  if (isHistory) annotations[tektonResultAnnotations.historySource] = "true";
+
+  return {
+    metadata: { name: "x", namespace: "ns", labels: {}, annotations },
     spec: {},
     status: {
       conditions: [{ status, reason }],
     },
-  }) as unknown as PipelineRun;
+  } as unknown as PipelineRun;
+};
 
 describe("matchFunctions.codebases", () => {
   test("empty selection passes everything", () => {
@@ -111,6 +115,13 @@ describe("matchFunctions.status", () => {
   test("'unknown' matches only running/pending runs", () => {
     expect(statusMatch(makeRunWithCondition("Unknown", "Running"), "unknown")).toBe(true);
     expect(statusMatch(makeRunWithCondition("False", "Failed"), "unknown")).toBe(false);
+  });
+
+  test("'unknown' excludes archived history runs (terminal, never actually running)", () => {
+    const historyUnknown = makeRunWithCondition("Unknown", undefined, true);
+    expect(statusMatch(historyUnknown, "unknown")).toBe(false);
+    // Same condition status, but live => genuinely running.
+    expect(statusMatch(makeRunWithCondition("Unknown", "Running"), "unknown")).toBe(true);
   });
 
   test("a stopping run (Unknown + PipelineRunStopping) counts as cancelled, not unknown", () => {

--- a/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.ts
+++ b/apps/client/src/modules/platform/tekton/components/PipelineRunList/components/Filter/constants.ts
@@ -2,6 +2,7 @@ import { MatchFunctions, createSearchMatchFunction } from "@/core/providers/Filt
 import {
   PipelineRun,
   pipelineRunLabels,
+  pipelineRunStatus,
   getPipelineRunStatus,
   getPipelineRunAnnotation,
   tektonResultAnnotations,
@@ -90,6 +91,13 @@ export const matchFunctions: MatchFunctions<PipelineRun, PipelineRunListFilterVa
     }
 
     if (isCancelled) {
+      return false;
+    }
+
+    // "Running / Pending" (status "unknown") is a live-only state. A history run
+    // from Tekton Results is archived => terminal; its summary may be an
+    // unfinalized "unknown" but it is never actually running, so exclude it.
+    if (value === pipelineRunStatus.unknown && isHistoryPipelineRun(item)) {
       return false;
     }
 

--- a/apps/client/src/modules/platform/tekton/hooks/useUnifiedPipelineRunList/index.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useUnifiedPipelineRunList/index.ts
@@ -1,6 +1,12 @@
 import { usePipelineRunWatchList } from "@/k8s/api/groups/Tekton/PipelineRun";
 import { useClusterStore } from "@/k8s/store";
-import { PipelineRun, TektonResult, normalizeResultToPipelineRun, pipelineRunLabels } from "@my-project/shared";
+import {
+  PipelineRun,
+  TektonResult,
+  normalizeResultToPipelineRun,
+  pipelineRunLabels,
+  pipelineRunStatus,
+} from "@my-project/shared";
 import { useTRPCClient } from "@/core/providers/trpc";
 import {
   buildAnnotationsFilter,
@@ -124,6 +130,13 @@ export function useUnifiedPipelineRunList(options?: UseUnifiedPipelineRunListOpt
     return parts.length > 0 ? parts.join(" && ") : undefined;
   }, [labels, searchTerm, status, pipelineType, codebases]);
 
+  // "Running / Pending" (status "unknown") is a live-only state: the Tekton Results
+  // `results` table stores only archived (terminal) runs, so history can never
+  // contribute a genuinely running run. Skip the history query for this filter —
+  // otherwise it returns terminal runs whose summary was never finalized ("unknown")
+  // that would masquerade as running, and wastes a full page on rows that never show.
+  const historyEnabled = enabled && status !== pipelineRunStatus.unknown;
+
   const historyQuery = useInfiniteQuery<HistoryPage, Error>({
     queryKey: ["tektonResults", "pipelineRunResults", clusterName, namespace, celFilter],
     queryFn: ({ pageParam }) => {
@@ -136,7 +149,7 @@ export function useUnifiedPipelineRunList(options?: UseUnifiedPipelineRunListOpt
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextPageToken || undefined,
-    enabled,
+    enabled: historyEnabled,
   });
 
   // Normalize history Result objects into K8s PipelineRun type.

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/constants.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/constants.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getPipelineRunReasonLabel, isPipelineRunCancelledReason, pipelineRunReason } from "./constants.js";
+
+describe("getPipelineRunReasonLabel", () => {
+  it("maps compound in-progress reasons to readable labels", () => {
+    expect(getPipelineRunReasonLabel(pipelineRunReason.pipelinerunpending)).toBe("Pending");
+    expect(getPipelineRunReasonLabel(pipelineRunReason.resolvingpipelineref)).toBe("Resolving");
+    expect(getPipelineRunReasonLabel(pipelineRunReason.pipelineruntimeoutrunningfinally)).toBe("Finalizing");
+    expect(getPipelineRunReasonLabel(pipelineRunReason.pipelineruntimeout)).toBe("Timeout");
+  });
+
+  it("collapses every cancel/stop reason to 'Cancelled'", () => {
+    expect(getPipelineRunReasonLabel(pipelineRunReason.cancelled)).toBe("Cancelled");
+    expect(getPipelineRunReasonLabel(pipelineRunReason.cancelledrunningfinally)).toBe("Cancelled");
+    expect(getPipelineRunReasonLabel(pipelineRunReason.stoppedrunningfinally)).toBe("Cancelled");
+    expect(getPipelineRunReasonLabel(pipelineRunReason.pipelinerunstopping)).toBe("Cancelled");
+  });
+
+  it("falls back to the raw reason for already-readable reasons", () => {
+    expect(getPipelineRunReasonLabel(pipelineRunReason.running)).toBe("running");
+    expect(getPipelineRunReasonLabel(pipelineRunReason.failed)).toBe("failed");
+  });
+
+  it("returns 'Unknown' for an undefined reason", () => {
+    expect(getPipelineRunReasonLabel(undefined)).toBe("Unknown");
+  });
+});
+
+describe("isPipelineRunCancelledReason", () => {
+  it("recognizes the cancel/stop family and nothing else", () => {
+    expect(isPipelineRunCancelledReason(pipelineRunReason.cancelled)).toBe(true);
+    expect(isPipelineRunCancelledReason(pipelineRunReason.pipelinerunstopping)).toBe(true);
+    expect(isPipelineRunCancelledReason(pipelineRunReason.running)).toBe(false);
+    expect(isPipelineRunCancelledReason(undefined)).toBe(false);
+  });
+});

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/constants.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/constants.ts
@@ -34,13 +34,30 @@ export const isPipelineRunCancelledReason = (reason: PipelineRunReason | undefin
   reason !== undefined && pipelineRunCancelledReasons.includes(reason);
 
 /**
+ * Human-friendly labels for reasons whose raw (lowercased) value reads poorly when
+ * capitalized for display, e.g. "pipelinerunpending" → "Pending". Reasons not listed
+ * here fall back to their raw value, which already reads fine ("running", "failed").
+ */
+const pipelineRunReasonLabels: Partial<Record<PipelineRunReason, string>> = {
+  [pipelineRunReason.pipelinerunpending]: "Pending",
+  [pipelineRunReason.resolvingpipelineref]: "Resolving",
+  [pipelineRunReason.pipelineruntimeoutrunningfinally]: "Finalizing",
+  [pipelineRunReason.pipelineruntimeout]: "Timeout",
+};
+
+/**
  * Human-friendly label for a PipelineRun condition reason. Collapses the several
- * cancel/stop reasons into a single "Cancelled" label; other reasons fall back
- * to their raw value (callers typically capitalize it for display).
+ * cancel/stop reasons into a single "Cancelled" label; maps the compound in-progress
+ * reasons to readable text; other reasons fall back to their raw value (callers
+ * typically capitalize it for display).
  */
 export const getPipelineRunReasonLabel = (reason: PipelineRunReason | undefined): string => {
   if (isPipelineRunCancelledReason(reason)) {
     return "Cancelled";
+  }
+
+  if (reason && pipelineRunReasonLabels[reason]) {
+    return pipelineRunReasonLabels[reason];
   }
 
   return reason ?? "Unknown";

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/schema.ts
@@ -22,16 +22,27 @@ const pipelineRunLabelsSchema = z
   })
   .catchall(z.string());
 
+// Mirrors tektoncd/pipeline PipelineRunReason (pkg/apis/pipeline/v1/pipelinerun_types.go).
+// Lowercased to match getPipelineRunStatus(), which lowercases the condition reason.
+// In-progress reasons all carry condition status "Unknown"; terminal reasons carry
+// "True" (succeeded/completed) or "False". Reasons Tekton emits that aren't listed
+// here still flow through as raw strings — this enum only types the ones we branch on.
 export const pipelineRunReasonEnum = z.enum([
+  // status "Unknown" — in progress
   "started",
   "running",
   "pipelinerunpending",
+  "resolvingpipelineref",
+  "pipelineruntimeoutrunningfinally",
+  // status "Unknown"/"False" — cancelled/stopped family (rendered neutrally, not as failures)
   "pipelinerunstopping",
   "cancelledrunningfinally",
   "stoppedrunningfinally",
   "cancelled",
+  // status "True" — success
   "succeeded",
   "completed",
+  // status "False" — failure
   "failed",
   "pipelineruntimeout",
   "createrunfailed",

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/index.ts
@@ -5,6 +5,7 @@ export * from "./createDeployPipelineRunDraft/index.js";
 export * from "./createPipelineRunDraftFromPipeline/index.js";
 export * from "./createRerunPipelineRun/index.js";
 export * from "./getPipelineRunStatus/index.js";
+export * from "./isPipelineRunInProgress/index.js";
 export * from "./getPipelineRunAnnotation/index.js";
 export * from "./getPipelineRunTaskGraphDefinitions/index.js";
 export * from "./isHistoryPipelineRun/index.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/isPipelineRunInProgress/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/isPipelineRunInProgress/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isPipelineRunInProgress } from "./index.js";
+import { pipelineRunReason, pipelineRunStatus } from "../../constants.js";
+import type { PipelineRun } from "../../types.js";
+
+const runWith = (status: string, reason?: string): PipelineRun =>
+  ({
+    metadata: { name: "x", namespace: "ns" },
+    spec: {},
+    status: { conditions: [{ type: "Succeeded", status, reason }] },
+  }) as unknown as PipelineRun;
+
+describe("isPipelineRunInProgress", () => {
+  it("is true for live in-progress reasons (status Unknown + reason)", () => {
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.unknown, pipelineRunReason.started))).toBe(true);
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.unknown, pipelineRunReason.running))).toBe(true);
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.unknown, pipelineRunReason.pipelinerunpending))).toBe(
+      true
+    );
+    expect(
+      isPipelineRunInProgress(runWith(pipelineRunStatus.unknown, pipelineRunReason.pipelineruntimeoutrunningfinally))
+    ).toBe(true);
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.unknown, pipelineRunReason.resolvingpipelineref))).toBe(
+      true
+    );
+  });
+
+  it("is false for terminal runs", () => {
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.true, pipelineRunReason.succeeded))).toBe(false);
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.false, pipelineRunReason.failed))).toBe(false);
+  });
+
+  it("is false for the cancelled/stopped family even while status is Unknown", () => {
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.unknown, pipelineRunReason.pipelinerunstopping))).toBe(
+      false
+    );
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.unknown, pipelineRunReason.cancelledrunningfinally))).toBe(
+      false
+    );
+  });
+
+  it("is false for a reasonless Unknown (loading, or an archived unfinalized record)", () => {
+    expect(isPipelineRunInProgress(runWith(pipelineRunStatus.unknown, undefined))).toBe(false);
+    expect(isPipelineRunInProgress(undefined)).toBe(false);
+    expect(isPipelineRunInProgress({ status: {} } as unknown as PipelineRun)).toBe(false);
+  });
+});

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/isPipelineRunInProgress/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/isPipelineRunInProgress/index.ts
@@ -1,0 +1,28 @@
+import { PipelineRun } from "../../types.js";
+import { pipelineRunStatus, isPipelineRunCancelledReason } from "../../constants.js";
+import { getPipelineRunStatus } from "../getPipelineRunStatus/index.js";
+
+/**
+ * Whether a PipelineRun is actively in progress (running / pending / finalizing).
+ *
+ * Mirrors the tektoncd/pipeline controller model: the single `Succeeded`
+ * condition is set to status "Unknown" for the entire lifetime of a run that has
+ * not reached a terminal state (see GetPipelineConditionStatus in
+ * pkg/reconciler/pipelinerun/resources/pipelinerunstate.go), and to "True"/"False"
+ * only once it finishes. So "in progress" is defined by status == "Unknown", NOT
+ * by an allowlist of reasons — that keeps us correct for pending
+ * (`PipelineRunPending`), finally-running, and any future reason Tekton adds.
+ *
+ * Two exclusions:
+ * - Cancelled/stopped runs report "Unknown" transiently but are their own neutral
+ *   category everywhere in the UI, so they are not "in progress".
+ * - A reasonless "Unknown" is not a live run: the controller always sets a reason
+ *   on an in-flight run, whereas an archived Tekton Results record with an
+ *   unfinalized summary (see normalizeResultToPipelineRun) has status "Unknown"
+ *   with no reason. Requiring a reason keeps those terminal records out.
+ */
+export const isPipelineRunInProgress = (pipelineRun: PipelineRun | undefined): boolean => {
+  const { status, reason } = getPipelineRunStatus(pipelineRun);
+
+  return status === pipelineRunStatus.unknown && reason !== undefined && !isPipelineRunCancelledReason(reason);
+};

--- a/packages/shared/src/models/tektonResults/adapters.test.ts
+++ b/packages/shared/src/models/tektonResults/adapters.test.ts
@@ -622,19 +622,16 @@ describe("normalizeResultToPipelineRun", () => {
     );
   });
 
-  it("should map UNKNOWN status to running condition", () => {
+  it("should render UNKNOWN status as a terminal, neutral condition (never running)", () => {
     const unknownResult: TektonResult = {
       ...mockTektonResult,
       summary: { ...mockTektonResult.summary!, status: "UNKNOWN" },
     };
     const result = normalizeResultToPipelineRun(unknownResult, "edp-delivery");
 
-    expect(result.status?.conditions?.[0]).toEqual(
-      expect.objectContaining({
-        status: "unknown",
-        reason: "running",
-      })
-    );
+    // Archived Results are terminal; an unfinalized summary must not spin as "Running".
+    expect(result.status?.conditions?.[0]?.status).toBe("unknown");
+    expect(result.status?.conditions?.[0]?.reason).toBeUndefined();
   });
 
   it("should fallback to update_time when end_time is null for completed runs", () => {
@@ -647,14 +644,15 @@ describe("normalizeResultToPipelineRun", () => {
     expect(result.status?.completionTime).toBe("2026-03-10T10:15:00Z");
   });
 
-  it("should not set completionTime for UNKNOWN status even without end_time", () => {
-    const running: TektonResult = {
+  it("should bound completionTime to update_time for UNKNOWN status without end_time", () => {
+    const unfinalized: TektonResult = {
       ...mockTektonResult,
       summary: { ...mockTektonResult.summary!, end_time: undefined, status: "UNKNOWN" },
     };
-    const result = normalizeResultToPipelineRun(running, "edp-delivery");
+    const result = normalizeResultToPipelineRun(unfinalized, "edp-delivery");
 
-    expect(result.status?.completionTime).toBeUndefined();
+    // Terminal-but-unfinalized runs still get a completion time (the "Running forever" bug).
+    expect(result.status?.completionTime).toBe("2026-03-10T10:15:00Z");
   });
 
   it("should use end_time as completionTime when available", () => {
@@ -775,8 +773,9 @@ describe("normalizeResultToPipelineRun", () => {
     };
     const result = normalizeResultToPipelineRun(noSummary, "edp-delivery");
 
-    expect(result.status?.conditions?.[0]?.reason).toBe("running");
     expect(result.status?.conditions?.[0]?.status).toBe("unknown");
+    expect(result.status?.conditions?.[0]?.reason).toBeUndefined();
+    expect(result.status?.completionTime).toBe("2026-03-10T10:15:00Z");
   });
 
   it("should ignore non-string annotation values via type guard", () => {

--- a/packages/shared/src/models/tektonResults/adapters.ts
+++ b/packages/shared/src/models/tektonResults/adapters.ts
@@ -150,12 +150,20 @@ export function normalizeHistoryTaskRun(decoded: DecodedTaskRun): TaskRun {
 // Result → PipelineRun normalizer (lightweight summary, no JSONB decode)
 // ---------------------------------------------------------------------------
 
-const RESULT_STATUS_MAP: Record<TektonResultStatus, { status: string; reason: string }> = {
+// A Result in the `results` table is an ARCHIVED run — terminal by definition:
+// the unified list dedupes any live run out (live wins), so a Result that reaches
+// the UI is never actually running. When the Tekton Results watcher failed to
+// finalize `summary.status` (left UNKNOWN), the true SUCCESS/FAILURE lives only in
+// the heavyweight record blob (surfaced on the detail page). For the lightweight
+// list we render it as a neutral, terminal "Unknown" — never an active "Running"
+// spinner. Omitting the reason is load-bearing: isPipelineRunInProgress (which
+// getStatusIcon uses) only spins an "unknown"-status run when a reason is present.
+const RESULT_STATUS_MAP: Record<TektonResultStatus, { status: string; reason?: string }> = {
   SUCCESS: { status: pipelineRunStatus.true, reason: pipelineRunReason.succeeded },
   FAILURE: { status: pipelineRunStatus.false, reason: pipelineRunReason.failed },
   TIMEOUT: { status: pipelineRunStatus.false, reason: pipelineRunReason.pipelineruntimeout },
   CANCELLED: { status: pipelineRunStatus.false, reason: pipelineRunReason.cancelled },
-  UNKNOWN: { status: pipelineRunStatus.unknown, reason: pipelineRunReason.running },
+  UNKNOWN: { status: pipelineRunStatus.unknown },
 };
 
 function getResultAnnotation(result: TektonResult, key: string): string | undefined {
@@ -185,12 +193,13 @@ export function normalizeResultToPipelineRun(result: TektonResult, namespace: st
   const statusInfo = RESULT_STATUS_MAP[summaryStatus] || RESULT_STATUS_MAP.UNKNOWN;
 
   const startTime = result.create_time;
+  // A Result row is archived => terminal, so it always has a completion time.
   // summary.end_time is NULL for many results due to a Tekton Results watcher bug
-  // (the watcher uses ConditionReady instead of status.completionTime).
-  // Fallback to update_time: the Result is updated when the PipelineRun completes,
-  // so update_time ≈ actual completion time for finished runs.
-  const isCompleted = summaryStatus !== "UNKNOWN";
-  const completionTime = result.summary?.end_time || (isCompleted ? result.update_time : undefined);
+  // (the watcher uses ConditionReady instead of status.completionTime). Fall back
+  // to update_time: the Result is updated when the PipelineRun completes, so
+  // update_time ≈ actual completion time. This bounds the rendered duration even
+  // when summary.status was never finalized (otherwise it grows forever).
+  const completionTime = result.summary?.end_time || result.update_time;
 
   const resultAnnotations: Record<string, string> = {};
   const annotationKeys = [
@@ -238,7 +247,7 @@ export function normalizeResultToPipelineRun(result: TektonResult, namespace: st
         {
           type: "Succeeded",
           status: statusInfo.status,
-          reason: statusInfo.reason,
+          ...(statusInfo.reason ? { reason: statusInfo.reason } : {}),
           lastTransitionTime: completionTime || startTime,
         },
       ],


### PR DESCRIPTION

Archived PipelineRuns whose Tekton Results summary.status was never finalized by the watcher were mapped to a running condition, so the list showed a perpetual "Running" spinner with an ever-growing duration for runs that had actually finished days earlier.

- Normalize an unfinalized (UNKNOWN) Result summary to a neutral, terminal "Unknown" with a bounded completion time, instead of an active "Running" reason
- Keep the live-only "Running / Pending" filter honest: skip the history query and exclude archived runs from that bucket, since Tekton Results stores only terminal records
- Align in-progress detection with the Tekton controller model (condition status "Unknown" with a reason = in progress) via a shared isPipelineRunInProgress primitive, so pending/finalizing/resolving runs render correctly instead of as grey "Unknown"

