### PR TITLE
EPMDEDP-17231: fix: make SQLite DB directory writable for the non-root runtime user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ COPY deploy/server/db ./db
 COPY deploy/server/node_modules ./node_modules
 COPY deploy/server/package.json ./package.json
 
+RUN chown -R 1000:0 /app/db && chmod -R g+rwX /app/db
+
+USER 1000
+
 EXPOSE 3000
 
 CMD ["node", "./dist/index.js"]


### PR DESCRIPTION


- Chown /app/db to UID 1000 / GID 0 and grant group write so the container can create the SQLite database and its journal/WAL files without a mounted PVC
- Set USER 1000 to keep the image non-root even when the chart's podSecurityContext is absent
- Resolves SQLITE_READONLY on startup when persistence is disabled, since fsGroup only chowns the mounted volume and left the baked-in db directory root-owned

