### PR TITLE
EPMDEDP-17229: fix: harden integration configuration against SSRF probing and stored XSS

### DIFF
--- a/apps/client/src/modules/platform/configuration/components/IntegrationCard/index.tsx
+++ b/apps/client/src/modules/platform/configuration/components/IntegrationCard/index.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/core/components/ui/button";
 import { Badge } from "@/core/components/ui/badge";
 import { ExternalLink } from "lucide-react";
 import React from "react";
+import { safeHttpsHref } from "@my-project/shared";
 import { CopyIconButton } from "../CopyIconButton";
 import { cn } from "@/core/utils/classname";
 
@@ -57,6 +58,8 @@ interface IntegrationCardLinkRowProps {
 }
 
 function IntegrationCardLinkRow({ label, href, icon, copyValue }: IntegrationCardLinkRowProps) {
+  const safeHref = safeHttpsHref(href);
+
   return (
     <div className={ROW_CLASS}>
       <div className="flex items-center justify-between">
@@ -64,14 +67,29 @@ function IntegrationCardLinkRow({ label, href, icon, copyValue }: IntegrationCar
           <div className={cn(ROW_ICON_BOX_CLASS, "bg-primary/10 text-primary")}>{icon}</div>
           <div>
             <div className="text-foreground mb-0.5 text-sm">{label}</div>
-            <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary text-xs hover:underline">
-              {href}
-            </a>
+            {safeHref ? (
+              <a
+                href={safeHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary text-xs hover:underline"
+              >
+                {href}
+              </a>
+            ) : (
+              <span className="text-muted-foreground text-xs">{href}</span>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-1">
           {copyValue !== undefined && <CopyIconButton value={copyValue} />}
-          <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => window.open(href, "_blank")}>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            disabled={!safeHref}
+            onClick={() => window.open(safeHref, "_blank", "noopener,noreferrer")}
+          >
             <ExternalLink className="text-muted-foreground h-3.5 w-3.5" />
           </Button>
         </div>

--- a/packages/shared/src/utils/httpsUrl.test.ts
+++ b/packages/shared/src/utils/httpsUrl.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { isHttpsUrl, safeHttpsHref, httpsUrlSchema } from "./httpsUrl.js";
+
+describe("isHttpsUrl", () => {
+  it("accepts https URLs", () => {
+    expect(isHttpsUrl("https://argocd.example.com")).toBe(true);
+    expect(isHttpsUrl("https://host:8443/path?q=1")).toBe(true);
+  });
+
+  it("rejects non-https schemes and malformed input", () => {
+    expect(isHttpsUrl("http://argocd.example.com")).toBe(false);
+    expect(isHttpsUrl("javascript:alert(document.cookie)")).toBe(false);
+    expect(isHttpsUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isHttpsUrl("/relative/path")).toBe(false);
+    expect(isHttpsUrl("not a url")).toBe(false);
+    expect(isHttpsUrl("")).toBe(false);
+    expect(isHttpsUrl(undefined)).toBe(false);
+    expect(isHttpsUrl(null)).toBe(false);
+  });
+});
+
+describe("safeHttpsHref", () => {
+  it("returns the url when https, otherwise undefined", () => {
+    expect(safeHttpsHref("https://ok.example.com")).toBe("https://ok.example.com");
+    expect(safeHttpsHref("javascript:alert(1)")).toBeUndefined();
+    expect(safeHttpsHref("http://insecure.example.com")).toBeUndefined();
+  });
+});
+
+describe("httpsUrlSchema", () => {
+  it("passes https and fails everything else", () => {
+    expect(httpsUrlSchema.safeParse("https://ok.example.com").success).toBe(true);
+    expect(httpsUrlSchema.safeParse("javascript:alert(1)").success).toBe(false);
+    expect(httpsUrlSchema.safeParse("http://insecure.example.com").success).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/httpsUrl.ts
+++ b/packages/shared/src/utils/httpsUrl.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/**
+ * Returns true only when `value` parses as an absolute URL with the `https:`
+ * scheme. Anything else — `http:`, `javascript:`, `data:`, a relative path, or
+ * an unparseable string — returns false.
+ */
+export function isHttpsUrl(value: string | null | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns `value` when it is an `https:` URL, otherwise `undefined`. Use at
+ * render time to decide whether a stored URL may be used as a link target.
+ */
+export function safeHttpsHref(value: string | null | undefined): string | undefined {
+  return isHttpsUrl(value) ? value : undefined;
+}
+
+/** Zod schema for a required, user-facing link that must be an `https:` URL. */
+export const httpsUrlSchema = z.string().refine(isHttpsUrl, {
+  message: "Must be a valid https:// URL",
+});

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -7,5 +7,6 @@ export * from "./truncateName.js";
 export * from "./versioning.js";
 export * from "./stripLeadingSlash.js";
 export * from "./stripTrailingSlash.js";
+export * from "./httpsUrl.js";
 export * from "./tryParseJsonArray.js";
 export * from "./sortByName.js";

--- a/packages/trpc/src/routers/k8s/procedures/composite/manageArgoCDIntegration/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/manageArgoCDIntegration/index.ts
@@ -11,6 +11,7 @@ import {
   k8sQuickLinkConfig,
   editQuickLinkURL,
   QuickLink,
+  httpsUrlSchema,
 } from "@my-project/shared";
 
 /**
@@ -27,7 +28,7 @@ const manageArgoCDIntegrationInputSchema = z.object({
   quickLink: z
     .object({
       name: z.string(),
-      externalUrl: z.string(),
+      externalUrl: httpsUrlSchema,
       currentResource: z.any().optional(), // The existing QuickLink resource (for edit mode)
     })
     .optional(),

--- a/packages/trpc/src/routers/k8s/procedures/composite/manageChatAssistantIntegration/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/manageChatAssistantIntegration/index.ts
@@ -11,6 +11,7 @@ import {
   k8sQuickLinkConfig,
   editQuickLinkURL,
   QuickLink,
+  httpsUrlSchema,
 } from "@my-project/shared";
 
 const manageChatAssistantIntegrationInputSchema = z.object({
@@ -24,7 +25,7 @@ const manageChatAssistantIntegrationInputSchema = z.object({
   quickLink: z
     .object({
       name: z.string(),
-      externalUrl: z.string(),
+      externalUrl: httpsUrlSchema,
       currentResource: z.any().optional(),
     })
     .optional(),

--- a/packages/trpc/src/routers/k8s/procedures/composite/manageDefectDojoIntegration/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/manageDefectDojoIntegration/index.ts
@@ -11,6 +11,7 @@ import {
   k8sQuickLinkConfig,
   editQuickLinkURL,
   QuickLink,
+  httpsUrlSchema,
 } from "@my-project/shared";
 
 const manageDefectDojoIntegrationInputSchema = z.object({
@@ -24,7 +25,7 @@ const manageDefectDojoIntegrationInputSchema = z.object({
   quickLink: z
     .object({
       name: z.string(),
-      externalUrl: z.string(),
+      externalUrl: httpsUrlSchema,
       currentResource: z.any().optional(),
     })
     .optional(),

--- a/packages/trpc/src/routers/k8s/procedures/composite/manageDependencyTrackIntegration/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/manageDependencyTrackIntegration/index.ts
@@ -11,6 +11,7 @@ import {
   k8sQuickLinkConfig,
   editQuickLinkURL,
   QuickLink,
+  httpsUrlSchema,
 } from "@my-project/shared";
 
 const manageDependencyTrackIntegrationInputSchema = z.object({
@@ -24,7 +25,7 @@ const manageDependencyTrackIntegrationInputSchema = z.object({
   quickLink: z
     .object({
       name: z.string(),
-      externalUrl: z.string(),
+      externalUrl: httpsUrlSchema,
       currentResource: z.any().optional(),
     })
     .optional(),

--- a/packages/trpc/src/routers/k8s/procedures/composite/manageJiraIntegration/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/manageJiraIntegration/index.ts
@@ -15,6 +15,7 @@ import {
   createJiraServerDraft,
   editJiraServer,
   JiraServer,
+  httpsUrlSchema,
 } from "@my-project/shared";
 
 const manageJiraIntegrationInputSchema = z.object({
@@ -33,7 +34,7 @@ const manageJiraIntegrationInputSchema = z.object({
   quickLink: z
     .object({
       name: z.string(),
-      externalUrl: z.string(),
+      externalUrl: httpsUrlSchema,
       currentResource: z.any().optional(),
     })
     .optional(),

--- a/packages/trpc/src/routers/k8s/procedures/composite/manageNexusIntegration/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/manageNexusIntegration/index.ts
@@ -11,6 +11,7 @@ import {
   k8sQuickLinkConfig,
   editQuickLinkURL,
   QuickLink,
+  httpsUrlSchema,
 } from "@my-project/shared";
 
 const manageNexusIntegrationInputSchema = z.object({
@@ -24,7 +25,7 @@ const manageNexusIntegrationInputSchema = z.object({
   quickLink: z
     .object({
       name: z.string(),
-      externalUrl: z.string(),
+      externalUrl: httpsUrlSchema,
       currentResource: z.any().optional(),
     })
     .optional(),

--- a/packages/trpc/src/routers/k8s/procedures/composite/manageSonarIntegration/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/manageSonarIntegration/index.ts
@@ -11,6 +11,7 @@ import {
   k8sQuickLinkConfig,
   editQuickLinkURL,
   QuickLink,
+  httpsUrlSchema,
 } from "@my-project/shared";
 
 const manageSonarIntegrationInputSchema = z.object({
@@ -24,7 +25,7 @@ const manageSonarIntegrationInputSchema = z.object({
   quickLink: z
     .object({
       name: z.string(),
-      externalUrl: z.string(),
+      externalUrl: httpsUrlSchema,
       currentResource: z.any().optional(),
     })
     .optional(),

--- a/packages/trpc/src/routers/k8s/procedures/composite/testIntegrationConnection/index.test.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/testIntegrationConnection/index.test.ts
@@ -71,7 +71,7 @@ describe("k8sTestIntegrationConnectionProcedure", () => {
     expect(result).toEqual({ success: true });
   });
 
-  it("should return NETWORK when fetch rejects with a connection error", async () => {
+  it("should return a generic NETWORK message without the underlying errno", async () => {
     fetchSpy.mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
 
     const caller = createCaller(mockContext);
@@ -85,11 +85,13 @@ describe("k8sTestIntegrationConnectionProcedure", () => {
       success: false,
       error: "NETWORK",
     });
-    expect(result.message).toContain("ECONNREFUSED");
-    expect(result.message).toContain("Connection refused");
+    expect(result.message).not.toContain("ECONNREFUSED");
+    expect(result.message).toBe(
+      "Unable to connect to the service. Check that the URL is correct and reachable from the cluster."
+    );
   });
 
-  it("should extract cause from generic fetch failed errors", async () => {
+  it("should not surface the underlying cause from generic fetch failed errors", async () => {
     const causeError = new Error("connect EHOSTUNREACH 10.96.1.5:8081");
     const fetchError = new Error("fetch failed");
     (fetchError as any).cause = causeError;
@@ -106,7 +108,8 @@ describe("k8sTestIntegrationConnectionProcedure", () => {
       success: false,
       error: "NETWORK",
     });
-    expect(result.message).toContain("EHOSTUNREACH");
+    expect(result.message).not.toContain("EHOSTUNREACH");
+    expect(result.message).not.toContain("10.96.1.5");
   });
 
   it("should return TIMEOUT when the request is aborted after 10 seconds", async () => {

--- a/packages/trpc/src/routers/k8s/procedures/composite/testIntegrationConnection/index.ts
+++ b/packages/trpc/src/routers/k8s/procedures/composite/testIntegrationConnection/index.ts
@@ -104,34 +104,17 @@ export const k8sTestIntegrationConnectionProcedure = protectedProcedure
         };
       }
 
-      // Provide detailed network error messages
-      let errorMessage = "Unknown network error";
+      // Log the underlying cause server-side; return a generic message to the client.
       if (error instanceof Error) {
-        // Extract the underlying error from fetch's cause property
         const cause = "cause" in error ? error.cause : undefined;
-        const rootError = cause instanceof Error ? cause.message : error.message;
-        errorMessage = rootError;
-
-        // Add helpful context for common errors
-        if (errorMessage.includes("ENOTFOUND") || errorMessage.includes("getaddrinfo")) {
-          errorMessage = `DNS resolution failed: ${errorMessage}. Check if the service name and namespace are correct.`;
-        } else if (errorMessage.includes("ECONNREFUSED")) {
-          errorMessage = `Connection refused: ${errorMessage}. The service may not be running or the port may be incorrect.`;
-        } else if (errorMessage.includes("ETIMEDOUT")) {
-          errorMessage = `Connection timed out: ${errorMessage}. The service may be unreachable due to network policies.`;
-        } else if (errorMessage === "fetch failed") {
-          // If still generic, include both error and cause for debugging
-          errorMessage =
-            cause instanceof Error
-              ? `Network error: ${cause.message}`
-              : `Network error: ${error.message}. Check if the URL is accessible from the cluster.`;
-        }
+        const detail = cause instanceof Error ? cause.message : error.message;
+        console.error(`testIntegrationConnection network error [${serviceType}]: ${detail}`);
       }
 
       return {
         success: false as const,
         error: "NETWORK" as const,
-        message: errorMessage,
+        message: "Unable to connect to the service. Check that the URL is correct and reachable from the cluster.",
       };
     } finally {
       clearTimeout(timeoutId);


### PR DESCRIPTION


- Collapse testIntegrationConnection network errors into one generic client message so the endpoint no longer leaks errno-level diagnostics (DNS vs refused vs timeout) that let an authenticated caller fingerprint reachable internal hosts and ports; keep the detail server-side
- Enforce https-only on integration QuickLink URLs at the render layer (safeHttpsHref) so a javascript: or other non-https URI can never be used as a link target, even for data written directly to the QuickLink resource, and disable the open action for unsafe URLs
- Validate quickLink.externalUrl as an https URL (httpsUrlSchema) across all integration mutations, rejecting unsafe schemes before they are persisted

