### PR TITLE
EPMDEDP-17231: feat: persist SQLite session store on an optional PVC

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -78,13 +78,20 @@ A Helm chart for KubeRocketCI Portal
 | livenessProbe | object | `{"tcpSocket":{"port":"http"}}` | Liveness probe configuration |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` | Node selector for pod assignment https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
+| persistence | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""}` | Persistence for the SQLite session/events database. A ReadWriteOnce PVC mounted at the server's DB directory (`/app/db`) keeps sessions across pod restarts (RWO forces the Recreate strategy). Removed on `helm uninstall` — no retention policy. |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes for the PVC (RWO is required for the SQLite file lock) |
+| persistence.annotations | object | `{}` | Extra annotations for the PVC |
+| persistence.enabled | bool | `false` | Enable persistent storage for the SQLite database. Disabled by default. |
+| persistence.existingClaim | string | `""` | Bind an existing PVC instead of creating one. When set, no PVC is created. |
+| persistence.size | string | `"1Gi"` | Size of the PVC |
+| persistence.storageClass | string | `""` | StorageClass for the PVC. Empty uses the cluster default; "-" disables dynamic provisioning. |
 | podAnnotations | object | `{}` | Pod annotations |
 | podLabels | object | `{}` | Pod labels |
-| podSecurityContext | object | `{}` | Pod security context |
+| podSecurityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context. `fsGroup` chowns the persistence volume to this GID on mount so the non-root container can write the SQLite database. |
 | readinessProbe | object | `{"initialDelaySeconds":20,"tcpSocket":{"port":"http"}}` | Readiness probe configuration |
 | replicaCount | int | `1` | Number of replicas for the deployment |
 | resources | object | `{}` | Resource limits and requests |
-| securityContext | object | `{}` | Container security context |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Container security context |
 | service | object | `{"port":3000,"type":"ClusterIP"}` | Service configuration |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | Service account configuration |

--- a/deploy-templates/templates/_helpers.tpl
+++ b/deploy-templates/templates/_helpers.tpl
@@ -76,6 +76,11 @@ Create the name of the secretstore to use
   {{- end }}
 {{- end }}
 
+{{/* Server DB directory. Hardcoded contract, not user-configurable. */}}
+{{- define "krci-portal.dbMountPath" -}}
+/app/db
+{{- end -}}
+
 {{/*
 Return the appropriate apiVersion for External Secrets
 */}}

--- a/deploy-templates/templates/deployment.yaml
+++ b/deploy-templates/templates/deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   labels:
     {{- include "krci-portal.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.persistence.enabled }}
+  # ReadWriteOnce PVC forces Recreate: the old pod must release the volume before the new one mounts it.
+  strategy:
+    type: Recreate
+  {{- end }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
@@ -56,13 +61,26 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.persistence.enabled .Values.volumeMounts }}
           volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ include "krci-portal.dbMountPath" . }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or .Values.persistence.enabled .Values.volumes }}
       volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "krci-portal.fullname" .) }}
+        {{- end }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy-templates/templates/pvc.yaml
+++ b/deploy-templates/templates/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "krci-portal.fullname" . }}
+  labels:
+    {{- include "krci-portal.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if eq "-" .Values.persistence.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -92,18 +92,22 @@ podAnnotations: {}
 # -- Pod labels
 podLabels: {}
 
-# -- Pod security context
-podSecurityContext: {}
-  # fsGroup: 2000
+# -- Pod security context. `fsGroup` chowns the persistence volume to this GID on mount so the non-root container can write the SQLite database.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- Container security context
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  # readOnlyRootFilesystem: true  # needs a writable volume for every runtime write path besides the persistence mount
 
 # -- Service configuration
 service:
@@ -209,6 +213,22 @@ volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
+
+# -- Persistence for the SQLite session/events database. A ReadWriteOnce PVC mounted at the server's DB directory (`/app/db`) keeps sessions across pod restarts (RWO forces the Recreate strategy). Removed on `helm uninstall` — no retention policy.
+persistence:
+  # -- Enable persistent storage for the SQLite database. Disabled by default.
+  enabled: false
+  # -- Bind an existing PVC instead of creating one. When set, no PVC is created.
+  existingClaim: ""
+  # -- StorageClass for the PVC. Empty uses the cluster default; "-" disables dynamic provisioning.
+  storageClass: ""
+  # -- Access modes for the PVC (RWO is required for the SQLite file lock)
+  accessModes:
+    - ReadWriteOnce
+  # -- Size of the PVC
+  size: 1Gi
+  # -- Extra annotations for the PVC
+  annotations: {}
 
 # -- Node selector for pod assignment
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector


### PR DESCRIPTION
- Add an optional ReadWriteOnce PersistentVolumeClaim mounted at the server DB directory so user sessions and events survive pod restarts and redeploys
- Switch the Deployment to the Recreate strategy when persistence is enabled, since an RWO volume cannot be shared during a rolling update
- Disable persistence by default so it can be opted into per environment overlay
- Harden the pod to run non-root with an fsGroup, letting the container write the volume, plus seccomp RuntimeDefault and dropped capabilities
