### PR TITLE
EPMDEDP-17229: feat: flag duplicate projects inline in the create wizard

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,12 +8,13 @@ on:
 
 jobs:
   review:
+    # startsWith (not contains) so URLs embedding "/review" in comments from
+    # service accounts (e.g. Tekton pipeline reports) don't trigger a review
     if: >
       github.event.comment.user.type != 'Bot' &&
-      (
-        (github.event.issue.pull_request && contains(github.event.comment.body, '/review')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/review'))
-      )
+      github.event.comment.user.login != 'epmd-edp' &&
+      startsWith(github.event.comment.body, '/review') &&
+      (github.event.issue.pull_request || github.event_name == 'pull_request_review_comment')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/GitUrlPath/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/GitUrlPath/index.tsx
@@ -2,9 +2,19 @@ import React from "react";
 import { useCreateCodebaseForm } from "../../../providers/form/hooks";
 import { NAMES } from "../../../names";
 import { isGerritProvider } from "../../../utils";
+import { useOnboardedRepoCheck } from "../../../hooks/useOnboardedRepoCheck";
 
 export const GitUrlPath: React.FC = () => {
   const form = useCreateCodebaseForm();
+
+  const { findOnboardedProject, membershipKey } = useOnboardedRepoCheck();
+
+  // Re-validate on list updates — validation otherwise runs only on change/blur/submit
+  React.useEffect(() => {
+    if (form.getFieldMeta(NAMES.gitUrlPath)?.isTouched) {
+      form.validateField(NAMES.gitUrlPath, "change");
+    }
+  }, [membershipKey, form]);
 
   return (
     <form.AppField
@@ -18,6 +28,12 @@ export const GitUrlPath: React.FC = () => {
           if (!value || value.length < 3) {
             return "Repository name has to be at least 3 characters long.";
           }
+
+          const onboardedProject = findOnboardedProject(value);
+          if (onboardedProject) {
+            return `This repository is already onboarded as project "${onboardedProject}".`;
+          }
+
           return undefined;
         },
       }}

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/Name/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/Name/index.tsx
@@ -1,23 +1,49 @@
 import React from "react";
-import z from "zod";
+import { useCodebaseWatchList } from "@/k8s/api/groups/KRCI/Codebase";
+import { sortByName } from "@/core/utils/sortByName";
 import { useCreateCodebaseForm } from "../../../providers/form/hooks";
 import { NAMES } from "../../../names";
+import { nameSchema } from "../../../schema";
 
 export const Name: React.FC = () => {
   const form = useCreateCodebaseForm();
+
+  const codebaseListWatch = useCodebaseWatchList();
+
+  // Changes only when name membership changes, so the revalidation effect below
+  // ignores unrelated watch events (e.g. status updates)
+  const existingNamesKey = React.useMemo(
+    () =>
+      (codebaseListWatch.data.array ?? [])
+        .map((codebase) => codebase.metadata.name)
+        .sort(sortByName)
+        .join("\n"),
+    [codebaseListWatch.data.array]
+  );
+
+  // Re-validate on list updates — validation otherwise runs only on change/blur/submit
+  React.useEffect(() => {
+    if (form.getFieldMeta(NAMES.name)?.isTouched) {
+      form.validateField(NAMES.name, "change");
+    }
+  }, [existingNamesKey, form]);
 
   return (
     <form.AppField
       name={NAMES.name}
       validators={{
-        onChange: z
-          .string()
-          .min(2, "Project name must be not less than two characters long.")
-          .max(30, "Project name must be less than 30 characters long.")
-          .regex(/^[a-z](?!.*--[^-])[a-z0-9-]*[a-z0-9]$/, {
-            message:
-              "Project name must be not less than two characters long. It must contain only lowercase letters, numbers, and dashes. It cannot start or end with a dash, and cannot have whitespaces",
-          }),
+        onChange: ({ value }) => {
+          const result = nameSchema.safeParse(value ?? "");
+          if (!result.success) {
+            return result.error.issues[0]?.message;
+          }
+
+          const isDuplicate = (codebaseListWatch.data.array ?? []).some(
+            (codebase) => codebase.metadata.name === value.trim()
+          );
+
+          return isDuplicate ? "A project with this name already exists." : undefined;
+        },
       }}
     >
       {(field) => <field.FormTextField label="Project Name" placeholder="Enter project name" />}

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/RepositoryName/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/components/fields/RepositoryName/index.tsx
@@ -10,6 +10,7 @@ import { validateField } from "@/core/utils/forms/validation";
 import { useCreateCodebaseForm } from "../../../providers/form/hooks";
 import { NAMES } from "../../../names";
 import { isGerritProvider } from "../../../utils";
+import { useOnboardedRepoCheck } from "../../../hooks/useOnboardedRepoCheck";
 
 export const RepositoryName: React.FC = () => {
   const form = useCreateCodebaseForm();
@@ -48,6 +49,15 @@ export const RepositoryName: React.FC = () => {
 
   const isImportStrategy = strategyFieldValue === codebaseCreationStrategy.import;
 
+  const { findOnboardedProject, membershipKey } = useOnboardedRepoCheck();
+
+  // Re-validate on list updates — validation otherwise runs only on change/blur/submit
+  React.useEffect(() => {
+    if (form.getFieldMeta(NAMES.ui_repositoryName)?.isTouched) {
+      form.validateField(NAMES.ui_repositoryName, "change");
+    }
+  }, [membershipKey, form]);
+
   return (
     <form.AppField
       name={NAMES.ui_repositoryName}
@@ -72,6 +82,14 @@ export const RepositoryName: React.FC = () => {
           ) {
             return "Repository with this name already exists";
           }
+
+          if (ownerFieldValue) {
+            const onboardedProject = findOnboardedProject(`${ownerFieldValue}/${value}`);
+            if (onboardedProject) {
+              return `This repository is already onboarded as project "${onboardedProject}".`;
+            }
+          }
+
           return undefined;
         },
       }}

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/hooks/useOnboardedRepoCheck.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/hooks/useOnboardedRepoCheck.ts
@@ -1,0 +1,23 @@
+import React from "react";
+import { useCodebaseWatchList } from "@/k8s/api/groups/KRCI/Codebase";
+import { findOnboardedProject, getRepoMembershipKey } from "../utils";
+
+/**
+ * Checks whether a repository path is already onboarded as another project.
+ * `membershipKey` is content-stable, so revalidation effects keyed on it ignore
+ * watch events that don't change the (name, gitUrlPath) membership.
+ */
+export const useOnboardedRepoCheck = () => {
+  const codebaseListWatch = useCodebaseWatchList();
+  const codebases = codebaseListWatch.data.array ?? [];
+
+  const membershipKey = React.useMemo(
+    () => getRepoMembershipKey(codebaseListWatch.data.array ?? []),
+    [codebaseListWatch.data.array]
+  );
+
+  return {
+    findOnboardedProject: (candidatePath: string) => findOnboardedProject(codebases, candidatePath),
+    membershipKey,
+  };
+};

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/schema.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/schema.ts
@@ -29,7 +29,7 @@ const repositoryUrlSchema = createCodebaseDraftInputSchema.shape.repositoryUrl.r
   { message: "Specify the application URL in the following format: http(s)://git.example.com/example." }
 );
 
-const nameSchema = createCodebaseDraftInputSchema.shape.name
+export const nameSchema = createCodebaseDraftInputSchema.shape.name
   .min(2, "Project name must be not less than two characters long.")
   .max(30, "Project name must be less than 30 characters long.")
   .regex(/^[a-z](?!.*--[^-])[a-z0-9-]*[a-z0-9]$/, {

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/utils.test.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { gitProvider } from "@my-project/shared";
-import { isGerritProvider } from "./utils";
+import { gitProvider, type Codebase } from "@my-project/shared";
+import { findOnboardedProject, getRepoMembershipKey, isGerritProvider } from "./utils";
 
 describe("isGerritProvider", () => {
   it("is true for the gerrit provider", () => {
@@ -17,5 +17,46 @@ describe("isGerritProvider", () => {
     expect(isGerritProvider("")).toBe(false);
     expect(isGerritProvider(null)).toBe(false);
     expect(isGerritProvider(undefined)).toBe(false);
+  });
+});
+
+const makeCodebase = (name: string, gitUrlPath: string): Codebase =>
+  ({
+    metadata: { name },
+    spec: { gitUrlPath },
+  }) as Codebase;
+
+describe("findOnboardedProject", () => {
+  const codebases = [makeCodebase("my-app", "/org/repo"), makeCodebase("other-app", "/org/other.git")];
+
+  it("finds a project by normalized path regardless of slash, case and .git suffix", () => {
+    expect(findOnboardedProject(codebases, "org/repo")).toBe("my-app");
+    expect(findOnboardedProject(codebases, "/Org/Repo.git")).toBe("my-app");
+    expect(findOnboardedProject(codebases, "org/other")).toBe("other-app");
+  });
+
+  it("returns undefined when no project uses the path", () => {
+    expect(findOnboardedProject(codebases, "org/unused")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty candidate", () => {
+    expect(findOnboardedProject(codebases, "")).toBeUndefined();
+    expect(findOnboardedProject(codebases, "/")).toBeUndefined();
+  });
+});
+
+describe("getRepoMembershipKey", () => {
+  it("is order-independent", () => {
+    const a = makeCodebase("a", "/org/a");
+    const b = makeCodebase("b", "/org/b");
+
+    expect(getRepoMembershipKey([a, b])).toBe(getRepoMembershipKey([b, a]));
+  });
+
+  it("changes when membership changes", () => {
+    const a = makeCodebase("a", "/org/a");
+    const b = makeCodebase("b", "/org/b");
+
+    expect(getRepoMembershipKey([a])).not.toBe(getRepoMembershipKey([a, b]));
   });
 });

--- a/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/utils.ts
+++ b/apps/client/src/modules/platform/codebases/pages/create/components/CreateCodebaseWizard/utils.ts
@@ -1,4 +1,23 @@
-import { gitProvider } from "@my-project/shared";
+import { gitProvider, normalizeGitUrlPath, type Codebase } from "@my-project/shared";
+import { sortByName } from "@/core/utils/sortByName";
 
 /** Whether the given Git provider value represents a Gerrit server. */
 export const isGerritProvider = (provider: string | null | undefined): boolean => provider === gitProvider.gerrit;
+
+/** Name of the project (Codebase) that already uses the given repository path, if any. */
+export const findOnboardedProject = (codebases: Codebase[], candidatePath: string): string | undefined => {
+  const normalizedCandidate = normalizeGitUrlPath(candidatePath);
+  if (!normalizedCandidate) {
+    return undefined;
+  }
+
+  return codebases.find((codebase) => normalizeGitUrlPath(codebase.spec.gitUrlPath) === normalizedCandidate)?.metadata
+    .name;
+};
+
+/** Content-stable key of (name, gitUrlPath) pairs for revalidation effects. */
+export const getRepoMembershipKey = (codebases: Codebase[]): string =>
+  codebases
+    .map((codebase) => `${codebase.metadata.name}:${codebase.spec.gitUrlPath}`)
+    .sort(sortByName)
+    .join("\n");

--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./createCodebaseDraft/index.js";
 export * from "./createCodebaseDraftSecret/index.js";
 export * from "./editCodebase/index.js";
 export * from "./checks/index.js";
+export * from "./normalizeGitUrlPath/index.js";

--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/normalizeGitUrlPath/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/normalizeGitUrlPath/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGitUrlPath } from "./index.js";
+
+describe("normalizeGitUrlPath", () => {
+  it("strips the leading slash", () => {
+    expect(normalizeGitUrlPath("/org/repo")).toBe("org/repo");
+  });
+
+  it("keeps a path without leading slash as is", () => {
+    expect(normalizeGitUrlPath("org/repo")).toBe("org/repo");
+  });
+
+  it("strips the .git suffix, including repeated ones", () => {
+    expect(normalizeGitUrlPath("org/repo.git")).toBe("org/repo");
+    expect(normalizeGitUrlPath("org/repo.git.git")).toBe("org/repo");
+  });
+
+  it("lowercases the path", () => {
+    expect(normalizeGitUrlPath("Org/Repo")).toBe("org/repo");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeGitUrlPath("  /org/repo  ")).toBe("org/repo");
+  });
+
+  it("normalizes all variants to the same value", () => {
+    expect(normalizeGitUrlPath(" /Org/Repo.git ")).toBe(normalizeGitUrlPath("org/repo"));
+  });
+
+  it("returns empty string for nullish or empty input", () => {
+    expect(normalizeGitUrlPath(null)).toBe("");
+    expect(normalizeGitUrlPath(undefined)).toBe("");
+    expect(normalizeGitUrlPath("")).toBe("");
+  });
+});

--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/normalizeGitUrlPath/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/normalizeGitUrlPath/index.ts
@@ -1,0 +1,19 @@
+import { stripLeadingSlash } from "../../../../../../../utils/index.js";
+
+/**
+ * Normalizes a git repository path for comparison across Codebase resources.
+ * Stored specs carry a leading slash while wizard-built candidates don't, and
+ * the Tekton interceptor matches paths case-insensitively — so comparisons must
+ * be slash-, case- and `.git`-suffix-insensitive.
+ *
+ * @example
+ * normalizeGitUrlPath("/Org/Repo.git") // "org/repo"
+ * normalizeGitUrlPath("org/repo")      // "org/repo"
+ */
+export const normalizeGitUrlPath = (path: string | null | undefined): string =>
+  stripLeadingSlash(
+    path
+      ?.trim()
+      .toLowerCase()
+      .replace(/(\.git)+$/, "")
+  );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
         "**/useFilter.tsx",
         "**/useColumns.tsx",
         "**/useDefaultValues.ts",
+        "**/useOnboardedRepoCheck.ts",
 
         // ============================================
         // INFRASTRUCTURE & SETUP


### PR DESCRIPTION
Creating a project that collided with an existing one failed only after the whole wizard was completed, surfacing a raw Kubernetes 409 error in a truncated toast.

- show an inline error while typing when the project name is already taken
- show an inline error when the selected repository is already onboarded, naming the conflicting project
- backend checks remain the authoritative enforcement

