### PR TITLE
EPMDEDP-17234: fix: bind each pipeline task to its own TaskRun

### DIFF
--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/data.ts
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/data.ts
@@ -178,12 +178,12 @@ export function useUnifiedPipelineRunData({ namespace, name }: UnifiedPipelineRu
       tasks: isLive ? tasksWatch.data.array : undefined,
       taskRuns: taskRunsArray,
       approvalTasks: approvalTasksArray,
-      pipelineRunName: resolvedPipelineRun?.metadata?.name,
+      childReferences: resolvedPipelineRun?.status?.childReferences,
     });
   }, [
     isLive,
     pipelineRunTasks.allTasks,
-    resolvedPipelineRun?.metadata?.name,
+    resolvedPipelineRun?.status?.childReferences,
     tasksWatch.data.array,
     taskRunsWatch.data.array,
     approvalTasksWatch.data.array,

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/utils.test.ts
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/utils.test.ts
@@ -1,0 +1,119 @@
+import { ApprovalTask, approvalTaskLabels, PipelineTask, Task, TaskRun, taskRunLabels } from "@my-project/shared";
+import { describe, expect, it } from "vitest";
+import { buildPipelineRunTasksByNameMap, buildTaskRunIndex, findTaskRunForPipelineTask } from "./utils";
+
+const PIPELINE_RUN_NAME = "review-sonar-operator-master-9grsx";
+
+const makeTaskRun = (name: string, pipelineTaskLabel?: string): TaskRun =>
+  ({
+    metadata: {
+      name,
+      ...(pipelineTaskLabel ? { labels: { [taskRunLabels.pipelineTask]: pipelineTaskLabel } } : {}),
+    },
+  }) as TaskRun;
+
+const makePipelineTask = (name: string, taskRefName?: string): PipelineTask =>
+  ({ name, ...(taskRefName ? { taskRef: { name: taskRefName } } : {}) }) as PipelineTask;
+
+const makeTask = (name: string): Task => ({ metadata: { name } }) as Task;
+
+const makeApprovalTask = (name: string, pipelineTaskLabel: string): ApprovalTask =>
+  ({
+    metadata: { name, labels: { [approvalTaskLabels.pipelineTask]: pipelineTaskLabel } },
+  }) as unknown as ApprovalTask;
+
+describe("findTaskRunForPipelineTask", () => {
+  it("matches by the pipelineTask label", () => {
+    const index = buildTaskRunIndex([
+      makeTaskRun(`${PIPELINE_RUN_NAME}-sonar-integration-test`, "sonar-integration-test"),
+      makeTaskRun(`${PIPELINE_RUN_NAME}-sonar`, "sonar"),
+    ]);
+
+    expect(findTaskRunForPipelineTask(index, "sonar")?.metadata?.name).toBe(`${PIPELINE_RUN_NAME}-sonar`);
+  });
+
+  it("does not bind a task to a sibling whose name it prefixes when its TaskRun is absent", () => {
+    const index = buildTaskRunIndex(
+      [makeTaskRun(`${PIPELINE_RUN_NAME}-sonar-integration-test`, "sonar-integration-test")],
+      [{ pipelineTaskName: "sonar-integration-test", name: `${PIPELINE_RUN_NAME}-sonar-integration-test` }]
+    );
+
+    expect(findTaskRunForPipelineTask(index, "sonar")).toBeUndefined();
+  });
+
+  it("falls back to the child reference name for unlabeled TaskRuns", () => {
+    const index = buildTaskRunIndex(
+      [makeTaskRun(`${PIPELINE_RUN_NAME}-sonar-integration-test`), makeTaskRun("r4b6fb41c9-sonar")],
+      [
+        { pipelineTaskName: "sonar", name: "r4b6fb41c9-sonar" },
+        { pipelineTaskName: "sonar-integration-test", name: `${PIPELINE_RUN_NAME}-sonar-integration-test` },
+      ]
+    );
+
+    expect(findTaskRunForPipelineTask(index, "sonar")?.metadata?.name).toBe("r4b6fb41c9-sonar");
+  });
+
+  it("keeps the first TaskRun when several share a pipelineTask label", () => {
+    const index = buildTaskRunIndex([makeTaskRun("first", "sonar"), makeTaskRun("second", "sonar")]);
+
+    expect(findTaskRunForPipelineTask(index, "sonar")?.metadata?.name).toBe("first");
+  });
+
+  it("returns undefined for a pipeline task without a name", () => {
+    expect(findTaskRunForPipelineTask(buildTaskRunIndex([makeTaskRun("x", "y")]), undefined)).toBeUndefined();
+  });
+});
+
+describe("buildPipelineRunTasksByNameMap", () => {
+  it("keeps prefix-colliding tasks bound to distinct TaskRuns", () => {
+    const map = buildPipelineRunTasksByNameMap({
+      allPipelineTasks: [makePipelineTask("sonar"), makePipelineTask("sonar-integration-test")],
+      taskRuns: [makeTaskRun(`${PIPELINE_RUN_NAME}-sonar-integration-test`, "sonar-integration-test")],
+      approvalTasks: [],
+      childReferences: [
+        { pipelineTaskName: "sonar-integration-test", name: `${PIPELINE_RUN_NAME}-sonar-integration-test` },
+      ],
+    });
+
+    expect(map.get("sonar")?.taskRun).toBeUndefined();
+    expect(map.get("sonar-integration-test")?.taskRun?.metadata?.name).toBe(
+      `${PIPELINE_RUN_NAME}-sonar-integration-test`
+    );
+  });
+
+  it("resolves the Task by taskRef name and the ApprovalTask by label", () => {
+    const map = buildPipelineRunTasksByNameMap({
+      allPipelineTasks: [makePipelineTask("sonar", "sonar-scanner-task")],
+      tasks: [makeTask("unrelated-task"), makeTask("sonar-scanner-task")],
+      taskRuns: [],
+      approvalTasks: [makeApprovalTask("approve-sonar", "sonar")],
+      childReferences: [],
+    });
+
+    const entry = map.get("sonar");
+    expect(entry?.task?.metadata?.name).toBe("sonar-scanner-task");
+    expect(entry?.approvalTask?.metadata?.name).toBe("approve-sonar");
+  });
+
+  it("leaves the Task unresolved when the pipeline task has no taskRef", () => {
+    const map = buildPipelineRunTasksByNameMap({
+      allPipelineTasks: [makePipelineTask("sonar")],
+      tasks: [makeTask("sonar")],
+      taskRuns: [],
+      approvalTasks: [],
+    });
+
+    expect(map.get("sonar")?.task).toBeUndefined();
+  });
+
+  it("skips pipeline tasks without a name", () => {
+    const map = buildPipelineRunTasksByNameMap({
+      allPipelineTasks: [{} as PipelineTask, makePipelineTask("sonar")],
+      taskRuns: [],
+      approvalTasks: [],
+    });
+
+    expect(map.size).toBe(1);
+    expect(map.has("sonar")).toBe(true);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/utils.ts
+++ b/apps/client/src/modules/platform/tekton/pages/pipelinerun-details/hooks/utils.ts
@@ -1,34 +1,55 @@
-import { ApprovalTask, approvalTaskLabels, PipelineTask, Task, TaskRun, taskRunLabels } from "@my-project/shared";
+import {
+  ApprovalTask,
+  approvalTaskLabels,
+  buildTaskRunNameByPipelineTaskMap,
+  PipelineRunChildReference,
+  PipelineTask,
+  Task,
+  TaskRun,
+  taskRunLabels,
+} from "@my-project/shared";
 import type { PipelineRunTaskData } from "./types";
 
-export const findTaskForPipelineTask = (tasks: Task[], pipelineTask: PipelineTask): Task | undefined => {
-  return tasks.find((task) => task.metadata?.name === pipelineTask?.taskRef?.name);
+/** Keeps the first item per key, so lookups resolve as the equivalent Array.prototype.find would have. */
+const indexByKey = <T>(items: T[], keyOf: (item: T) => string | undefined): Map<string, T> => {
+  const map = new Map<string, T>();
+
+  for (const item of items) {
+    const key = keyOf(item);
+    if (key && !map.has(key)) {
+      map.set(key, item);
+    }
+  }
+
+  return map;
 };
 
-export const findTaskRunForPipelineTask = (
+export interface TaskRunIndex {
+  byPipelineTask: Map<string, TaskRun>;
+  byName: Map<string, TaskRun>;
+  nameByPipelineTask: Map<string, string>;
+}
+
+export const buildTaskRunIndex = (
   taskRuns: TaskRun[],
-  pipelineTask: PipelineTask,
-  pipelineRunName?: string
-): TaskRun | undefined => {
-  const byLabel = taskRuns.find(
-    (taskRun) => taskRun.metadata?.labels?.[taskRunLabels.pipelineTask] === pipelineTask?.name
-  );
-  if (byLabel) return byLabel;
-  if (!pipelineRunName || !pipelineTask?.name) return undefined;
-  const prefix = `${pipelineRunName}-${pipelineTask.name}-`;
-  return taskRuns.find((taskRun) => {
-    const n = taskRun.metadata?.name;
-    return typeof n === "string" && n.startsWith(prefix);
-  });
-};
+  childReferences?: PipelineRunChildReference[]
+): TaskRunIndex => ({
+  byPipelineTask: indexByKey(taskRuns, (taskRun) => taskRun.metadata?.labels?.[taskRunLabels.pipelineTask]),
+  byName: indexByKey(taskRuns, (taskRun) => taskRun.metadata?.name),
+  nameByPipelineTask: buildTaskRunNameByPipelineTaskMap(childReferences),
+});
 
-export const findApprovalTaskForPipelineTask = (
-  approvalTasks: ApprovalTask[],
-  pipelineTask: PipelineTask
-): ApprovalTask | undefined => {
-  return approvalTasks.find(
-    (approvalTask) => approvalTask.metadata?.labels?.[approvalTaskLabels.pipelineTask] === pipelineTask?.name
-  );
+export const findTaskRunForPipelineTask = (index: TaskRunIndex, pipelineTaskName?: string): TaskRun | undefined => {
+  if (!pipelineTaskName) return undefined;
+
+  const byLabel = index.byPipelineTask.get(pipelineTaskName);
+  if (byLabel) return byLabel;
+
+  // Defense in depth: Tekton always sets this label on TaskRuns it creates, so this
+  // tier should rarely fire. Kept in case a TaskRun is observed before its label is set,
+  // or via a future Tekton Results/API path that doesn't preserve labels.
+  const taskRunName = index.nameByPipelineTask.get(pipelineTaskName);
+  return taskRunName ? index.byName.get(taskRunName) : undefined;
 };
 
 export const buildPipelineRunTasksByNameMap = (params: {
@@ -36,17 +57,32 @@ export const buildPipelineRunTasksByNameMap = (params: {
   tasks?: Task[];
   taskRuns: TaskRun[];
   approvalTasks: ApprovalTask[];
-  pipelineRunName?: string;
+  childReferences?: PipelineRunChildReference[];
 }): Map<string, PipelineRunTaskData> => {
-  const { allPipelineTasks, tasks = [], taskRuns, approvalTasks, pipelineRunName } = params;
-  return allPipelineTasks.reduce((acc, pipelineTask) => {
-    if (!pipelineTask.name) return acc;
-    acc.set(pipelineTask.name, {
+  const { allPipelineTasks, tasks = [], taskRuns, approvalTasks, childReferences } = params;
+
+  // `tasks` is the namespace-wide Task list, so scanning it per pipeline task was the dominant cost.
+  const taskByName = indexByKey(tasks, (task) => task.metadata?.name);
+  const approvalTaskByPipelineTask = indexByKey(
+    approvalTasks,
+    (approvalTask) => approvalTask.metadata?.labels?.[approvalTaskLabels.pipelineTask]
+  );
+  const taskRunIndex = buildTaskRunIndex(taskRuns, childReferences);
+
+  const result = new Map<string, PipelineRunTaskData>();
+
+  for (const pipelineTask of allPipelineTasks) {
+    if (!pipelineTask.name) continue;
+
+    const taskRefName = pipelineTask.taskRef?.name;
+
+    result.set(pipelineTask.name, {
       pipelineRunTask: pipelineTask,
-      task: findTaskForPipelineTask(tasks, pipelineTask),
-      taskRun: findTaskRunForPipelineTask(taskRuns, pipelineTask, pipelineRunName),
-      approvalTask: findApprovalTaskForPipelineTask(approvalTasks, pipelineTask),
+      task: taskRefName ? taskByName.get(taskRefName) : undefined,
+      taskRun: findTaskRunForPipelineTask(taskRunIndex, pipelineTask.name),
+      approvalTask: approvalTaskByPipelineTask.get(pipelineTask.name),
     });
-    return acc;
-  }, new Map<string, PipelineRunTaskData>());
+  }
+
+  return result;
 };

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/childReferences/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/childReferences/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildTaskRunNameByPipelineTaskMap, isTaskRunChildReference, type PipelineRunChildReference } from "./index.js";
+
+const PIPELINE_RUN_NAME = "review-sonar-operator-master-9grsx";
+
+describe("isTaskRunChildReference", () => {
+  it("accepts TaskRun and unspecified kinds", () => {
+    expect(isTaskRunChildReference({ kind: "TaskRun" })).toBe(true);
+    expect(isTaskRunChildReference({})).toBe(true);
+  });
+
+  it("rejects CustomRun children", () => {
+    expect(isTaskRunChildReference({ kind: "Run" })).toBe(false);
+  });
+});
+
+describe("buildTaskRunNameByPipelineTaskMap", () => {
+  it("maps pipeline task names to their TaskRun names", () => {
+    const map = buildTaskRunNameByPipelineTaskMap([
+      { pipelineTaskName: "sonar", name: `${PIPELINE_RUN_NAME}-sonar` },
+      { pipelineTaskName: "sonar-integration-test", name: `${PIPELINE_RUN_NAME}-sonar-integration-test` },
+    ]);
+
+    expect(map.get("sonar")).toBe(`${PIPELINE_RUN_NAME}-sonar`);
+    expect(map.get("sonar-integration-test")).toBe(`${PIPELINE_RUN_NAME}-sonar-integration-test`);
+  });
+
+  it("maps hashed TaskRun names that cannot be derived from the pipeline task name", () => {
+    const map = buildTaskRunNameByPipelineTaskMap([
+      {
+        pipelineTaskName: "github-report-pipeline-status",
+        name: "r4b6fb41c94b7ea194670faf5a9795c34-github-report-pipeline-status",
+      },
+    ]);
+
+    expect(map.get("github-report-pipeline-status")).toBe(
+      "r4b6fb41c94b7ea194670faf5a9795c34-github-report-pipeline-status"
+    );
+  });
+
+  it("skips incomplete child references and tolerates missing input", () => {
+    expect(buildTaskRunNameByPipelineTaskMap(undefined).size).toBe(0);
+    expect(buildTaskRunNameByPipelineTaskMap([]).size).toBe(0);
+    expect(buildTaskRunNameByPipelineTaskMap([{ pipelineTaskName: "sonar" }, { name: "orphan" }]).size).toBe(0);
+  });
+
+  it("excludes CustomRun children", () => {
+    const childReferences = [
+      { pipelineTaskName: "sonar", name: `${PIPELINE_RUN_NAME}-sonar`, kind: "Run" },
+    ] as PipelineRunChildReference[];
+
+    expect(buildTaskRunNameByPipelineTaskMap(childReferences).size).toBe(0);
+  });
+});

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/childReferences/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/childReferences/index.ts
@@ -1,0 +1,31 @@
+import type { PipelineRun } from "../../types.js";
+
+export type PipelineRunChildReference = NonNullable<NonNullable<PipelineRun["status"]>["childReferences"]>[number];
+
+/**
+ * A child reference points at a TaskRun unless its kind is "Run" — those are
+ * v1alpha1 CustomRun children, which are not TaskRuns and never appear in a
+ * TaskRun list. Every reader of status.childReferences must apply this filter,
+ * or a CustomRun name can be paired with an unrelated TaskRun of the same name.
+ */
+export const isTaskRunChildReference = (childReference: PipelineRunChildReference): boolean =>
+  childReference.kind !== "Run";
+
+/**
+ * The authoritative pipeline task -> TaskRun link. TaskRun names cannot be derived
+ * from the pipeline task name, since Tekton truncates and hashes long names.
+ */
+export const buildTaskRunNameByPipelineTaskMap = (
+  childReferences?: PipelineRunChildReference[]
+): Map<string, string> => {
+  const map = new Map<string, string>();
+
+  for (const childReference of childReferences ?? []) {
+    if (!isTaskRunChildReference(childReference)) continue;
+    if (childReference.pipelineTaskName && childReference.name) {
+      map.set(childReference.pipelineTaskName, childReference.name);
+    }
+  }
+
+  return map;
+};

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/getPipelineRunTaskGraphDefinitions/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/getPipelineRunTaskGraphDefinitions/index.ts
@@ -1,5 +1,6 @@
 import type { PipelineTask } from "../../../Pipeline/types.js";
 import type { PipelineRun } from "../../types.js";
+import { isTaskRunChildReference } from "../childReferences/index.js";
 
 export interface PipelineRunTaskGraphDefinitions {
   allTasks: PipelineTask[];
@@ -34,7 +35,7 @@ export function getPipelineRunTaskGraphDefinitions(
     const names = [
       ...new Set(
         pipelineRun.status.childReferences
-          .filter((ref) => ref.pipelineTaskName && ref.kind !== "Run")
+          .filter((ref) => ref.pipelineTaskName && isTaskRunChildReference(ref))
           .map((ref) => ref.pipelineTaskName as string)
       ),
     ];

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/index.ts
@@ -7,6 +7,7 @@ export * from "./createRerunPipelineRun/index.js";
 export * from "./getPipelineRunStatus/index.js";
 export * from "./isPipelineRunInProgress/index.js";
 export * from "./getPipelineRunAnnotation/index.js";
+export * from "./childReferences/index.js";
 export * from "./getPipelineRunTaskGraphDefinitions/index.js";
 export * from "./isHistoryPipelineRun/index.js";
 export * from "./resultAnnotations/index.js";


### PR DESCRIPTION
A pipeline task with no TaskRun yet fell back to guessing one by name prefix, which matched a longer sibling task's TaskRun ("sonar" matched "sonar-integration-test"). Both tasks then rendered identical steps and durations until the real TaskRun appeared, at which point the view silently self-corrected.

- Resolve unlabeled TaskRuns through the pipeline run's child references, the association Tekton itself publishes, instead of deriving a name; Tekton truncates and hashes long names, so no derivation is sound
- Move child reference parsing into the shared package so the rule excluding CustomRun children has a single home, shared with the existing task graph resolution rather than duplicated alongside it
- Index tasks, task runs and approval tasks once per rebuild instead of scanning them per pipeline task, preserving first-match semantics for duplicate keys

