### PR TITLE
EPMDEDP-17229: fix: correct Prettier format-on-write hook

### DIFF
--- a/.claude/hooks/prettier-on-write.sh
+++ b/.claude/hooks/prettier-on-write.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# PostToolUse(Write|Edit): format the file Claude just wrote.
+# No `set -e`: the edit is already applied, so formatting must never fail it.
+set -uo pipefail
+
+file=$(jq -r '.tool_response.filePath // .tool_input.file_path // empty')
+
+# Absolute path required: `dirname .` is a fixpoint, so a relative path spins the loop below.
+[ -n "$file" ] || exit 0
+case "$file" in
+  /*) ;;
+  *) exit 0 ;;
+esac
+
+# Narrower than Prettier's own support (it also handles .md/.yaml) — inherited from the previous hook.
+case "$file" in
+  *.ts | *.tsx | *.js | *.json | *.css | *.html) ;;
+  *) exit 0 ;;
+esac
+
+[ -f "$file" ] || exit 0
+
+# Prettier resolves plugins relative to cwd, not the config file: apps/client's tailwind plugin is only visible there.
+dir=$(dirname "$file")
+while [ "$dir" != "/" ]; do
+  if [ -f "$dir/prettier.config.js" ] || [ -f "$dir/.prettierrc" ] || [ -f "$dir/.prettierrc.json" ]; then
+    break
+  fi
+  dir=$(dirname "$dir")
+done
+
+# No config above the file: npx from / would fetch an unpinned Prettier.
+if [ "$dir" = "/" ]; then
+  exit 0
+fi
+
+cd "$dir" || exit 0
+
+# --stdin-filepath, not a path argument: Prettier globs its arguments, so routes/[id].tsx would format a different file.
+# npx, not node_modules/.bin/prettier: only apps/client has a local binary.
+tmp=$(mktemp) || exit 0
+if npx prettier --stdin-filepath "$file" --log-level warn <"$file" >"$tmp" && [ -s "$tmp" ]; then
+  cat "$tmp" >"$file" # cat, not mv: preserves inode and permissions
+else
+  echo "prettier-on-write: failed to format $file, left unchanged" >&2
+fi
+rm -f "$tmp"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,8 +15,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; echo \"$f\" | grep -qE '\\.(ts|tsx|js|json|css|html)$' || exit 0; d=$(dirname \"$f\"); while [ \"$d\" != \"/\" ]; do [ -f \"$d/prettier.config.js\" ] || [ -f \"$d/.prettierrc\" ] || [ -f \"$d/.prettierrc.json\" ] && break; d=$(dirname \"$d\"); done; cd \"$d\" && npx prettier --write \"$f\"; } 2>/dev/null || true",
-            "timeout": 30
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/prettier-on-write.sh\"",
+            "timeout": 10
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,23 +2,6 @@
 
 KubeRocketCI Portal — monorepo for a Kubernetes CI/CD platform UI.
 
-## Structure
-
-```
-apps/client    — React 19 SPA (Vite, Radix UI, Tailwind, TanStack Router/Query/Form)
-apps/server    — Fastify + tRPC v11 (session: SQLite, auth: OIDC via Keycloak/Azure AD)
-packages/trpc  — tRPC routers, procedures, Kubernetes API clients
-packages/shared — shared types, models, K8s resource interfaces
-```
-
-## Commands
-
-- `pnpm build` — build all (shared → trpc → server → client)
-- `pnpm tsc:check` — TypeScript validation
-- `pnpm lint:check` — ESLint
-- `pnpm test:coverage` — Vitest
-- `pnpm format:check` — Prettier
-
 ## Critical Conventions
 
 - All tRPC endpoints use `protectedProcedure` (never `publicProcedure`)


### PR DESCRIPTION
Fixes a non-terminating config lookup, an unpinned Prettier download for repo-root files, and glob expansion that formatted the wrong file. Failures are now reported rather than silenced.

Also drops project memory content derivable from the manifest and a directory listing.

