### PR TITLE
EPMDEDP-17247: feat: surface EventListener labelSelector in list and topology views

### DIFF
--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/EventListenerNode.stories.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/EventListenerNode.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ReactFlowProvider } from "@xyflow/react";
+import { eventListenerSchema } from "@my-project/shared";
+import { TriggerSelection } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { EventListenerNode } from "./EventListenerNode";
+
+const eventListener = eventListenerSchema.parse({
+  apiVersion: "triggers.tekton.dev/v1beta1",
+  kind: "EventListener",
+  metadata: {
+    name: "github-listener",
+    namespace: "edp-delivery",
+    uid: "u-el",
+    creationTimestamp: "2025-01-01T00:00:00Z",
+  },
+  spec: {},
+});
+
+const selection = (overrides: Partial<TriggerSelection> = {}): TriggerSelection => ({
+  labelSelectorActive: false,
+  terms: [],
+  listedCount: 3,
+  labelMatchedCount: 0,
+  gaps: [],
+  ...overrides,
+});
+
+const meta = {
+  title: "Feature/EventFlowDiagram/EventListenerNode",
+  component: EventListenerNode,
+  parameters: { layout: "centered" },
+  // Handle throws outside a ReactFlow store; the provider is the minimal host.
+  decorators: [
+    (Story) => (
+      <ReactFlowProvider>
+        <Story />
+      </ReactFlowProvider>
+    ),
+  ],
+  tags: ["autodocs"],
+} satisfies Meta<typeof EventListenerNode>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ready: Story = {
+  args: {
+    data: {
+      eventListener,
+      ready: true,
+      address: "http://el-github-listener.edp-delivery.svc:8080",
+      triggerSelection: selection(),
+    },
+  },
+};
+
+export const Degraded: Story = {
+  args: { data: { eventListener, ready: false, address: null, triggerSelection: selection() } },
+};
+
+/** Listed and label-matched Triggers are counted separately so the list view never disagrees. */
+export const WithLabelMatchedTriggers: Story = {
+  args: {
+    data: {
+      eventListener,
+      ready: true,
+      address: "http://el-github-listener.edp-delivery.svc:8080",
+      triggerSelection: selection({ labelSelectorActive: true, terms: ["app=el"], labelMatchedCount: 2 }),
+    },
+  },
+};
+
+/** Every reason the rendered Trigger set may be narrower than what the sink serves. */
+export const PartialView: Story = {
+  args: {
+    data: {
+      eventListener,
+      ready: true,
+      address: null,
+      triggerSelection: selection({
+        labelSelectorActive: true,
+        terms: ["app=el", "n Gt (3)"],
+        gaps: [
+          { kind: "triggersRestricted" },
+          { kind: "unsupportedOperators", operators: ["Gt"] },
+          { kind: "otherNamespaces", namespaces: ["*"] },
+        ],
+      }),
+    },
+  },
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/EventListenerNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/EventListenerNode.tsx
@@ -1,9 +1,14 @@
 import { Handle, Position } from "@xyflow/react";
-import { Webhook } from "lucide-react";
+import { Webhook, EyeOff } from "lucide-react";
 import { EventListener } from "@my-project/shared";
 import { Badge } from "@/core/components/ui/badge";
+import { Tooltip } from "@/core/components/ui/tooltip";
 import { cn } from "@/core/utils/classname";
+import { TriggerSelection } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import { describeSelectionGaps } from "../utils/selectionGaps";
 import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
+
+const pluralize = (count: number, noun: string) => `${count} ${noun}${count === 1 ? "" : "s"}`;
 
 export const EventListenerNode = ({
   data,
@@ -12,25 +17,38 @@ export const EventListenerNode = ({
     eventListener: EventListener;
     ready: boolean;
     address: string | null;
-    triggerCount: number;
+    triggerSelection: TriggerSelection;
   };
-}) => (
-  <div
-    className={cn(
-      "border-border rounded-lg border p-3 text-sm shadow-sm",
-      NODE_KIND_TAILWIND[NODE_KIND.EVENT_LISTENER]
-    )}
-  >
-    <Handle type="target" position={Position.Left} />
-    <Handle type="source" position={Position.Right} />
-    <div className="mb-1 flex items-center gap-2 font-medium">
-      <Webhook size={16} />
-      <span>{data.eventListener.metadata.name}</span>
-      {data.ready ? <Badge variant="success">Ready</Badge> : <Badge variant="destructive">Degraded</Badge>}
+}) => {
+  const { listedCount, labelMatchedCount, gaps } = data.triggerSelection;
+
+  return (
+    <div
+      className={cn(
+        "border-border rounded-lg border p-3 text-sm shadow-sm",
+        NODE_KIND_TAILWIND[NODE_KIND.EVENT_LISTENER]
+      )}
+    >
+      <Handle type="target" position={Position.Left} />
+      <Handle type="source" position={Position.Right} />
+      <div className="mb-1 flex items-center gap-2 font-medium">
+        <Webhook size={16} />
+        <span>{data.eventListener.metadata.name}</span>
+        {data.ready ? <Badge variant="success">Ready</Badge> : <Badge variant="destructive">Degraded</Badge>}
+        {gaps.length > 0 && (
+          <Tooltip title={describeSelectionGaps(gaps).join(" ")}>
+            <Badge variant="warning" tabIndex={0}>
+              <EyeOff size={10} />
+              partial view
+            </Badge>
+          </Tooltip>
+        )}
+      </div>
+      {data.address && <div className="text-muted-foreground font-mono text-xs">{data.address}</div>}
+      <div className="text-muted-foreground mt-1 text-xs">
+        {pluralize(listedCount, "trigger")}
+        {labelMatchedCount > 0 && ` · ${labelMatchedCount} via label`}
+      </div>
     </div>
-    {data.address && <div className="text-muted-foreground font-mono text-xs">{data.address}</div>}
-    <div className="text-muted-foreground mt-1 text-xs">
-      {data.triggerCount} trigger{data.triggerCount === 1 ? "" : "s"}
-    </div>
-  </div>
-);
+  );
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerNode.stories.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerNode.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ReactFlowProvider } from "@xyflow/react";
+import { triggerSchema } from "@my-project/shared";
+import { TriggerNode } from "./TriggerNode";
+
+const resolved = triggerSchema.parse({
+  apiVersion: "triggers.tekton.dev/v1beta1",
+  kind: "Trigger",
+  metadata: {
+    name: "github-build",
+    namespace: "edp-delivery",
+    uid: "u-1",
+    creationTimestamp: "2025-01-01T00:00:00Z",
+    labels: { "app.edp.epam.com/gitServer": "github" },
+  },
+  spec: {},
+});
+
+const meta = {
+  title: "Feature/EventFlowDiagram/TriggerNode",
+  component: TriggerNode,
+  parameters: { layout: "centered" },
+  // Handle throws outside a ReactFlow store; the provider is the minimal host.
+  decorators: [
+    (Story) => (
+      <ReactFlowProvider>
+        <Story />
+      </ReactFlowProvider>
+    ),
+  ],
+  tags: ["autodocs"],
+} satisfies Meta<typeof TriggerNode>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resolved: Story = {
+  args: { data: { triggerRef: "github-build", resolved, status: "resolved", namespace: "edp-delivery" } },
+};
+
+export const Missing: Story = {
+  args: { data: { triggerRef: "github-build", resolved: null, status: "missing", namespace: "edp-delivery" } },
+};
+
+/** The Trigger watch errored, so presence cannot be determined. */
+export const Restricted: Story = {
+  args: { data: { triggerRef: "github-build", resolved: null, status: "restricted", namespace: "edp-delivery" } },
+};
+
+/** Discovered through spec.labelSelector rather than spec.triggers. */
+export const ViaLabelSelector: Story = {
+  args: {
+    data: {
+      triggerRef: "github-build",
+      resolved,
+      status: "resolved",
+      namespace: "edp-delivery",
+      viaTerms: ["app.edp.epam.com/gitServer=github", "type in (build, review)"],
+    },
+  },
+};
+
+/** Both listed and label-matched — Tekton fires this Trigger twice per event. */
+export const FiresTwice: Story = {
+  args: {
+    data: {
+      triggerRef: "github-build",
+      resolved,
+      status: "resolved",
+      namespace: "edp-delivery",
+      firesTwice: true,
+    },
+  },
+};

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerNode.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/components/TriggerNode.tsx
@@ -1,7 +1,9 @@
 import { Handle, Position } from "@xyflow/react";
-import { Zap, AlertTriangle, Lock } from "lucide-react";
+import { Zap, AlertTriangle, Lock, Tag } from "lucide-react";
 import { Trigger } from "@my-project/shared";
 import { cn } from "@/core/utils/classname";
+import { Badge } from "@/core/components/ui/badge";
+import { Tooltip } from "@/core/components/ui/tooltip";
 import { NODE_KIND_TAILWIND, NODE_KIND } from "../constants";
 import { ResolutionStatusBadge } from "./ResolutionStatusBadge";
 import { ResolutionStatus } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
@@ -26,15 +28,39 @@ export const TriggerNode = ({
     resolved: Trigger | null;
     status: ResolutionStatus;
     namespace: string;
+    viaTerms?: string[];
+    firesTwice?: boolean;
   };
 }) => (
-  <div className={cn("border-border rounded-lg border p-3 text-sm shadow-sm", NODE_KIND_TAILWIND[NODE_KIND.TRIGGER])}>
+  <div
+    className={cn(
+      "border-border rounded-lg border p-3 text-sm shadow-sm",
+      NODE_KIND_TAILWIND[NODE_KIND.TRIGGER],
+      data.firesTwice && "border-destructive"
+    )}
+  >
     <Handle type="target" position={Position.Left} />
     <Handle type="source" position={Position.Right} />
     <div className="flex items-center gap-2 font-medium">
       {iconFor(data.status)}
       <span>{data.triggerRef}</span>
       <ResolutionStatusBadge status={data.status} resourceLabel="Trigger" />
+      {data.viaTerms && (
+        <Tooltip title={`Matched via labelSelector: ${data.viaTerms.join(", ") || "(no terms)"}`}>
+          <Badge variant="secondary" tabIndex={0}>
+            <Tag size={10} />
+            via label
+          </Badge>
+        </Tooltip>
+      )}
+      {data.firesTwice && (
+        <Tooltip title="This Trigger is both listed in spec.triggers and matched by spec.labelSelector — it fires twice per event.">
+          <Badge variant="destructive" tabIndex={0}>
+            <AlertTriangle size={10} />
+            fires twice
+          </Badge>
+        </Tooltip>
+      )}
     </div>
     <div className="text-muted-foreground mt-1 text-xs">{captionFor(data.status)}</div>
   </div>

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/hooks/useEventFlowGraphData.test.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/hooks/useEventFlowGraphData.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { eventListenerSchema, gitServerSchema } from "@my-project/shared";
+import { eventListenerSchema, gitServerSchema, triggerSchema } from "@my-project/shared";
 import { EventListenerTopology, ResolvedTriggerNode } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
 import { NODE_KIND } from "../constants";
 import { buildEdges, buildNodes } from "./useEventFlowGraphData";
@@ -20,6 +20,7 @@ const baseTopology = (overrides: Partial<EventListenerTopology>): EventListenerT
   ready: true,
   gitServer: null,
   triggers: [],
+  triggerSelection: { labelSelectorActive: false, terms: [], listedCount: 0, labelMatchedCount: 0, gaps: [] },
   ...overrides,
 });
 
@@ -34,6 +35,22 @@ const triggerRefNode = (overrides: Partial<ResolvedTriggerNode> = {}): ResolvedT
 
 const inlineNode = (overrides: Partial<ResolvedTriggerNode> = {}): ResolvedTriggerNode => ({
   source: { kind: "inline", name: "inline-1" },
+  interceptors: [],
+  bindings: [],
+  template: { ref: "tt", resolved: null, status: "resolved", pipelineRef: { kind: "unknown" } },
+  latestPipelineRun: null,
+  ...overrides,
+});
+
+const labelMatchedTrigger = triggerSchema.parse({
+  apiVersion: "triggers.tekton.dev/v1beta1",
+  kind: "Trigger",
+  metadata: { name: "lbl", namespace: ns, uid: "u-lbl", creationTimestamp: "2025-01-01T00:00:00Z", labels: {} },
+  spec: {},
+});
+
+const labelSelectorNode = (overrides: Partial<ResolvedTriggerNode> = {}): ResolvedTriggerNode => ({
+  source: { kind: "labelSelector", name: "lbl", matchedTerms: ["app=gitlab"], resolved: labelMatchedTrigger },
   interceptors: [],
   bindings: [],
   template: { ref: "tt", resolved: null, status: "resolved", pipelineRef: { kind: "unknown" } },
@@ -77,6 +94,24 @@ describe("buildNodes", () => {
       "node::template::inline-1-0",
       "node::pipeline::inline-1-0",
     ]);
+  });
+
+  test("labelSelector trigger emits trigger + template + pipeline nodes (like triggerRef)", () => {
+    const result = buildNodes(baseTopology({ triggers: [labelSelectorNode()] }));
+    expect(result.map((n) => n.id)).toEqual([
+      "node::eventListener",
+      "node::trigger::lbl-0",
+      "node::template::lbl-0",
+      "node::pipeline::lbl-0",
+    ]);
+    const triggerNode = result.find((n) => n.id === "node::trigger::lbl-0");
+    expect(triggerNode?.data).toMatchObject({ triggerRef: "lbl", viaTerms: ["app=gitlab"] });
+  });
+
+  test("firesTwice flag on a triggerRef entry is passed through to the trigger node data", () => {
+    const result = buildNodes(baseTopology({ triggers: [triggerRefNode({ firesTwice: true })] }));
+    const triggerNode = result.find((n) => n.id === "node::trigger::g-0");
+    expect(triggerNode?.data).toMatchObject({ firesTwice: true });
   });
 
   test("interceptors and bindings get unique numbered ids per trigger", () => {
@@ -249,6 +284,13 @@ describe("buildEdges", () => {
     expect(pairs).toContainEqual({ source: "node::binding::g-0::0", target: "node::template::g-0" });
     expect(pairs).toContainEqual({ source: "node::binding::g-0::1", target: "node::template::g-0" });
     expect(pairs).toContainEqual({ source: "node::binding::g-0::2", target: "node::template::g-0" });
+  });
+
+  test("labelSelector trigger emits a dashed EL → trigger edge (visually distinct from a listed triggerRef)", () => {
+    const edges = buildEdges(baseTopology({ triggers: [labelSelectorNode()] }));
+    const elToTrigger = edges.find((e) => e.id === "edge::el→trigger::lbl-0");
+    expect(elToTrigger).toMatchObject({ source: "node::eventListener", target: "node::trigger::lbl-0" });
+    expect(elToTrigger?.style).toMatchObject({ strokeDasharray: "6 4" });
   });
 
   test("inline trigger with no interceptors and multiple bindings: every binding has an incoming edge from the EventListener", () => {

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/hooks/useEventFlowGraphData.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/hooks/useEventFlowGraphData.ts
@@ -5,6 +5,7 @@ import {
   EventListenerTopology,
   ResolvedTriggerNode,
   ResolutionStatus,
+  TriggerSelection,
 } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
 import { NODE_KIND, NodeKind } from "../constants";
 import { getLayoutedElements } from "../utils/layoutUtils";
@@ -15,13 +16,18 @@ export type EventListenerNodeData = {
   eventListener: EventListenerTopology["eventListener"];
   ready: boolean;
   address: string | null;
-  triggerCount: number;
+  triggerSelection: TriggerSelection;
 };
 export type TriggerNodeData = {
   triggerRef: string;
   resolved: Trigger | null;
   status: ResolutionStatus;
   namespace: string;
+  // Selector terms this Trigger satisfied; set only when it was discovered via
+  // spec.labelSelector rather than listed in spec.triggers.
+  viaTerms?: string[];
+  // Both listed AND label-matched — the Tekton sink fires it twice per event.
+  firesTwice?: boolean;
 };
 export type InterceptorNodeData = { interceptor: ResolvedTriggerNode["interceptors"][number]; namespace: string };
 export type TriggerBindingNodeData = { binding: ResolvedTriggerNode["bindings"][number]; namespace: string };
@@ -76,7 +82,7 @@ export const buildNodes = (topology: EventListenerTopology): FlowNode[] => {
       eventListener: topology.eventListener,
       ready: topology.ready,
       address: topology.address,
-      triggerCount: topology.triggers.length,
+      triggerSelection: topology.triggerSelection,
     },
     position: { x: 0, y: 0 },
   });
@@ -93,6 +99,20 @@ export const buildNodes = (topology: EventListenerTopology): FlowNode[] => {
           resolved: entry.source.resolved,
           status: entry.source.status,
           namespace: topology.eventListener.metadata.namespace ?? "",
+          firesTwice: entry.firesTwice,
+        },
+        position: { x: 0, y: 0 },
+      });
+    } else if (entry.source.kind === "labelSelector") {
+      nodes.push({
+        id: `node::trigger::${key}`,
+        type: NODE_KIND.TRIGGER,
+        data: {
+          triggerRef: entry.source.name,
+          resolved: entry.source.resolved,
+          status: "resolved",
+          namespace: topology.eventListener.metadata.namespace ?? "",
+          viaTerms: entry.source.matchedTerms,
         },
         position: { x: 0, y: 0 },
       });
@@ -144,6 +164,13 @@ export const buildEdges = (topology: EventListenerTopology): Edge[] => {
     type: "smoothstep",
     markerEnd: { type: MarkerType.ArrowClosed, width: 18, height: 18 },
     style: { strokeWidth: 1.5 },
+    // Edge labels sit on top of the dotted canvas and can overlap a node when
+    // the gap between ranks is short, so they carry their own opaque plate.
+    labelStyle: { fontSize: 11 },
+    labelShowBg: true,
+    labelBgPadding: [6, 3] as [number, number],
+    labelBgBorderRadius: 4,
+    labelBgStyle: { fill: "var(--card)", fillOpacity: 0.95, stroke: "var(--border)" },
   };
 
   if (topology.gitServer) {
@@ -156,13 +183,18 @@ export const buildEdges = (topology: EventListenerTopology): Edge[] => {
     const templateId = `node::template::${key}`;
     const pipelineId = `node::pipeline::${key}`;
 
-    if (entry.source.kind === "triggerRef") {
+    if (entry.source.kind === "triggerRef" || entry.source.kind === "labelSelector") {
+      const viaLabel = entry.source.kind === "labelSelector";
       edges.push({
         id: `edge::el→trigger::${key}`,
         source: "node::eventListener",
         target: `node::trigger::${key}`,
-        label: entry.source.ref,
+        // The target node already names the Trigger and badges it "via label",
+        // so the edge only has to say how it was selected.
+        label: entry.source.kind === "labelSelector" ? "via label" : entry.source.ref,
         ...opts,
+        // dashed = discovered via labelSelector, solid = explicitly listed
+        style: viaLabel ? { ...opts.style, strokeDasharray: "6 4" } : opts.style,
       });
       const tail = firstInterceptorId ?? (entry.bindings.length ? `node::binding::${key}::0` : templateId);
       edges.push({ id: `edge::trigger→${tail}`, source: `node::trigger::${key}`, target: tail, ...opts });
@@ -191,7 +223,7 @@ export const buildEdges = (topology: EventListenerTopology): Edge[] => {
       : null;
 
     const noInterceptorBindingSourceId = !lastInterceptorId
-      ? entry.source.kind === "triggerRef"
+      ? entry.source.kind === "triggerRef" || entry.source.kind === "labelSelector"
         ? `node::trigger::${key}`
         : "node::eventListener"
       : null;

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/index.tsx
@@ -59,7 +59,11 @@ const nodeToSelection = (node: FlowNode, topology: EventListenerTopology): Drawe
     case NODE_KIND.GIT_SOURCE:
       return { kind: "gitSource", gitServer: topology.gitServer };
     case NODE_KIND.EVENT_LISTENER:
-      return { kind: "eventListener", eventListener: topology.eventListener };
+      return {
+        kind: "eventListener",
+        eventListener: topology.eventListener,
+        triggerSelection: node.data.triggerSelection,
+      };
     case NODE_KIND.TRIGGER:
       return {
         kind: "trigger",
@@ -67,6 +71,8 @@ const nodeToSelection = (node: FlowNode, topology: EventListenerTopology): Drawe
         resolved: node.data.resolved,
         status: node.data.status,
         namespace: ns,
+        viaTerms: node.data.viaTerms,
+        firesTwice: node.data.firesTwice,
       };
     case NODE_KIND.INTERCEPTOR:
       return { kind: "interceptor", interceptor: node.data.interceptor, namespace: ns };

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/utils/selectionGaps.test.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/utils/selectionGaps.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { describeSelectionGaps } from "./selectionGaps";
+
+describe("describeSelectionGaps", () => {
+  test("no gaps produces no copy", () => {
+    expect(describeSelectionGaps([])).toEqual([]);
+  });
+
+  test("a restricted Trigger watch is explained as a visibility problem, not a missing Trigger", () => {
+    const [message] = describeSelectionGaps([{ kind: "triggersRestricted" }]);
+    expect(message).toContain("not visible");
+    expect(message).toContain("RBAC");
+  });
+
+  test("unsupported operators are listed and pluralised", () => {
+    expect(describeSelectionGaps([{ kind: "unsupportedOperators", operators: ["Gt"] }])[0]).toContain("an operator");
+    const many = describeSelectionGaps([{ kind: "unsupportedOperators", operators: ["Gt", "Lt"] }])[0];
+    expect(many).toContain("operators");
+    expect(many).toContain("Gt, Lt");
+  });
+
+  test("namespaces are listed, and the Tekton wildcard reads as all namespaces", () => {
+    expect(describeSelectionGaps([{ kind: "otherNamespaces", namespaces: ["a", "b"] }])[0]).toContain("a, b");
+    expect(describeSelectionGaps([{ kind: "otherNamespaces", namespaces: ["*"] }])[0]).toContain("all namespaces");
+  });
+
+  test("every gap produces exactly one message, in order", () => {
+    expect(
+      describeSelectionGaps([{ kind: "triggersRestricted" }, { kind: "otherNamespaces", namespaces: ["a"] }])
+    ).toHaveLength(2);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/utils/selectionGaps.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowDiagram/utils/selectionGaps.ts
@@ -1,0 +1,17 @@
+import { SelectionGap } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+
+/** User-facing copy for why the diagram may show fewer Triggers than the sink serves. */
+export const describeSelectionGaps = (gaps: SelectionGap[]): string[] =>
+  gaps.map((gap) => {
+    switch (gap.kind) {
+      case "triggersRestricted":
+        return "Trigger CRs are not visible (RBAC or missing CRD), so Triggers matched by spec.labelSelector cannot be shown.";
+      case "unsupportedOperators":
+        return `spec.labelSelector.matchExpressions uses ${gap.operators.length === 1 ? "an operator" : "operators"} this view cannot evaluate (${gap.operators.join(", ")}); Triggers matched only by ${gap.operators.length === 1 ? "it" : "them"} are omitted.`;
+      case "otherNamespaces": {
+        // Tekton reads matchNames: ["*"] as every namespace in the cluster.
+        const where = gap.namespaces.includes("*") ? "all namespaces" : gap.namespaces.join(", ");
+        return `spec.namespaceSelector also selects Triggers from ${where}; only Triggers in this EventListener's own namespace are shown.`;
+      }
+    }
+  });

--- a/apps/client/src/modules/platform/tekton/components/EventFlowNodeDrawer/index.tsx
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowNodeDrawer/index.tsx
@@ -15,6 +15,7 @@ import { routeInterceptorDetails } from "@/modules/platform/tekton/pages/interce
 import { routeClusterInterceptorDetails } from "@/modules/platform/tekton/pages/cluster-interceptor-details/route";
 import { PATH_CONFIG_GITSERVERS_FULL } from "@/modules/platform/configuration/modules/gitservers/route";
 import { ResolutionStatusBadge } from "../EventFlowDiagram/components/ResolutionStatusBadge";
+import { describeSelectionGaps } from "../EventFlowDiagram/utils/selectionGaps";
 import { DrawerSelection } from "./types";
 
 export interface EventFlowNodeDrawerProps {
@@ -89,7 +90,8 @@ export const EventFlowNodeDrawer: React.FC<EventFlowNodeDrawerProps> = ({ open, 
             )}
           </div>
         );
-      case "eventListener":
+      case "eventListener": {
+        const { terms, listedCount, labelMatchedCount, gaps } = selection.triggerSelection;
         return (
           <div className="space-y-2 text-sm">
             <div>
@@ -97,17 +99,41 @@ export const EventFlowNodeDrawer: React.FC<EventFlowNodeDrawerProps> = ({ open, 
               <code>{selection.eventListener.status?.address?.url ?? "—"}</code>
             </div>
             <div>
-              <span className="text-muted-foreground">Triggers:</span>{" "}
-              {(selection.eventListener.spec?.triggers ?? []).length}
+              <span className="text-muted-foreground">Triggers (spec.triggers):</span> {listedCount}
             </div>
+            {terms.length > 0 && (
+              <>
+                <div>
+                  <span className="text-muted-foreground">Label selector:</span> <code>{terms.join(", ")}</code>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Matched via label selector:</span> {labelMatchedCount}
+                </div>
+              </>
+            )}
+            {describeSelectionGaps(gaps).map((message) => (
+              <p key={message} className="text-status-missing">
+                {message}
+              </p>
+            ))}
           </div>
         );
+      }
       case "trigger":
         return (
           <div className="space-y-2 text-sm">
             <div>
               <span className="text-muted-foreground">Ref:</span> {selection.triggerRef}
             </div>
+            {selection.viaTerms && (
+              <div>
+                <span className="text-muted-foreground">Matched via labelSelector:</span>{" "}
+                <code>{selection.viaTerms.join(", ") || "—"}</code>
+              </div>
+            )}
+            {selection.firesTwice && (
+              <Badge variant="destructive">Fires twice — listed in spec.triggers AND matched by labelSelector</Badge>
+            )}
             {selection.resolved ? (
               <Button variant="link" asChild className="p-0">
                 <Link

--- a/apps/client/src/modules/platform/tekton/components/EventFlowNodeDrawer/types.ts
+++ b/apps/client/src/modules/platform/tekton/components/EventFlowNodeDrawer/types.ts
@@ -1,10 +1,22 @@
 import { EventListener, Trigger, GitServer, PipelineRun } from "@my-project/shared";
-import { ResolutionStatus, ResolvedTriggerNode } from "@/modules/platform/tekton/hooks/useEventListenerTopology";
+import {
+  ResolutionStatus,
+  ResolvedTriggerNode,
+  TriggerSelection,
+} from "@/modules/platform/tekton/hooks/useEventListenerTopology";
 
 export type DrawerSelection =
   | { kind: "gitSource"; gitServer: GitServer | null }
-  | { kind: "eventListener"; eventListener: EventListener }
-  | { kind: "trigger"; triggerRef: string; resolved: Trigger | null; status: ResolutionStatus; namespace: string }
+  | { kind: "eventListener"; eventListener: EventListener; triggerSelection: TriggerSelection }
+  | {
+      kind: "trigger";
+      triggerRef: string;
+      resolved: Trigger | null;
+      status: ResolutionStatus;
+      namespace: string;
+      viaTerms?: string[];
+      firesTwice?: boolean;
+    }
   | { kind: "interceptor"; interceptor: ResolvedTriggerNode["interceptors"][number]; namespace: string }
   | { kind: "triggerBinding"; binding: ResolvedTriggerNode["bindings"][number]; namespace: string }
   | { kind: "triggerTemplate"; template: ResolvedTriggerNode["template"]; namespace: string }

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/build.test.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/build.test.ts
@@ -419,6 +419,316 @@ describe("buildTopology — GitServer resolution", () => {
   });
 });
 
+describe("buildTopology — labelSelector union", () => {
+  test("no labelSelector → output identical to today (regression guard)", () => {
+    const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });
+    const withoutSelector = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }] } }),
+        triggersByName: new Map([["g", trig]]),
+      })
+    );
+    const withEmptyMatchLabels = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "g" }], labelSelector: { matchLabels: {} } } }),
+        triggersByName: new Map([["g", trig]]),
+      })
+    );
+    expect(withEmptyMatchLabels.triggers).toEqual(withoutSelector.triggers);
+    expect(withoutSelector.triggers[0].firesTwice).toBeUndefined();
+  });
+
+  test("Trigger CR matched only via labelSelector appears as an additional labelSelector-sourced node", () => {
+    const listed = triggerCR("listed", { interceptors: [], bindings: [], template: { ref: "" } });
+    const labelOnly = triggerCR("label-only", { interceptors: [], bindings: [], template: { ref: "" } });
+    labelOnly.metadata.labels = { "app.edp.epam.com/gitServer": "gitlab" };
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: {
+            triggers: [{ triggerRef: "listed" }],
+            labelSelector: { matchLabels: { "app.edp.epam.com/gitServer": "gitlab" } },
+          },
+        }),
+        triggersByName: new Map([
+          ["listed", listed],
+          ["label-only", labelOnly],
+        ]),
+      })
+    );
+    expect(result.triggers).toHaveLength(2);
+    expect(result.triggers[0].source).toMatchObject({ kind: "triggerRef", ref: "listed" });
+    expect(result.triggers[0].firesTwice).toBeUndefined();
+    expect(result.triggers[1].source).toEqual({
+      kind: "labelSelector",
+      name: "label-only",
+      matchedTerms: ["app.edp.epam.com/gitServer=gitlab"],
+      resolved: labelOnly,
+    });
+    expect(result.triggerSelection).toMatchObject({ listedCount: 1, labelMatchedCount: 1, gaps: [] });
+  });
+
+  test("Trigger CR both listed AND label-matched dedups to a single flagged node", () => {
+    const both = triggerCR("both", { interceptors: [], bindings: [], template: { ref: "" } });
+    both.metadata.labels = { "app.edp.epam.com/gitServer": "gitlab" };
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: {
+            triggers: [{ triggerRef: "both" }],
+            labelSelector: { matchLabels: { "app.edp.epam.com/gitServer": "gitlab" } },
+          },
+        }),
+        triggersByName: new Map([["both", both]]),
+      })
+    );
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggers[0].source).toMatchObject({ kind: "triggerRef", ref: "both" });
+    expect(result.triggers[0].firesTwice).toBe(true);
+  });
+
+  test("matchLabels requires ALL pairs to match — a Trigger with only a subset of labels is excluded", () => {
+    const partial = triggerCR("partial", { interceptors: [], bindings: [], template: { ref: "" } });
+    partial.metadata.labels = { "app.edp.epam.com/gitServer": "gitlab" };
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: {
+            triggers: [],
+            labelSelector: {
+              matchLabels: { "app.edp.epam.com/gitServer": "gitlab", "app.edp.epam.com/pipelinetype": "build" },
+            },
+          },
+        }),
+        triggersByName: new Map([["partial", partial]]),
+      })
+    );
+    expect(result.triggers).toHaveLength(0);
+  });
+});
+
+describe("buildTopology — labelSelector matchExpressions", () => {
+  const withLabels = (name: string, labels: Record<string, string>) => {
+    const trigger = triggerCR(name, { interceptors: [], bindings: [], template: { ref: "" } });
+    trigger.metadata.labels = labels;
+    return trigger;
+  };
+
+  const selectorEL = (labelSelector: object) => baseEL({ spec: { triggers: [], labelSelector } });
+
+  const matchedNames = (labelSelector: object, triggers: ReturnType<typeof withLabels>[]) =>
+    buildTopology(
+      args({
+        eventListener: selectorEL(labelSelector),
+        triggersByName: new Map(triggers.map((t) => [t.metadata.name, t])),
+      })
+    ).triggers.map((t) => t.source.kind === "labelSelector" && t.source.name);
+
+  test("In / NotIn / Exists / DoesNotExist are evaluated with Kubernetes semantics", () => {
+    const build = withLabels("build", { type: "build" });
+    const review = withLabels("review", { type: "review" });
+    const unlabelled = withLabels("unlabelled", {});
+
+    expect(matchedNames({ matchExpressions: [{ key: "type", operator: "In", values: ["build"] }] }, [build, review])) //
+      .toEqual(["build"]);
+    expect(
+      matchedNames({ matchExpressions: [{ key: "type", operator: "NotIn", values: ["build"] }] }, [build, review])
+    ).toEqual(["review"]);
+    expect(matchedNames({ matchExpressions: [{ key: "type", operator: "Exists" }] }, [build, unlabelled])).toEqual([
+      "build",
+    ]);
+    expect(
+      matchedNames({ matchExpressions: [{ key: "type", operator: "DoesNotExist" }] }, [build, unlabelled])
+    ).toEqual(["unlabelled"]);
+  });
+
+  test("matchLabels and matchExpressions are ANDed — passing only one is not enough", () => {
+    const both = withLabels("both", { app: "el", type: "build" });
+    const labelsOnly = withLabels("labels-only", { app: "el", type: "review" });
+    expect(
+      matchedNames(
+        { matchLabels: { app: "el" }, matchExpressions: [{ key: "type", operator: "In", values: ["build"] }] },
+        [both, labelsOnly]
+      )
+    ).toEqual(["both"]);
+  });
+
+  test("matchExpressions alone activates label selection (no matchLabels present)", () => {
+    const result = buildTopology(
+      args({
+        eventListener: selectorEL({ matchExpressions: [{ key: "type", operator: "Exists" }] }),
+        triggersByName: new Map([["build", withLabels("build", { type: "build" })]]),
+      })
+    );
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggerSelection).toMatchObject({ labelSelectorActive: true, terms: ["type"], gaps: [] });
+  });
+
+  test("an operator this client cannot evaluate excludes the Trigger and is reported as a gap", () => {
+    const result = buildTopology(
+      args({
+        eventListener: selectorEL({ matchExpressions: [{ key: "type", operator: "GreaterThan", values: ["1"] }] }),
+        triggersByName: new Map([["build", withLabels("build", { type: "build" })]]),
+      })
+    );
+    expect(result.triggers).toHaveLength(0);
+    expect(result.triggerSelection.gaps).toEqual([{ kind: "unsupportedOperators", operators: ["GreaterThan"] }]);
+  });
+
+  test("a malformed matchExpressions entry is skipped rather than throwing", () => {
+    const result = buildTopology(
+      args({
+        eventListener: selectorEL({ matchLabels: { type: "build" }, matchExpressions: [{}, null, "nonsense"] }),
+        triggersByName: new Map([["build", withLabels("build", { type: "build" })]]),
+      })
+    );
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggerSelection.terms).toEqual(["type=build"]);
+  });
+});
+
+describe("buildTopology — selection gaps", () => {
+  test("an errored Trigger watch is reported as restricted rather than silently matching nothing", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [], labelSelector: { matchLabels: { app: "el" } } } }),
+        triggersByName: new Map(),
+        availability: { triggers: false },
+      })
+    );
+    expect(result.triggers).toHaveLength(0);
+    expect(result.triggerSelection.gaps).toEqual([{ kind: "triggersRestricted" }]);
+  });
+
+  test("no restricted gap is reported when the EventListener has no label selector at all", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [] } }),
+        availability: { triggers: false },
+      })
+    );
+    expect(result.triggerSelection.gaps).toEqual([]);
+  });
+
+  test("namespaceSelector reaching other namespaces is reported, the EventListener's own namespace is not", () => {
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({
+          spec: { triggers: [], namespaceSelector: { matchNames: [ns, "other-a", "other-b", "other-a"] } },
+        }),
+      })
+    );
+    expect(result.triggerSelection.gaps).toEqual([{ kind: "otherNamespaces", namespaces: ["other-a", "other-b"] }]);
+  });
+
+  test("namespaceSelector listing only the EventListener's own namespace is not a gap", () => {
+    const result = buildTopology(
+      args({ eventListener: baseEL({ spec: { triggers: [], namespaceSelector: { matchNames: [ns] } } }) })
+    );
+    expect(result.triggerSelection.gaps).toEqual([]);
+  });
+});
+
+describe("buildTopology — degenerate EventListener specs", () => {
+  test("an EventListener with no spec at all builds an empty topology", () => {
+    const el = eventListenerSchema.parse({
+      apiVersion: "triggers.tekton.dev/v1beta1",
+      kind: "EventListener",
+      metadata: { name: elName, namespace: ns, uid: "u-el", creationTimestamp: "2025-01-01T00:00:00Z" },
+    });
+    const result = buildTopology(args({ eventListener: el }));
+    expect(result.triggers).toEqual([]);
+    expect(result.triggerSelection).toEqual({
+      labelSelectorActive: false,
+      terms: [],
+      listedCount: 0,
+      labelMatchedCount: 0,
+      gaps: [],
+    });
+  });
+
+  test("a labelSelector-only EventListener (no spec.triggers) still resolves its matched Triggers", () => {
+    const labelled = triggerCR("labelled", { interceptors: [], bindings: [{ ref: "b" }], template: { ref: "t" } });
+    labelled.metadata.labels = { app: "el" };
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { labelSelector: { matchLabels: { app: "el" } } } }),
+        triggersByName: new Map([["labelled", labelled]]),
+        triggerBindingsByName: new Map([["b", tb("b")]]),
+        triggerTemplatesByName: new Map([["t", tt("t", "build-pipeline")]]),
+      })
+    );
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggers[0].bindings[0]).toMatchObject({ ref: "b", status: "resolved" });
+    expect(result.triggers[0].template.pipelineRef).toEqual({ kind: "literal", pipelineName: "build-pipeline" });
+    expect(result.triggerSelection).toMatchObject({ listedCount: 0, labelMatchedCount: 1 });
+  });
+
+  // Tekton stores an omitted interceptors/bindings list as an explicit `null`,
+  // which a default parameter would hand straight to `.map`.
+  test("a Trigger CR with null bindings/interceptors resolves to empty lists", () => {
+    const nulled = triggerSchema.parse({
+      apiVersion: "triggers.tekton.dev/v1beta1",
+      kind: "Trigger",
+      metadata: {
+        name: "nulled",
+        namespace: ns,
+        uid: "u-nulled",
+        creationTimestamp: "2025-01-01T00:00:00Z",
+        labels: { app: "el" },
+      },
+      spec: { bindings: null, interceptors: null, template: { ref: "t" } },
+    });
+    const viaLabel = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [], labelSelector: { matchLabels: { app: "el" } } } }),
+        triggersByName: new Map([["nulled", nulled]]),
+        triggerTemplatesByName: new Map([["t", tt("t", "p")]]),
+      })
+    );
+    expect(viaLabel.triggers[0]).toMatchObject({ interceptors: [], bindings: [] });
+
+    const viaRef = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [{ triggerRef: "nulled" }] } }),
+        triggersByName: new Map([["nulled", nulled]]),
+      })
+    );
+    expect(viaRef.triggers[0]).toMatchObject({ interceptors: [], bindings: [] });
+  });
+
+  test("an EventListener with null spec.triggers is treated as having none", () => {
+    const result = buildTopology(args({ eventListener: baseEL({ spec: { triggers: null } }) }));
+    expect(result.triggers).toEqual([]);
+    expect(result.triggerSelection.listedCount).toBe(0);
+  });
+
+  test("a label-matched Trigger CR with no spec resolves to empty interceptors/bindings", () => {
+    const bare = triggerSchema.parse({
+      apiVersion: "triggers.tekton.dev/v1beta1",
+      kind: "Trigger",
+      metadata: {
+        name: "bare",
+        namespace: ns,
+        uid: "u-bare",
+        creationTimestamp: "2025-01-01T00:00:00Z",
+        labels: { app: "el" },
+      },
+    });
+    const result = buildTopology(
+      args({
+        eventListener: baseEL({ spec: { triggers: [], labelSelector: { matchLabels: { app: "el" } } } }),
+        triggersByName: new Map([["bare", bare]]),
+      })
+    );
+    expect(result.triggers[0]).toMatchObject({
+      interceptors: [],
+      bindings: [],
+      template: { ref: "", status: "resolved" },
+    });
+  });
+});
+
 describe("buildTopology — latestPipelineRun selection", () => {
   test("no labeled runs → null", () => {
     const trig = triggerCR("g", { interceptors: [], bindings: [], template: { ref: "" } });

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/build.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/build.ts
@@ -9,6 +9,12 @@ import {
   eventListenerLabels,
 } from "@my-project/shared";
 import {
+  labelSelectorTerms,
+  otherSelectedNamespaces,
+  parseLabelSelector,
+  triggerMatchesSelector,
+} from "@/modules/platform/tekton/utils/labelSelector";
+import {
   BuildTopologyArgs,
   EventListenerTopology,
   PipelineRefShape,
@@ -16,6 +22,8 @@ import {
   ResolvedBindingRef,
   ResolvedInterceptorRef,
   ResolvedTriggerNode,
+  SelectionGap,
+  TriggerSelection,
 } from "./types";
 
 const PR_TRIGGER_LABEL = "triggers.tekton.dev/trigger";
@@ -36,14 +44,17 @@ const readPipelineRefName = (template: TriggerTemplate | null): string | undefin
 const statusFor = (resolved: object | null, available: boolean): ResolutionStatus =>
   resolved ? "resolved" : available ? "missing" : "restricted";
 
+// `raw` is defaulted with `??`, not a default parameter: Tekton stores an
+// absent interceptors/bindings list as `null`, which a default parameter
+// (undefined-only) would pass straight through to `.map`.
 const resolveInterceptors = (
-  raw: TriggerEntry["interceptors"] = [],
+  raw: TriggerEntry["interceptors"],
   interceptorsByName: Map<string, Interceptor>,
   clusterInterceptorsByName: Map<string, ClusterInterceptor>,
   interceptorsAvailable: boolean,
   clusterInterceptorsAvailable: boolean
 ): ResolvedInterceptorRef[] =>
-  raw.map((i) => {
+  (raw ?? []).map((i) => {
     const kind = i.ref?.kind === "ClusterInterceptor" ? "ClusterInterceptor" : "NamespacedInterceptor";
     const name = i.ref?.name ?? "";
     const resolved =
@@ -60,11 +71,11 @@ const resolveInterceptors = (
   });
 
 const resolveBindings = (
-  raw: TriggerEntry["bindings"] = [],
+  raw: TriggerEntry["bindings"],
   triggerBindingsByName: Map<string, TriggerBinding>,
   triggerBindingsAvailable: boolean
 ): ResolvedBindingRef[] =>
-  raw.map((b) => {
+  (raw ?? []).map((b) => {
     const kind = b.kind === "ClusterTriggerBinding" ? "ClusterTriggerBinding" : "TriggerBinding";
     const ref = b.ref ?? "";
     // ClusterTriggerBinding is intentionally not watched in MVP. We cannot
@@ -139,19 +150,30 @@ export const buildTopology = ({
     };
   };
 
+  // An inline spec.triggers entry has the same shape as a Trigger CR's spec, so
+  // all three sources — inline, triggerRef, label-matched — resolve through here.
+  const resolveFromTriggerSpec = (triggerSpec: TriggerEntry | undefined, triggerName: string) => {
+    const interceptors = resolveInterceptors(
+      triggerSpec?.interceptors,
+      interceptorsByName,
+      clusterInterceptorsByName,
+      interceptorsAvailable,
+      clusterInterceptorsAvailable
+    );
+    const bindings = resolveBindings(triggerSpec?.bindings, triggerBindingsByName, triggerBindingsAvailable);
+    const templateRef = triggerSpec?.template?.ref ?? "";
+    return {
+      interceptors,
+      bindings,
+      template: resolveTemplate(templateRef),
+      latestPipelineRun: pickLatestRun(recentRuns, triggerName),
+    };
+  };
+
   const triggers: ResolvedTriggerNode[] = rawTriggers.map((entry) => {
     if (entry.triggerRef) {
       const resolvedTrigger = triggersByName.get(entry.triggerRef) ?? null;
-      const triggerSpec = resolvedTrigger?.spec;
-      const interceptors = resolveInterceptors(
-        triggerSpec?.interceptors,
-        interceptorsByName,
-        clusterInterceptorsByName,
-        interceptorsAvailable,
-        clusterInterceptorsAvailable
-      );
-      const bindings = resolveBindings(triggerSpec?.bindings, triggerBindingsByName, triggerBindingsAvailable);
-      const templateRef = triggerSpec?.template?.ref ?? "";
+      const resolution = resolveFromTriggerSpec(resolvedTrigger?.spec, entry.triggerRef);
       return {
         source: {
           kind: "triggerRef" as const,
@@ -159,30 +181,79 @@ export const buildTopology = ({
           resolved: resolvedTrigger,
           status: statusFor(resolvedTrigger, triggersAvailable),
         },
-        interceptors,
-        bindings,
-        template: resolveTemplate(templateRef),
-        latestPipelineRun: pickLatestRun(recentRuns, entry.triggerRef),
+        ...resolution,
       };
     }
     const inlineName = entry.name ?? "";
-    const interceptors = resolveInterceptors(
-      entry.interceptors,
-      interceptorsByName,
-      clusterInterceptorsByName,
-      interceptorsAvailable,
-      clusterInterceptorsAvailable
-    );
-    const bindings = resolveBindings(entry.bindings, triggerBindingsByName, triggerBindingsAvailable);
-    const templateRef = entry.template?.ref ?? "";
+    const resolution = resolveFromTriggerSpec(entry, inlineName);
     return {
       source: { kind: "inline" as const, name: inlineName },
-      interceptors,
-      bindings,
-      template: resolveTemplate(templateRef),
-      latestPipelineRun: pickLatestRun(recentRuns, inlineName),
+      ...resolution,
     };
   });
 
-  return { eventListener, address, ready, gitServer, triggers };
+  // The Tekton sink serves the UNION of spec.triggers and every Trigger CR the
+  // selector matches, so a Trigger that is both listed and label-matched fires
+  // twice per event — keep the listed node, flagged, instead of rendering two.
+  const selector = parseLabelSelector(eventListener);
+  const terms = labelSelectorTerms(selector);
+
+  const listedTriggerRefNames = new Set(
+    triggers
+      .map((t) => (t.source.kind === "triggerRef" ? t.source.ref : null))
+      .filter((ref): ref is string => ref !== null)
+  );
+
+  const labelMatchedTriggers = selector.active
+    ? Array.from(triggersByName.values()).filter((trigger) => triggerMatchesSelector(trigger, selector))
+    : [];
+
+  const doubleFiredNames = new Set(
+    labelMatchedTriggers.map((t) => t.metadata.name).filter((name) => listedTriggerRefNames.has(name))
+  );
+
+  const flaggedTriggers = triggers.map((t) =>
+    t.source.kind === "triggerRef" && doubleFiredNames.has(t.source.ref) ? { ...t, firesTwice: true } : t
+  );
+
+  const labelSelectorNodes: ResolvedTriggerNode[] = labelMatchedTriggers
+    .filter((trigger) => !listedTriggerRefNames.has(trigger.metadata.name))
+    .map((trigger) => ({
+      source: {
+        kind: "labelSelector" as const,
+        name: trigger.metadata.name,
+        matchedTerms: terms,
+        resolved: trigger,
+      },
+      ...resolveFromTriggerSpec(trigger.spec, trigger.metadata.name),
+    }));
+
+  const gaps: SelectionGap[] = [];
+  if (selector.active && !triggersAvailable) {
+    gaps.push({ kind: "triggersRestricted" });
+  }
+  if (selector.unsupportedOperators.length) {
+    gaps.push({ kind: "unsupportedOperators", operators: selector.unsupportedOperators });
+  }
+  const otherNamespaces = otherSelectedNamespaces(eventListener);
+  if (otherNamespaces.length) {
+    gaps.push({ kind: "otherNamespaces", namespaces: otherNamespaces });
+  }
+
+  const triggerSelection: TriggerSelection = {
+    labelSelectorActive: selector.active,
+    terms,
+    listedCount: rawTriggers.length,
+    labelMatchedCount: labelSelectorNodes.length,
+    gaps,
+  };
+
+  return {
+    eventListener,
+    address,
+    ready,
+    gitServer,
+    triggers: [...flaggedTriggers, ...labelSelectorNodes],
+    triggerSelection,
+  };
 };

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/index.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/index.ts
@@ -20,6 +20,8 @@ export type {
   ResolvedBindingRef,
   ResolutionStatus,
   PipelineRefShape,
+  SelectionGap,
+  TriggerSelection,
 } from "./types";
 
 export interface UseEventListenerTopologyResult {

--- a/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/types.ts
+++ b/apps/client/src/modules/platform/tekton/hooks/useEventListenerTopology/types.ts
@@ -43,7 +43,10 @@ export type PipelineRefShape =
 export type ResolvedTriggerNode = {
   source:
     | { kind: "triggerRef"; ref: string; resolved: Trigger | null; status: ResolutionStatus }
-    | { kind: "inline"; name: string };
+    | { kind: "inline"; name: string }
+    // Discovered by matching spec.labelSelector against the namespace's Trigger
+    // CRs, so unlike a triggerRef this one cannot be unresolved.
+    | { kind: "labelSelector"; name: string; matchedTerms: string[]; resolved: Trigger };
   interceptors: ResolvedInterceptorRef[];
   bindings: ResolvedBindingRef[];
   template: {
@@ -53,6 +56,32 @@ export type ResolvedTriggerNode = {
     pipelineRef: PipelineRefShape;
   };
   latestPipelineRun: PipelineRun | null;
+  /**
+   * True when this Trigger is both listed in spec.triggers AND matched by
+   * spec.labelSelector — Tekton's sink fires it twice per event, a
+   * misconfiguration the UI flags rather than hiding behind a single node.
+   */
+  firesTwice?: boolean;
+};
+
+/**
+ * A reason the label-matched Trigger set the UI shows may be narrower than what
+ * the Tekton sink actually serves, so an incomplete diagram is never mistaken
+ * for a complete one.
+ */
+export type SelectionGap =
+  | { kind: "triggersRestricted" }
+  | { kind: "unsupportedOperators"; operators: string[] }
+  | { kind: "otherNamespaces"; namespaces: string[] };
+
+export type TriggerSelection = {
+  labelSelectorActive: boolean;
+  /** Selector terms in kubectl syntax, e.g. ["app=gitlab", "tier in (a, b)"]. */
+  terms: string[];
+  /** The "Triggers" number the list view shows; kept apart from the label-matched count so the two views cannot disagree. */
+  listedCount: number;
+  labelMatchedCount: number;
+  gaps: SelectionGap[];
 };
 
 export type EventListenerTopology = {
@@ -61,6 +90,7 @@ export type EventListenerTopology = {
   ready: boolean;
   gitServer: GitServer | null;
   triggers: ResolvedTriggerNode[];
+  triggerSelection: TriggerSelection;
 };
 
 /**

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-details/view.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-details/view.tsx
@@ -14,7 +14,7 @@ const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 export default function EventListenerDetailsView() {
   const { topology, params } = useEventListenerDetailsData();
 
-  const triggersConfigured = topology.data ? topology.data.triggers.length : 0;
+  const selection = topology.data?.triggerSelection;
   const runs24h = React.useMemo(() => {
     const cutoff = Date.now() - TWENTY_FOUR_HOURS_MS;
 
@@ -36,7 +36,12 @@ export default function EventListenerDetailsView() {
       </div>
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
         <MetricCard title="Triggers configured" hasData={topology.isReady} isLoading={!topology.isReady}>
-          <div className="text-3xl font-semibold">{triggersConfigured}</div>
+          <div className="text-3xl font-semibold">{selection?.listedCount ?? 0}</div>
+          {!!selection?.labelMatchedCount && (
+            <div className="text-muted-foreground text-sm">
+              + {selection.labelMatchedCount} matched via label selector
+            </div>
+          )}
         </MetricCard>
         <MetricCard
           title="Triggered runs · 24h"

--- a/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerList/hooks/useColumns.tsx
+++ b/apps/client/src/modules/platform/tekton/pages/event-listener-list/components/EventListenerList/hooks/useColumns.tsx
@@ -13,6 +13,7 @@ import { TABLE } from "@/k8s/constants/tables";
 import { formatTimestamp } from "@/core/utils/date-humanize";
 import { useClusterStore } from "@/k8s/store";
 import { routeEventListenerDetails } from "@/modules/platform/tekton/pages/event-listener-details/route";
+import { labelSelectorTerms, parseLabelSelector } from "@/modules/platform/tekton/utils/labelSelector";
 
 const isReady = (el: EventListener): boolean =>
   el.status?.conditions?.find((c) => c.type === "Ready")?.status === "True";
@@ -20,6 +21,8 @@ const isReady = (el: EventListener): boolean =>
 const triggerCount = (el: EventListener): number => el.spec?.triggers?.length ?? 0;
 
 const address = (el: EventListener): string => el.status?.address?.url ?? "";
+
+const selectorTerms = (el: EventListener): string[] => labelSelectorTerms(parseLabelSelector(el));
 
 export function useColumns(): TableColumn<EventListener>[] {
   const { loadSettings } = useTableSettings(TABLE.EVENT_LISTENER_LIST.id);
@@ -50,13 +53,13 @@ export function useColumns(): TableColumn<EventListener>[] {
             );
           },
         },
-        cell: { isFixed: true, baseWidth: 30, ...getSyncedColumnData(tableSettings, "name") },
+        cell: { isFixed: true, baseWidth: 15, ...getSyncedColumnData(tableSettings, "name") },
       },
       {
         id: "namespace",
         label: "Namespace",
         data: { render: ({ data }) => <span>{data.metadata.namespace}</span> },
-        cell: { baseWidth: 15, ...getSyncedColumnData(tableSettings, "namespace") },
+        cell: { baseWidth: 8, ...getSyncedColumnData(tableSettings, "namespace") },
       },
       {
         id: "status",
@@ -69,13 +72,13 @@ export function useColumns(): TableColumn<EventListener>[] {
               <Badge className="bg-destructive/10 text-destructive">Degraded</Badge>
             ),
         },
-        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "status") },
+        cell: { baseWidth: 7, ...getSyncedColumnData(tableSettings, "status") },
       },
       {
         id: "triggers",
         label: "Triggers",
         data: { render: ({ data }) => <span>{triggerCount(data)}</span> },
-        cell: { baseWidth: 10, ...getSyncedColumnData(tableSettings, "triggers") },
+        cell: { baseWidth: 7, ...getSyncedColumnData(tableSettings, "triggers") },
       },
       {
         id: "address",
@@ -83,7 +86,27 @@ export function useColumns(): TableColumn<EventListener>[] {
         data: {
           render: ({ data }) => <TextWithTooltip text={address(data) || "—"} />,
         },
-        cell: { baseWidth: 25, ...getSyncedColumnData(tableSettings, "address") },
+        cell: { baseWidth: 26, ...getSyncedColumnData(tableSettings, "address") },
+      },
+      {
+        id: "labelSelector",
+        label: "Label Selector",
+        data: {
+          render: ({ data }) => {
+            const terms = selectorTerms(data);
+            if (!terms.length) return <span>—</span>;
+            return (
+              <div className="flex flex-wrap items-center gap-1">
+                {terms.map((term) => (
+                  <Badge key={term} variant="secondary">
+                    {term}
+                  </Badge>
+                ))}
+              </div>
+            );
+          },
+        },
+        cell: { baseWidth: 25, ...getSyncedColumnData(tableSettings, "labelSelector") },
       },
       {
         id: "createdAt",
@@ -91,7 +114,7 @@ export function useColumns(): TableColumn<EventListener>[] {
         data: {
           render: ({ data }) => formatTimestamp(data.metadata.creationTimestamp),
         },
-        cell: { isFixed: true, baseWidth: 10, ...getSyncedColumnData(tableSettings, "createdAt") },
+        cell: { isFixed: true, baseWidth: 12, ...getSyncedColumnData(tableSettings, "createdAt") },
       },
     ],
     [tableSettings, clusterName, defaultNamespace]

--- a/apps/client/src/modules/platform/tekton/utils/labelSelector.test.ts
+++ b/apps/client/src/modules/platform/tekton/utils/labelSelector.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+import { eventListenerSchema, triggerSchema } from "@my-project/shared";
+import {
+  labelSelectorTerms,
+  otherSelectedNamespaces,
+  parseLabelSelector,
+  triggerMatchesSelector,
+} from "./labelSelector";
+
+const ns = "edp-delivery";
+
+const el = (spec: object | undefined) =>
+  eventListenerSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "EventListener",
+    metadata: { name: "el", namespace: ns, uid: "u-el", creationTimestamp: "2025-01-01T00:00:00Z" },
+    ...(spec ? { spec } : {}),
+  });
+
+const trigger = (labels: Record<string, string>) =>
+  triggerSchema.parse({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "Trigger",
+    metadata: { name: "t", namespace: ns, uid: "u-t", creationTimestamp: "2025-01-01T00:00:00Z", labels },
+    spec: {},
+  });
+
+describe("parseLabelSelector", () => {
+  test("an EventListener with no spec yields an inactive selector", () => {
+    expect(parseLabelSelector(el(undefined))).toEqual({
+      matchLabels: {},
+      matchExpressions: [],
+      active: false,
+      unsupportedOperators: [],
+    });
+  });
+
+  test("an empty selector object is inactive — it selects nothing rather than everything", () => {
+    expect(parseLabelSelector(el({ labelSelector: { matchLabels: {}, matchExpressions: [] } })).active).toBe(false);
+  });
+
+  test("matchLabels or matchExpressions alone activates the selector", () => {
+    expect(parseLabelSelector(el({ labelSelector: { matchLabels: { a: "b" } } })).active).toBe(true);
+    expect(
+      parseLabelSelector(el({ labelSelector: { matchExpressions: [{ key: "a", operator: "Exists" }] } })).active
+    ).toBe(true);
+  });
+
+  test("entries missing key or operator are dropped instead of throwing", () => {
+    const parsed = parseLabelSelector(
+      el({ labelSelector: { matchExpressions: [{ key: "a", operator: "Exists" }, { key: "b" }, null, 7] } })
+    );
+    expect(parsed.matchExpressions).toEqual([{ key: "a", operator: "Exists" }]);
+  });
+
+  test("unknown operators are collected once each", () => {
+    const parsed = parseLabelSelector(
+      el({
+        labelSelector: {
+          matchExpressions: [
+            { key: "a", operator: "Gt" },
+            { key: "b", operator: "Gt" },
+            { key: "c", operator: "In", values: ["x"] },
+          ],
+        },
+      })
+    );
+    expect(parsed.unsupportedOperators).toEqual(["Gt"]);
+  });
+});
+
+describe("labelSelectorTerms", () => {
+  test("renders matchLabels pairs then matchExpressions in kubectl syntax", () => {
+    const parsed = parseLabelSelector(
+      el({
+        labelSelector: {
+          matchLabels: { app: "el" },
+          matchExpressions: [
+            { key: "type", operator: "In", values: ["build", "review"] },
+            { key: "type", operator: "NotIn", values: ["deploy"] },
+            { key: "managed", operator: "Exists" },
+            { key: "legacy", operator: "DoesNotExist" },
+          ],
+        },
+      })
+    );
+    expect(labelSelectorTerms(parsed)).toEqual([
+      "app=el",
+      "type in (build, review)",
+      "type notin (deploy)",
+      "managed",
+      "!legacy",
+    ]);
+  });
+
+  test("an unknown operator still renders readably instead of being dropped from the summary", () => {
+    const parsed = parseLabelSelector(
+      el({ labelSelector: { matchExpressions: [{ key: "n", operator: "Gt", values: ["3"] }] } })
+    );
+    expect(labelSelectorTerms(parsed)).toEqual(["n Gt (3)"]);
+  });
+});
+
+describe("triggerMatchesSelector", () => {
+  const matches = (labels: Record<string, string>, labelSelector: object) =>
+    triggerMatchesSelector(trigger(labels), parseLabelSelector(el({ labelSelector })));
+
+  test("every matchLabels pair must be present with the same value", () => {
+    expect(matches({ a: "1", b: "2" }, { matchLabels: { a: "1" } })).toBe(true);
+    expect(matches({ a: "1" }, { matchLabels: { a: "1", b: "2" } })).toBe(false);
+    expect(matches({ a: "2" }, { matchLabels: { a: "1" } })).toBe(false);
+  });
+
+  test("NotIn and DoesNotExist hold for an absent key", () => {
+    expect(matches({}, { matchExpressions: [{ key: "a", operator: "NotIn", values: ["1"] }] })).toBe(true);
+    expect(matches({}, { matchExpressions: [{ key: "a", operator: "DoesNotExist" }] })).toBe(true);
+  });
+
+  test("an In requirement with no values matches nothing", () => {
+    expect(matches({ a: "1" }, { matchExpressions: [{ key: "a", operator: "In" }] })).toBe(false);
+  });
+
+  test("an unevaluable operator never matches, so the UI cannot claim a Trigger fires", () => {
+    expect(matches({ a: "1" }, { matchExpressions: [{ key: "a", operator: "Gt", values: ["0"] }] })).toBe(false);
+  });
+});
+
+describe("otherSelectedNamespaces", () => {
+  test("returns nothing when namespaceSelector is absent or names only the own namespace", () => {
+    expect(otherSelectedNamespaces(el({}))).toEqual([]);
+    expect(otherSelectedNamespaces(el({ namespaceSelector: { matchNames: [ns] } }))).toEqual([]);
+  });
+
+  test("deduplicates and excludes the EventListener's own namespace", () => {
+    expect(otherSelectedNamespaces(el({ namespaceSelector: { matchNames: [ns, "a", "b", "a"] } }))).toEqual(["a", "b"]);
+  });
+
+  test("the wildcard is preserved for the caller to render", () => {
+    expect(otherSelectedNamespaces(el({ namespaceSelector: { matchNames: ["*"] } }))).toEqual(["*"]);
+  });
+
+  test("non-string entries are ignored rather than throwing", () => {
+    expect(otherSelectedNamespaces(el({ namespaceSelector: { matchNames: ["a", null, 3] } }))).toEqual(["a"]);
+  });
+});

--- a/apps/client/src/modules/platform/tekton/utils/labelSelector.ts
+++ b/apps/client/src/modules/platform/tekton/utils/labelSelector.ts
@@ -1,0 +1,124 @@
+import { EventListener, Trigger } from "@my-project/shared";
+
+/**
+ * A `metav1.LabelSelector.matchExpressions` entry. `operator` is a plain string
+ * rather than a union because the API may serve an operator this client does
+ * not know about — evaluation degrades explicitly instead of the type system
+ * pretending the set is closed.
+ */
+export type LabelSelectorRequirement = {
+  key: string;
+  operator: string;
+  values?: string[];
+};
+
+export type ParsedLabelSelector = {
+  matchLabels: Record<string, string>;
+  matchExpressions: LabelSelectorRequirement[];
+  /** An empty selector is inactive here — it selects nothing, not everything. */
+  active: boolean;
+  unsupportedOperators: string[];
+};
+
+const SUPPORTED_OPERATORS = new Set(["In", "NotIn", "Exists", "DoesNotExist"]);
+
+const toRequirement = (value: unknown): LabelSelectorRequirement | null => {
+  if (typeof value !== "object" || value === null) return null;
+  const { key, operator, values } = value as Record<string, unknown>;
+  if (typeof key !== "string" || typeof operator !== "string") return null;
+  return {
+    key,
+    operator,
+    values: Array.isArray(values) ? values.filter((v): v is string => typeof v === "string") : undefined,
+  };
+};
+
+export const parseLabelSelector = (eventListener: EventListener): ParsedLabelSelector => {
+  const selector = eventListener.spec?.labelSelector;
+  const matchLabels = Object.fromEntries(
+    Object.entries(selector?.matchLabels ?? {}).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string"
+    )
+  );
+  const rawExpressions: unknown = selector?.matchExpressions;
+  const matchExpressions = (Array.isArray(rawExpressions) ? rawExpressions : [])
+    .map(toRequirement)
+    .filter((r): r is LabelSelectorRequirement => r !== null);
+
+  return {
+    matchLabels,
+    matchExpressions,
+    active: Object.keys(matchLabels).length > 0 || matchExpressions.length > 0,
+    unsupportedOperators: Array.from(
+      new Set(matchExpressions.map((r) => r.operator).filter((op) => !SUPPORTED_OPERATORS.has(op)))
+    ),
+  };
+};
+
+/**
+ * Namespaces the EventListener selects Triggers from beyond its own — the
+ * portal watches only its own namespace, so a non-empty result means the
+ * topology is necessarily partial. `"*"` is preserved verbatim; Tekton reads it
+ * as every namespace.
+ */
+export const otherSelectedNamespaces = (eventListener: EventListener): string[] => {
+  const raw: unknown = eventListener.spec?.namespaceSelector?.matchNames;
+  const own = eventListener.metadata.namespace;
+  const names = (Array.isArray(raw) ? raw : []).filter((n): n is string => typeof n === "string");
+  return Array.from(new Set(names.filter((n) => n !== own)));
+};
+
+const formatRequirement = (requirement: LabelSelectorRequirement): string => {
+  const values = (requirement.values ?? []).join(", ");
+  switch (requirement.operator) {
+    case "In":
+      return `${requirement.key} in (${values})`;
+    case "NotIn":
+      return `${requirement.key} notin (${values})`;
+    case "Exists":
+      return requirement.key;
+    case "DoesNotExist":
+      return `!${requirement.key}`;
+    default:
+      return `${requirement.key} ${requirement.operator}${values ? ` (${values})` : ""}`;
+  }
+};
+
+/** One `kubectl`-syntax term per matchLabels pair, then one per matchExpression. */
+export const labelSelectorTerms = (selector: ParsedLabelSelector): string[] => [
+  ...Object.entries(selector.matchLabels).map(([key, value]) => `${key}=${value}`),
+  ...selector.matchExpressions.map(formatRequirement),
+];
+
+/** `null` — not `false` — when the operator is unknown, so callers can tell "no" from "cannot say". */
+const matchesRequirement = (
+  labels: Record<string, string | undefined> | undefined,
+  requirement: LabelSelectorRequirement
+): boolean | null => {
+  const value = labels?.[requirement.key];
+  const values = requirement.values ?? [];
+  switch (requirement.operator) {
+    case "In":
+      return value !== undefined && values.includes(value);
+    case "NotIn":
+      return value === undefined || !values.includes(value);
+    case "Exists":
+      return value !== undefined;
+    case "DoesNotExist":
+      return value === undefined;
+    default:
+      return null;
+  }
+};
+
+/**
+ * Kubernetes AND-semantics: every matchLabels pair and every matchExpression
+ * must hold. An unevaluable requirement counts as a non-match so the diagram
+ * never claims a Trigger fires when it cannot prove it — callers report the
+ * unsupported operator as a coverage gap instead.
+ */
+export const triggerMatchesSelector = (trigger: Trigger, selector: ParsedLabelSelector): boolean => {
+  const labels = trigger.metadata.labels;
+  const labelsMatch = Object.entries(selector.matchLabels).every(([key, value]) => labels?.[key] === value);
+  return labelsMatch && selector.matchExpressions.every((r) => matchesRequirement(labels, r) === true);
+};

--- a/packages/shared/src/models/k8s/groups/Tekton/EventListener/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/EventListener/schema.ts
@@ -7,9 +7,27 @@ const eventListenerLabelsSchema = z.object({
   [eventListenerLabels.gitServer]: z.string().optional(),
 });
 
+// Loose on purpose: one EventListener with an unexpected shape here must not
+// fail the parse of the whole list and blank the page. Consumers validate and
+// degrade per entry instead — see the tekton labelSelector util.
+const eventListenerLabelSelectorSchema = z
+  .object({
+    matchLabels: z.record(z.unknown()).optional(),
+    matchExpressions: z.array(z.unknown()).optional(),
+  })
+  .catchall(z.any());
+
+const eventListenerNamespaceSelectorSchema = z
+  .object({
+    matchNames: z.array(z.unknown()).optional(),
+  })
+  .catchall(z.any());
+
 const eventListenerSpecSchema = z
   .object({
-    triggers: z.array(triggerSpecSchema).optional(),
+    triggers: z.array(triggerSpecSchema).nullish(),
+    labelSelector: eventListenerLabelSelectorSchema.optional(),
+    namespaceSelector: eventListenerNamespaceSelectorSchema.optional(),
   })
   .catchall(z.any());
 

--- a/packages/shared/src/models/k8s/groups/Tekton/Trigger/schema.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Trigger/schema.ts
@@ -33,8 +33,10 @@ const triggerBindingRefSchema = z
 export const triggerSpecSchema = z
   .object({
     name: z.string().optional(),
-    interceptors: z.array(triggerInterceptorSchema).optional(),
-    bindings: z.array(triggerBindingRefSchema).optional(),
+    // Tekton persists these as explicit `null` (not absent) when a Trigger
+    // declares neither, so they must be nullish rather than merely optional.
+    interceptors: z.array(triggerInterceptorSchema).nullish(),
+    bindings: z.array(triggerBindingRefSchema).nullish(),
     template: z
       .object({
         ref: z.string().optional(),


### PR DESCRIPTION


EventListeners now select Triggers declaratively via spec.labelSelector.matchLabels, so the portal must show label-based registration alongside the explicit spec.triggers list.

- add a Label Selector column to the EventListener list rendering matchLabels as key=value badges
- include label-matched Triggers in the topology as a distinct source kind served from the existing namespace Trigger watch
- draw label-sourced triggers with a dashed edge and a via-label badge with matched pairs in the node and drawer
- flag triggers that are both listed and label-matched with a fires-twice warning to surface the double-trigger misconfiguration
- guard the no-selector path with a regression test producing output identical to the previous behavior

# Pull Request

