### PR TITLE
EPMDEDP-17264: fix: resolve PipelineRun history timestamps across both Tekton Results watcher generations

### DIFF
--- a/packages/shared/src/models/tektonResults/adapters.test.ts
+++ b/packages/shared/src/models/tektonResults/adapters.test.ts
@@ -634,31 +634,84 @@ describe("normalizeResultToPipelineRun", () => {
     expect(result.status?.conditions?.[0]?.reason).toBeUndefined();
   });
 
-  it("should fallback to update_time when end_time is null for completed runs", () => {
-    const noEndTime: TektonResult = {
-      ...mockTektonResult,
-      summary: { ...mockTektonResult.summary!, end_time: undefined, status: "SUCCESS" },
-    };
-    const result = normalizeResultToPipelineRun(noEndTime, "edp-delivery");
+  describe("run interval resolution across watcher versions", () => {
+    it("should prefer summary timestamps when the watcher populated both (>= v0.20.0)", () => {
+      const result = normalizeResultToPipelineRun(mockTektonResult, "edp-delivery");
 
-    expect(result.status?.completionTime).toBe("2026-03-10T10:15:00Z");
-  });
+      expect(result.status?.startTime).toBe("2026-03-10T10:00:01Z");
+      expect(result.status?.completionTime).toBe("2026-03-10T10:14:50Z");
+    });
 
-  it("should bound completionTime to update_time for UNKNOWN status without end_time", () => {
-    const unfinalized: TektonResult = {
-      ...mockTektonResult,
-      summary: { ...mockTektonResult.summary!, end_time: undefined, status: "UNKNOWN" },
-    };
-    const result = normalizeResultToPipelineRun(unfinalized, "edp-delivery");
+    it("should fall back to row timestamps when both summary fields are null (< v0.20.0)", () => {
+      const legacyRow: TektonResult = {
+        ...mockTektonResult,
+        summary: { ...mockTektonResult.summary!, start_time: undefined, end_time: undefined, status: "FAILURE" },
+      };
+      const result = normalizeResultToPipelineRun(legacyRow, "edp-delivery");
 
-    // Terminal-but-unfinalized runs still get a completion time (the "Running forever" bug).
-    expect(result.status?.completionTime).toBe("2026-03-10T10:15:00Z");
-  });
+      expect(result.status?.startTime).toBe("2026-03-10T10:00:00Z");
+      expect(result.status?.completionTime).toBe("2026-03-10T10:15:00Z");
+    });
 
-  it("should use end_time as completionTime when available", () => {
-    const result = normalizeResultToPipelineRun(mockTektonResult, "edp-delivery");
+    it("should mix sources per field: real end_time with create_time as start (< v0.20.0 success)", () => {
+      // The old watcher set end_time for SUCCESS runs (ConditionSucceeded was True)
+      // but never start_time (ConditionReady is unset on batch resources).
+      const legacySuccess: TektonResult = {
+        ...mockTektonResult,
+        summary: { ...mockTektonResult.summary!, start_time: undefined, status: "SUCCESS" },
+      };
+      const result = normalizeResultToPipelineRun(legacySuccess, "edp-delivery");
 
-    expect(result.status?.completionTime).toBe("2026-03-10T10:14:50Z");
+      expect(result.status?.startTime).toBe("2026-03-10T10:00:00Z");
+      expect(result.status?.completionTime).toBe("2026-03-10T10:14:50Z");
+    });
+
+    it("should bound completionTime to update_time for UNKNOWN status without end_time", () => {
+      const unfinalized: TektonResult = {
+        ...mockTektonResult,
+        summary: { ...mockTektonResult.summary!, end_time: undefined, status: "UNKNOWN" },
+      };
+      const result = normalizeResultToPipelineRun(unfinalized, "edp-delivery");
+
+      // Terminal-but-unfinalized runs still get a completion time (the "Running forever" bug).
+      expect(result.status?.completionTime).toBe("2026-03-10T10:15:00Z");
+    });
+
+    it("should fall back to the row pair when mixed sources invert the interval", () => {
+      // Archived after completion: create_time (10:20) is later than the watcher's
+      // end_time (10:14:50), which would render a negative duration.
+      const archivedLate: TektonResult = {
+        ...mockTektonResult,
+        create_time: "2026-03-10T10:20:00Z",
+        update_time: "2026-03-10T10:20:05Z",
+        summary: { ...mockTektonResult.summary!, start_time: undefined, status: "SUCCESS" },
+      };
+      const result = normalizeResultToPipelineRun(archivedLate, "edp-delivery");
+
+      expect(result.status?.startTime).toBe("2026-03-10T10:20:00Z");
+      expect(result.status?.completionTime).toBe("2026-03-10T10:20:05Z");
+    });
+
+    it("should not invert when only the summary pair is present and ordered", () => {
+      const result = normalizeResultToPipelineRun(mockTektonResult, "edp-delivery");
+      const start = Date.parse(result.status!.startTime!);
+      const end = Date.parse(result.status!.completionTime!);
+
+      expect(end).toBeGreaterThanOrEqual(start);
+    });
+
+    it("should tolerate unparseable summary timestamps without inverting", () => {
+      const malformed: TektonResult = {
+        ...mockTektonResult,
+        summary: { ...mockTektonResult.summary!, start_time: "not-a-timestamp" },
+      };
+      const result = normalizeResultToPipelineRun(malformed, "edp-delivery");
+
+      // No epoch to compare against, so the value passes through untouched rather
+      // than silently discarding the (valid) end_time.
+      expect(result.status?.startTime).toBe("not-a-timestamp");
+      expect(result.status?.completionTime).toBe("2026-03-10T10:14:50Z");
+    });
   });
 
   it("should fallback to uid when objectMetadataName annotation is missing", () => {

--- a/packages/shared/src/models/tektonResults/adapters.ts
+++ b/packages/shared/src/models/tektonResults/adapters.ts
@@ -172,6 +172,41 @@ function getResultAnnotation(result: TektonResult, key: string): string | undefi
   return value;
 }
 
+function toEpochMs(timestamp: string | undefined): number | undefined {
+  if (!timestamp) return undefined;
+  const ms = Date.parse(timestamp);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+/**
+ * Tekton Results < v0.20.0 derived RecordSummary timestamps from Knative conditions,
+ * leaving `start_time` NULL on every row (`ConditionReady` is never set on batch
+ * resources) and `end_time` NULL on failed/timed-out/cancelled ones (`ConditionSucceeded`
+ * was skipped while False) — hence the per-field, rather than all-or-nothing, fallback.
+ * tektoncd/results#1285 fixed the write path in v0.20.0 but does not backfill, so both
+ * shapes coexist until the pre-upgrade rows age out of the retention window.
+ *
+ * `create_time`/`update_time` are server-populated and never NULL, so the fallback always
+ * yields a bounded duration instead of one that grows forever — which matters most for
+ * rows whose `summary.status` the watcher also left UNKNOWN.
+ */
+function resolveResultTimes(result: TektonResult): { startTime: string; completionTime: string } {
+  const startTime = result.summary?.start_time || result.create_time;
+  const completionTime = result.summary?.end_time || result.update_time;
+
+  const startMs = toEpochMs(startTime);
+  const completionMs = toEpochMs(completionTime);
+
+  // Mixing a summary timestamp with a row timestamp can invert the interval: a run
+  // archived after it finished has `create_time` > `end_time`, rendering a negative
+  // duration. The row pair is written in order, so it is always self-consistent.
+  if (startMs !== undefined && completionMs !== undefined && completionMs < startMs) {
+    return { startTime: result.create_time, completionTime: result.update_time };
+  }
+
+  return { startTime, completionTime };
+}
+
 /**
  * Normalize a Tekton Result (from the `results` table) to a K8s PipelineRun shape.
  *
@@ -192,14 +227,7 @@ export function normalizeResultToPipelineRun(result: TektonResult, namespace: st
   const summaryStatus = result.summary?.status || "UNKNOWN";
   const statusInfo = RESULT_STATUS_MAP[summaryStatus] || RESULT_STATUS_MAP.UNKNOWN;
 
-  const startTime = result.create_time;
-  // A Result row is archived => terminal, so it always has a completion time.
-  // summary.end_time is NULL for many results due to a Tekton Results watcher bug
-  // (the watcher uses ConditionReady instead of status.completionTime). Fall back
-  // to update_time: the Result is updated when the PipelineRun completes, so
-  // update_time ≈ actual completion time. This bounds the rendered duration even
-  // when summary.status was never finalized (otherwise it grows forever).
-  const completionTime = result.summary?.end_time || result.update_time;
+  const { startTime, completionTime } = resolveResultTimes(result);
 
   const resultAnnotations: Record<string, string> = {};
   const annotationKeys = [

--- a/packages/trpc/src/routers/tektonResults/procedures/getPipelineRunResults/index.ts
+++ b/packages/trpc/src/routers/tektonResults/procedures/getPipelineRunResults/index.ts
@@ -37,6 +37,9 @@ export const getPipelineRunResultsProcedure = protectedProcedure
       filter: combinedFilter,
       pageSize,
       pageToken,
+      // Not `summary.end_time desc`: it is NULL on rows archived before Tekton Results
+      // v0.20.0 (tektoncd/results#1285, no backfill), and ordering by a NULL column
+      // corrupts the pagination cursor so page 2+ comes back empty.
       orderBy: "create_time desc",
     });
 


### PR DESCRIPTION


Tekton Results < v0.20.0 left RecordSummary start_time NULL on every archived row and end_time NULL on failed, timed-out, and cancelled ones, because the watcher derived both from Knative conditions that batch resources never set. History rows therefore fell back to the archive timestamp, overstating durations by the watcher's reconcile lag and letting unfinalized runs render a duration that grew forever.

tektoncd/results#1285 fixes the write path in v0.20.0 but does not backfill, so with a 90-day retention window both row shapes coexist until the pre-upgrade rows expire. Resolve each timestamp independently — preferring the summary field and falling back to the row's create_time/update_time — so a legacy successful run still contributes its real completion time instead of being discarded wholesale by a version check.

Guard against an inverted interval: pairing a summary timestamp with a row timestamp can place the end before the start for a run archived after it finished, which would render a negative duration. Fall back to the row pair, which the server writes in order.

Keep ordering on create_time rather than summary.end_time; the latter is still NULL on legacy rows and would corrupt the pagination cursor.

