### PR TITLE
EPMDEDP-17229: fix: remove ReDoS-prone regex from git URL path normalization

### DIFF
--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/normalizeGitUrlPath/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/normalizeGitUrlPath/index.test.ts
@@ -15,6 +15,15 @@ describe("normalizeGitUrlPath", () => {
     expect(normalizeGitUrlPath("org/repo.git.git")).toBe("org/repo");
   });
 
+  it("strips a trailing slash", () => {
+    expect(normalizeGitUrlPath("org/repo/")).toBe("org/repo");
+    expect(normalizeGitUrlPath("/org/repo.git/")).toBe("org/repo");
+  });
+
+  it("collapses duplicate and surrounding slashes", () => {
+    expect(normalizeGitUrlPath("//org//repo//")).toBe("org/repo");
+  });
+
   it("lowercases the path", () => {
     expect(normalizeGitUrlPath("Org/Repo")).toBe("org/repo");
   });

--- a/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/normalizeGitUrlPath/index.ts
+++ b/packages/shared/src/models/k8s/groups/KRCI/Codebase/utils/normalizeGitUrlPath/index.ts
@@ -1,19 +1,35 @@
-import { stripLeadingSlash } from "../../../../../../../utils/index.js";
+import { stripLeadingSlash, stripTrailingSlash } from "../../../../../../../utils/index.js";
+
+const GIT_SUFFIX = ".git";
+
+// A loop rather than a `(\.git)+$` regex: the repeating group is a polynomial
+// ReDoS backtracking risk on pathological input, whereas this stays linear.
+function stripTrailingGitSuffixes(value: string): string {
+  let result = value;
+  while (result.endsWith(GIT_SUFFIX)) {
+    result = result.slice(0, -GIT_SUFFIX.length);
+  }
+  return result;
+}
 
 /**
  * Normalizes a git repository path for comparison across Codebase resources.
  * Stored specs carry a leading slash while wizard-built candidates don't, and
  * the Tekton interceptor matches paths case-insensitively — so comparisons must
- * be slash-, case- and `.git`-suffix-insensitive.
+ * be slash-, case- and `.git`-suffix-insensitive. Wizard input is slash-normal,
+ * but Codebases created out-of-band (e.g. raw `kubectl apply`) can carry
+ * surrounding or duplicate slashes that bypass form validation, so those are
+ * collapsed too before comparison.
  *
  * @example
  * normalizeGitUrlPath("/Org/Repo.git") // "org/repo"
  * normalizeGitUrlPath("org/repo")      // "org/repo"
  */
-export const normalizeGitUrlPath = (path: string | null | undefined): string =>
-  stripLeadingSlash(
-    path
-      ?.trim()
-      .toLowerCase()
-      .replace(/(\.git)+$/, "")
-  );
+export function normalizeGitUrlPath(path: string | null | undefined): string {
+  if (!path) {
+    return "";
+  }
+  const collapsed = path.trim().toLowerCase().replace(/\/+/g, "/");
+  const slashNormalized = stripLeadingSlash(stripTrailingSlash(collapsed));
+  return stripTrailingGitSuffixes(slashNormalized);
+}


### PR DESCRIPTION


The `(\.git)+$` regex used to strip trailing `.git` suffixes backtracks super-linearly on crafted input, flagged by CodeQL (js/polynomial-redos) and SonarQube (S5852). Replace it with a linear suffix-stripping loop so neither scanner alerts and untrusted `gitUrlPath` values can't stall the UI.

