### PR TITLE
EPMDEDP-17267: fix: resolve the TriggerTemplate ServiceAccount placeholder for portal-started PipelineRuns

### DIFF
--- a/apps/client/src/modules/platform/codebases/pages/details/components/BranchList/components/PipelineActionsGroup/index.tsx
+++ b/apps/client/src/modules/platform/codebases/pages/details/components/BranchList/components/PipelineActionsGroup/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { ButtonWithPermission } from "@/core/components/ButtonWithPermission";
 import { StatusIcon } from "@/core/components/StatusIcon";
+import { usePipelineWatchItem } from "@/k8s/api/groups/Tekton/Pipeline";
 import { usePipelineRunCRUD, usePipelineRunPermissions } from "@/k8s/api/groups/Tekton/PipelineRun";
 import { CUSTOM_RESOURCE_STATUS } from "@/k8s/constants/statuses";
 import {
@@ -65,6 +66,36 @@ export function PipelineActionsGroup({
   const isTektonCI = codebaseCiTool === ciTool.tekton;
   const isGitLabCI = codebaseCiTool === ciTool.gitlab;
 
+  // Fetched solely for its app.edp.epam.com/service-account annotation, which the
+  // TriggerTemplates reference as $(tt.params.serviceAccount) and the interceptor
+  // resolves for webhooks — this path bypasses the interceptor.
+  // Per branch row, but cache and watch registry key on (cluster, ns, kind, name),
+  // so branches sharing a pipeline collapse to one GET; a namespace-wide list watch
+  // would be worse, the library ships 200+ Pipelines.
+  const buildPipelineName = codebaseBranch.spec?.pipelines?.build;
+  const securityPipelineName = codebaseBranch.spec?.pipelines?.security;
+
+  const buildPipelineWatch = usePipelineWatchItem({
+    name: buildPipelineName,
+    namespace: codebaseBranch.metadata.namespace,
+    queryOptions: {
+      enabled: isTektonCI && !!buildPipelineName,
+    },
+  });
+
+  const securityPipelineWatch = usePipelineWatchItem({
+    name: securityPipelineName,
+    namespace: codebaseBranch.metadata.namespace,
+    queryOptions: {
+      enabled: isTektonCI && !!securityPipelineName,
+    },
+  });
+
+  // Settled, not successful: a 404 must not wedge the button — it falls back to the
+  // TriggerTemplate default.
+  const buildPipelineReady = !buildPipelineName || !buildPipelineWatch.query.isPending;
+  const securityPipelineReady = !securityPipelineName || !securityPipelineWatch.query.isPending;
+
   // Normalize gitUrlPath by stripping leading slash (used for GitLab CI)
   const normalizedGitUrlPath = React.useMemo(
     () => stripLeadingSlash(codebase?.spec.gitUrlPath),
@@ -73,7 +104,7 @@ export function PipelineActionsGroup({
 
   // Build pipeline run draft (Tekton)
   const buildPipelineRunData = React.useMemo(() => {
-    if (!isTektonCI || !gitServerByCodebase || !codebase) {
+    if (!isTektonCI || !gitServerByCodebase || !codebase || !buildPipelineReady) {
       return;
     }
 
@@ -92,12 +123,22 @@ export function PipelineActionsGroup({
       codebaseBranch,
       pipelineRunTemplate: buildPipelineRunTemplateCopy,
       gitServer: gitServerByCodebase,
+      pipeline: buildPipelineWatch.query.data,
+      triggerTemplate: buildTriggerTemplate,
     });
-  }, [isTektonCI, buildTriggerTemplate?.spec?.resourcetemplates, codebase, codebaseBranch, gitServerByCodebase]);
+  }, [
+    isTektonCI,
+    buildTriggerTemplate,
+    codebase,
+    codebaseBranch,
+    gitServerByCodebase,
+    buildPipelineReady,
+    buildPipelineWatch.query.data,
+  ]);
 
   // Security pipeline run draft (Tekton only)
   const securityPipelineRunData = React.useMemo(() => {
-    if (!isTektonCI || !gitServerByCodebase || !codebase) {
+    if (!isTektonCI || !gitServerByCodebase || !codebase || !securityPipelineReady) {
       return;
     }
 
@@ -114,8 +155,18 @@ export function PipelineActionsGroup({
       codebaseBranch,
       pipelineRunTemplate: securityPipelineRunTemplateCopy,
       gitServer: gitServerByCodebase,
+      pipeline: securityPipelineWatch.query.data,
+      triggerTemplate: securityTriggerTemplate,
     });
-  }, [isTektonCI, securityTriggerTemplate?.spec?.resourcetemplates, codebase, codebaseBranch, gitServerByCodebase]);
+  }, [
+    isTektonCI,
+    securityTriggerTemplate,
+    codebase,
+    codebaseBranch,
+    gitServerByCodebase,
+    securityPipelineReady,
+    securityPipelineWatch.query.data,
+  ]);
 
   // Build handlers
   const onTektonBuildClick = React.useCallback(async () => {
@@ -228,13 +279,15 @@ export function PipelineActionsGroup({
     !pipelineRunPermissions.data.create.allowed ||
     latestBuildIsRunning ||
     !codebaseBranchStatusIsOk ||
-    (isGitLabCI && isGitLabLoading);
+    (isGitLabCI && isGitLabLoading) ||
+    (isTektonCI && !buildPipelineRunData);
 
   const securityButtonDisabled =
     !pipelineRunPermissions.data.create.allowed ||
     latestSecurityIsRunning ||
     !codebaseBranchStatusIsOk ||
-    !securityPipelineConfigured;
+    !securityPipelineConfigured ||
+    (isTektonCI && !securityPipelineRunData);
 
   // Tooltips
   const buildButtonTooltip = (() => {
@@ -252,6 +305,14 @@ export function PipelineActionsGroup({
 
     if (!codebaseBranchStatusIsOk) {
       return `Codebase branch status is ${codebaseBranch?.status?.status}`;
+    }
+
+    if (isTektonCI && !buildPipelineRunData) {
+      // A settled-but-empty TriggerTemplate watch is misconfiguration, not slow load;
+      // "loading" would leave the button disabled behind a promise never kept.
+      return buildTriggerTemplateWatch.query.isPending || buildTriggerTemplate?.spec?.resourcetemplates?.[0]
+        ? "Loading build pipeline definition..."
+        : "Build TriggerTemplate is missing or declares no resourcetemplates";
     }
 
     return isGitLabCI ? "Trigger GitLab CI pipeline" : "Trigger build PipelineRun";

--- a/packages/shared/src/models/k8s/groups/Tekton/Pipeline/annotations.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Pipeline/annotations.ts
@@ -1,0 +1,5 @@
+export const pipelineAnnotations = {
+  /** Chart-written, fed to the build/review TriggerTemplates by the krci interceptor.
+   *  The portal reads it directly so runs started outside the webhook flow match. */
+  serviceAccount: "app.edp.epam.com/service-account",
+} as const;

--- a/packages/shared/src/models/k8s/groups/Tekton/Pipeline/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/Pipeline/index.ts
@@ -3,3 +3,4 @@ export * from "./types.js";
 export * from "./constants.js";
 export * from "./utils/index.js";
 export * from "./labels.js";
+export * from "./annotations.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createBuildPipelineRunDraft/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createBuildPipelineRunDraft/index.test.ts
@@ -452,3 +452,65 @@ describe("testing createBuildPipelineRunDraft", () => {
     });
   });
 });
+
+describe("createBuildPipelineRunDraft ServiceAccount resolution", () => {
+  const gitServer = {
+    spec: { gitHost: "github.com", gitProvider: "github", gitUser: "git", sshPort: 22, nameSshKeySecret: "secretName" },
+  } as unknown as GitServer;
+
+  const templateWithPlaceholder = () =>
+    ({
+      ...structuredClone(mockPipelineRunTemplate),
+      spec: {
+        ...structuredClone(mockPipelineRunTemplate.spec),
+        taskRunTemplate: { serviceAccountName: "$(tt.params.serviceAccount)" },
+      },
+    }) as unknown as PipelineRun;
+
+  const triggerTemplate = {
+    spec: { params: [{ name: "serviceAccount", default: "tekton-unprivileged" }] },
+  } as unknown as Parameters<typeof createBuildPipelineRunDraft>[0]["triggerTemplate"];
+
+  it("resolves the placeholder from the build Pipeline annotation", () => {
+    const object = createBuildPipelineRunDraft({
+      codebase: mockCodebase,
+      codebaseBranch: mockCodebaseBranch as unknown as CodebaseBranch,
+      pipelineRunTemplate: templateWithPlaceholder(),
+      gitServer,
+      pipeline: {
+        metadata: { name: "test-build-pipeline", annotations: { "app.edp.epam.com/service-account": "tekton" } },
+        spec: {},
+      } as unknown as Parameters<typeof createBuildPipelineRunDraft>[0]["pipeline"],
+      triggerTemplate,
+    });
+
+    expect(object.spec.taskRunTemplate?.serviceAccountName).toBe("tekton");
+  });
+
+  it("falls back to the TriggerTemplate default for an unannotated Pipeline", () => {
+    const object = createBuildPipelineRunDraft({
+      codebase: mockCodebase,
+      codebaseBranch: mockCodebaseBranch as unknown as CodebaseBranch,
+      pipelineRunTemplate: templateWithPlaceholder(),
+      gitServer,
+      pipeline: {
+        metadata: { name: "test-build-pipeline" },
+        spec: {},
+      } as unknown as Parameters<typeof createBuildPipelineRunDraft>[0]["pipeline"],
+      triggerTemplate,
+    });
+
+    expect(object.spec.taskRunTemplate?.serviceAccountName).toBe("tekton-unprivileged");
+  });
+
+  it("never emits an unresolved placeholder as a ServiceAccount name", () => {
+    const object = createBuildPipelineRunDraft({
+      codebase: mockCodebase,
+      codebaseBranch: mockCodebaseBranch as unknown as CodebaseBranch,
+      pipelineRunTemplate: templateWithPlaceholder(),
+      gitServer,
+    });
+
+    expect(object.spec.taskRunTemplate?.serviceAccountName).toBeUndefined();
+  });
+});

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createBuildPipelineRunDraft/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createBuildPipelineRunDraft/index.ts
@@ -3,18 +3,25 @@ import { Codebase, GitServer, CodebaseBranch, gitProvider } from "../../../../KR
 import { PipelineRun } from "../../types.js";
 import { pipelineRunLabels } from "../../labels.js";
 import { pipelineType } from "../../../Pipeline/constants.js";
+import { Pipeline } from "../../../Pipeline/types.js";
+import { TriggerTemplate } from "../../../TriggerTemplate/types.js";
 import { RESULT_ANNOTATIONS_KEY, createResultAnnotations } from "../resultAnnotations/index.js";
+import { applyTaskRunServiceAccount } from "../resolveTaskRunServiceAccount/index.js";
 
 export const createBuildPipelineRunDraft = ({
   codebase,
   codebaseBranch,
   pipelineRunTemplate,
   gitServer,
+  pipeline,
+  triggerTemplate,
 }: {
   codebase: Codebase;
   codebaseBranch: CodebaseBranch;
   pipelineRunTemplate: PipelineRun;
   gitServer: GitServer;
+  pipeline?: Pipeline;
+  triggerTemplate?: TriggerTemplate;
 }): PipelineRun => {
   const {
     metadata: { name: codebaseName },
@@ -51,6 +58,8 @@ export const createBuildPipelineRunDraft = ({
   if (base.spec.pipelineRef) {
     base.spec.pipelineRef.name = codebaseBranch.spec?.pipelines?.build;
   }
+
+  applyTaskRunServiceAccount(base, { pipeline, triggerTemplate });
 
   base.spec.workspaces = [
     ...(base.spec.workspaces || []),

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.test.ts
@@ -480,3 +480,56 @@ describe("testing createPipelineRunDraftFromPipeline", () => {
     ]);
   });
 });
+
+describe("createPipelineRunDraftFromPipeline ServiceAccount resolution", () => {
+  const triggerTemplate = (saDefault?: string) =>
+    ({
+      spec: {
+        params: [
+          { name: "codebase" },
+          ...(saDefault === undefined ? [] : [{ name: "serviceAccount", default: saDefault }]),
+        ],
+        resourcetemplates: [
+          {
+            apiVersion: "tekton.dev/v1",
+            kind: "PipelineRun",
+            metadata: { generateName: "build-$(tt.params.codebase)-", labels: {} },
+            spec: {
+              taskRunTemplate: { serviceAccountName: "$(tt.params.serviceAccount)" },
+              pipelineRef: { name: "$(tt.params.pipelineName)" },
+              params: [],
+            },
+          },
+        ],
+      },
+    }) as unknown as TriggerTemplate;
+
+  const pipeline = (sa?: string) =>
+    ({
+      metadata: {
+        name: "github-go-beego-app-build-default",
+        namespace: "krci",
+        labels: { "app.edp.epam.com/pipelinetype": "build" },
+        ...(sa === undefined ? {} : { annotations: { "app.edp.epam.com/service-account": sa } }),
+      },
+      spec: { params: [{ name: "CODEBASE_NAME", default: "" }] },
+    }) as unknown as Pipeline;
+
+  it("resolves the placeholder from the Pipeline annotation, not the generic param walker", () => {
+    const result = createPipelineRunDraftFromPipeline(triggerTemplate("tekton-unprivileged"), pipeline("tekton"));
+
+    expect(result.spec?.taskRunTemplate?.serviceAccountName).toBe("tekton");
+  });
+
+  it("falls back to the TriggerTemplate default for an unannotated Pipeline", () => {
+    const result = createPipelineRunDraftFromPipeline(triggerTemplate("tekton-unprivileged"), pipeline());
+
+    expect(result.spec?.taskRunTemplate?.serviceAccountName).toBe("tekton-unprivileged");
+  });
+
+  it("does not degrade the ServiceAccount to an empty string", () => {
+    const result = createPipelineRunDraftFromPipeline(triggerTemplate(), pipeline());
+
+    expect(result.spec?.taskRunTemplate?.serviceAccountName).toBeUndefined();
+  });
+});

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createPipelineRunDraftFromPipeline/index.ts
@@ -4,6 +4,7 @@ import { PipelineRunDraft } from "../../types.js";
 import { TriggerTemplate } from "../../../TriggerTemplate/index.js";
 import { pipelineLabels } from "../../../Pipeline/labels.js";
 import { pipelineRunLabels } from "../../labels.js";
+import { applyTaskRunServiceAccount, WHOLE_TT_PARAM_RE } from "../resolveTaskRunServiceAccount/index.js";
 
 interface PipelineRunWorkspaceWithVCT {
   name: string;
@@ -14,9 +15,6 @@ interface PipelineRunWorkspaceWithVCT {
     };
   };
 }
-
-// Matches Tekton Triggers placeholder syntax: $(tt.params.<name>)
-const TT_PARAM_RE = /^\$\(tt\.params\.([^)]+)\)$/;
 
 type PipelineParamSpec = NonNullable<Pipeline["spec"]["params"]>[number];
 
@@ -81,7 +79,7 @@ function resolveTtParams(
     const spec = byName.get(param.name);
 
     // Case 1: unresolved placeholder
-    if (typeof param.value === "string" && TT_PARAM_RE.test(param.value)) {
+    if (typeof param.value === "string" && WHOLE_TT_PARAM_RE.test(param.value)) {
       const value = spec?.default ?? (spec?.type === "array" ? [] : "");
       return { name: param.name, value };
     }
@@ -118,6 +116,10 @@ const getPipelineRunFromTriggerTemplate = (
   if (pipelineRun.spec?.pipelineRef) {
     pipelineRun.spec.pipelineRef.name = pipeline.metadata.name;
   }
+
+  // Must precede the generic pass: serviceAccount is no Pipeline param, so the
+  // walker below would resolve it to "" and silently use Tekton's default account.
+  applyTaskRunServiceAccount(pipelineRun, { pipeline, triggerTemplate });
 
   if (pipeline.spec?.params) {
     // Pass 1: resolve ALL $(tt.params.*) throughout the entire template as

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createSecurityPipelineRunDraft/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createSecurityPipelineRunDraft/index.test.ts
@@ -224,3 +224,58 @@ describe("createSecurityPipelineRunDraft", () => {
     });
   });
 });
+
+describe("createSecurityPipelineRunDraft ServiceAccount resolution", () => {
+  const templateWith = (serviceAccountName: string) =>
+    ({
+      ...structuredClone(mockPipelineRunTemplate),
+      spec: { ...structuredClone(mockPipelineRunTemplate.spec), taskRunTemplate: { serviceAccountName } },
+    }) as unknown as PipelineRun;
+
+  const triggerTemplate = {
+    spec: { params: [{ name: "serviceAccount", default: "tekton-unprivileged" }] },
+  } as unknown as Parameters<typeof createSecurityPipelineRunDraft>[0]["triggerTemplate"];
+
+  const base = {
+    codebase: mockCodebase as unknown as Codebase,
+    codebaseBranch: mockCodebaseBranch as unknown as CodebaseBranch,
+    gitServer: mockGitServer,
+  };
+
+  it("leaves the chart-pinned tekton-security account untouched", () => {
+    const result = createSecurityPipelineRunDraft({
+      ...base,
+      pipelineRunTemplate: templateWith("tekton-security"),
+      pipeline: {
+        metadata: { name: "sec", annotations: { "app.edp.epam.com/service-account": "tekton" } },
+        spec: {},
+      } as unknown as Parameters<typeof createSecurityPipelineRunDraft>[0]["pipeline"],
+      triggerTemplate,
+    });
+
+    expect(result.spec.taskRunTemplate?.serviceAccountName).toBe("tekton-security");
+  });
+
+  it("resolves a placeholder from the security Pipeline annotation", () => {
+    const result = createSecurityPipelineRunDraft({
+      ...base,
+      pipelineRunTemplate: templateWith("$(tt.params.serviceAccount)"),
+      pipeline: {
+        metadata: { name: "sec", annotations: { "app.edp.epam.com/service-account": "tekton-security" } },
+        spec: {},
+      } as unknown as Parameters<typeof createSecurityPipelineRunDraft>[0]["pipeline"],
+      triggerTemplate,
+    });
+
+    expect(result.spec.taskRunTemplate?.serviceAccountName).toBe("tekton-security");
+  });
+
+  it("never emits an unresolved placeholder as a ServiceAccount name", () => {
+    const result = createSecurityPipelineRunDraft({
+      ...base,
+      pipelineRunTemplate: templateWith("$(tt.params.serviceAccount)"),
+    });
+
+    expect(result.spec.taskRunTemplate?.serviceAccountName).toBeUndefined();
+  });
+});

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createSecurityPipelineRunDraft/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/createSecurityPipelineRunDraft/index.ts
@@ -3,18 +3,25 @@ import { Codebase, GitServer, CodebaseBranch, gitProvider } from "../../../../KR
 import { PipelineRun } from "../../types.js";
 import { pipelineRunLabels } from "../../labels.js";
 import { pipelineType } from "../../../Pipeline/constants.js";
+import { Pipeline } from "../../../Pipeline/types.js";
+import { TriggerTemplate } from "../../../TriggerTemplate/types.js";
 import { RESULT_ANNOTATIONS_KEY, createResultAnnotations } from "../resultAnnotations/index.js";
+import { applyTaskRunServiceAccount } from "../resolveTaskRunServiceAccount/index.js";
 
 export function createSecurityPipelineRunDraft({
   codebase,
   codebaseBranch,
   pipelineRunTemplate,
   gitServer,
+  pipeline,
+  triggerTemplate,
 }: {
   codebase: Codebase;
   codebaseBranch: CodebaseBranch;
   pipelineRunTemplate: PipelineRun;
   gitServer: GitServer;
+  pipeline?: Pipeline;
+  triggerTemplate?: TriggerTemplate;
 }): PipelineRun {
   const {
     metadata: { name: codebaseName },
@@ -51,6 +58,8 @@ export function createSecurityPipelineRunDraft({
   if (base.spec.pipelineRef) {
     base.spec.pipelineRef.name = codebaseBranch.spec?.pipelines?.security;
   }
+
+  applyTaskRunServiceAccount(base, { pipeline, triggerTemplate });
 
   const gitUrlPathWithoutSlashAtStart = stripLeadingSlash(codebaseGitUrlPath);
 

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/index.ts
@@ -12,3 +12,4 @@ export * from "./childReferences/index.js";
 export * from "./getPipelineRunTaskGraphDefinitions/index.js";
 export * from "./isHistoryPipelineRun/index.js";
 export * from "./resultAnnotations/index.js";
+export * from "./resolveTaskRunServiceAccount/index.js";

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/resolveTaskRunServiceAccount/index.test.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/resolveTaskRunServiceAccount/index.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { applyTaskRunServiceAccount, resolveServiceAccountName } from "./index.js";
+import { Pipeline } from "../../../Pipeline/types.js";
+import { TriggerTemplate } from "../../../TriggerTemplate/types.js";
+
+const pipelineWithAnnotation = (value?: string) =>
+  ({
+    apiVersion: "tekton.dev/v1",
+    kind: "Pipeline",
+    metadata: {
+      name: "github-go-beego-app-build-default",
+      namespace: "krci",
+      ...(value === undefined ? {} : { annotations: { "app.edp.epam.com/service-account": value } }),
+    },
+    spec: {},
+  }) as unknown as Pipeline;
+
+const triggerTemplateWithDefault = (def?: string) =>
+  ({
+    apiVersion: "triggers.tekton.dev/v1beta1",
+    kind: "TriggerTemplate",
+    metadata: { name: "github-build-template", namespace: "krci" },
+    spec: {
+      params: [{ name: "codebase" }, ...(def === undefined ? [] : [{ name: "serviceAccount", default: def }])],
+      resourcetemplates: [],
+    },
+  }) as unknown as TriggerTemplate;
+
+const draft = (serviceAccountName?: string) => ({
+  spec: {
+    ...(serviceAccountName === undefined ? {} : { taskRunTemplate: { serviceAccountName } }),
+  },
+});
+
+describe("resolveServiceAccountName", () => {
+  it("prefers the Pipeline annotation over the TriggerTemplate default", () => {
+    expect(
+      resolveServiceAccountName({
+        pipeline: pipelineWithAnnotation("tekton"),
+        triggerTemplate: triggerTemplateWithDefault("tekton-unprivileged"),
+        paramName: "serviceAccount",
+      })
+    ).toBe("tekton");
+  });
+
+  it("falls back to the TriggerTemplate param default when the annotation is absent", () => {
+    expect(
+      resolveServiceAccountName({
+        pipeline: pipelineWithAnnotation(),
+        triggerTemplate: triggerTemplateWithDefault("tekton-unprivileged"),
+        paramName: "serviceAccount",
+      })
+    ).toBe("tekton-unprivileged");
+  });
+
+  it("treats a blank annotation as absent", () => {
+    expect(
+      resolveServiceAccountName({
+        pipeline: pipelineWithAnnotation("   "),
+        triggerTemplate: triggerTemplateWithDefault("tekton-unprivileged"),
+        paramName: "serviceAccount",
+      })
+    ).toBe("tekton-unprivileged");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(
+      resolveServiceAccountName({
+        pipeline: pipelineWithAnnotation(" tekton-cd\n"),
+        paramName: "serviceAccount",
+      })
+    ).toBe("tekton-cd");
+  });
+
+  it("returns undefined when neither source resolves", () => {
+    expect(
+      resolveServiceAccountName({
+        pipeline: pipelineWithAnnotation(),
+        triggerTemplate: triggerTemplateWithDefault(),
+        paramName: "serviceAccount",
+      })
+    ).toBeUndefined();
+  });
+
+  it("matches the TriggerTemplate default by param name", () => {
+    expect(
+      resolveServiceAccountName({
+        triggerTemplate: triggerTemplateWithDefault("tekton-unprivileged"),
+        paramName: "somethingElse",
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe("applyTaskRunServiceAccount", () => {
+  it("replaces the placeholder with the Pipeline annotation value", () => {
+    const d = draft("$(tt.params.serviceAccount)");
+
+    applyTaskRunServiceAccount(d, {
+      pipeline: pipelineWithAnnotation("tekton"),
+      triggerTemplate: triggerTemplateWithDefault("tekton-unprivileged"),
+    });
+
+    expect(d.spec.taskRunTemplate?.serviceAccountName).toBe("tekton");
+  });
+
+  it("replaces the placeholder with the TriggerTemplate default when unannotated", () => {
+    const d = draft("$(tt.params.serviceAccount)");
+
+    applyTaskRunServiceAccount(d, {
+      pipeline: pipelineWithAnnotation(),
+      triggerTemplate: triggerTemplateWithDefault("tekton-unprivileged"),
+    });
+
+    expect(d.spec.taskRunTemplate?.serviceAccountName).toBe("tekton-unprivileged");
+  });
+
+  it("leaves a concrete ServiceAccount untouched", () => {
+    const d = draft("tekton-security");
+
+    applyTaskRunServiceAccount(d, {
+      pipeline: pipelineWithAnnotation("tekton"),
+      triggerTemplate: triggerTemplateWithDefault("tekton-unprivileged"),
+    });
+
+    expect(d.spec.taskRunTemplate?.serviceAccountName).toBe("tekton-security");
+  });
+
+  it("leaves a pre-hardening chart's literal 'tekton' untouched", () => {
+    const d = draft("tekton");
+
+    applyTaskRunServiceAccount(d, { pipeline: pipelineWithAnnotation("tekton-unprivileged") });
+
+    expect(d.spec.taskRunTemplate?.serviceAccountName).toBe("tekton");
+  });
+
+  it("drops an unresolvable placeholder instead of shipping it to the apiserver", () => {
+    const d = draft("$(tt.params.serviceAccount)");
+
+    applyTaskRunServiceAccount(d, {
+      pipeline: pipelineWithAnnotation(),
+      triggerTemplate: triggerTemplateWithDefault(),
+    });
+
+    expect(d.spec.taskRunTemplate).toBeUndefined();
+  });
+
+  it("keeps sibling taskRunTemplate keys when dropping an unresolvable placeholder", () => {
+    const d = {
+      spec: {
+        taskRunTemplate: { serviceAccountName: "$(tt.params.serviceAccount)", podTemplate: { nodeSelector: {} } },
+      },
+    };
+
+    applyTaskRunServiceAccount(d, {});
+
+    expect(d.spec.taskRunTemplate).toEqual({ podTemplate: { nodeSelector: {} } });
+  });
+
+  it("is a no-op when the draft has no taskRunTemplate", () => {
+    const d = draft();
+
+    expect(() => applyTaskRunServiceAccount(d, { pipeline: pipelineWithAnnotation("tekton") })).not.toThrow();
+    expect(d.spec).toEqual({});
+  });
+});

--- a/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/resolveTaskRunServiceAccount/index.ts
+++ b/packages/shared/src/models/k8s/groups/Tekton/PipelineRun/utils/resolveTaskRunServiceAccount/index.ts
@@ -1,0 +1,95 @@
+import { pipelineAnnotations } from "../../../Pipeline/annotations.js";
+import { Pipeline } from "../../../Pipeline/types.js";
+import { TriggerTemplate } from "../../../TriggerTemplate/types.js";
+
+/** Anchored: a composite "$(tt.params.a)-$(tt.params.b)" is two references, and
+ *  group 1 would capture a bogus param name. */
+export const WHOLE_TT_PARAM_RE = /^\$\(tt\.params\.([^)]+)\)$/;
+
+/** Structural rather than `PipelineRun`, so both it and `PipelineRunDraft` satisfy it. */
+type TaskRunServiceAccountHost = {
+  spec?: { taskRunTemplate?: { serviceAccountName?: string } };
+};
+
+const nonEmpty = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed === "" ? undefined : trimmed;
+};
+
+/**
+ * Precedence deliberately mirrors the krci Tekton interceptor: a run started
+ * from the portal must land on the same ServiceAccount a webhook would pick.
+ */
+export function resolveServiceAccountName({
+  pipeline,
+  triggerTemplate,
+  paramName,
+}: {
+  pipeline?: Pipeline;
+  triggerTemplate?: TriggerTemplate;
+  paramName?: string;
+}): string | undefined {
+  const fromAnnotation = nonEmpty(pipeline?.metadata?.annotations?.[pipelineAnnotations.serviceAccount]);
+
+  if (fromAnnotation) {
+    return fromAnnotation;
+  }
+
+  if (!paramName) {
+    return undefined;
+  }
+
+  return nonEmpty(triggerTemplate?.spec?.params?.find((param) => param.name === paramName)?.default);
+}
+
+/**
+ * Only placeholders are rewritten: a concrete value (`tekton-cd`, `tekton-security`,
+ * plain `tekton` pre-hardening) is the chart pinning the account, which the webhook
+ * flow would not override either. An unresolvable placeholder is deleted rather than
+ * left — sent as-is it becomes a ServiceAccount name and fails every TaskRun.
+ */
+export function applyTaskRunServiceAccount(
+  draft: TaskRunServiceAccountHost,
+  {
+    pipeline,
+    triggerTemplate,
+  }: {
+    pipeline?: Pipeline;
+    triggerTemplate?: TriggerTemplate;
+  }
+): void {
+  const spec = draft?.spec;
+  const taskRunTemplate = spec?.taskRunTemplate;
+
+  if (!spec || !taskRunTemplate) {
+    return;
+  }
+
+  const current = nonEmpty(taskRunTemplate.serviceAccountName);
+  const placeholder = current && WHOLE_TT_PARAM_RE.exec(current);
+
+  if (!placeholder) {
+    return;
+  }
+
+  const resolved = resolveServiceAccountName({ pipeline, triggerTemplate, paramName: placeholder[1] });
+
+  if (resolved) {
+    taskRunTemplate.serviceAccountName = resolved;
+
+    return;
+  }
+
+  delete taskRunTemplate.serviceAccountName;
+
+  // `taskRunTemplate: {}` would be visible noise in the "Build with params" editor
+  // and in `krci pipelinerun start --dry-run`.
+  if (Object.keys(taskRunTemplate).length === 0) {
+    delete spec.taskRunTemplate;
+  }
+}


### PR DESCRIPTION


The pipelines-library now renders build and review TriggerTemplates with taskRunTemplate.serviceAccountName: $(tt.params.serviceAccount). Tekton Triggers substitutes that param for webhook events, but the portal renders the same resourcetemplate itself, so the literal reached the apiserver and every TaskRun failed with `serviceaccounts "$(tt.params.serviceAccount)" not found`.

Resolve it the way the krci interceptor does: the Pipeline's app.edp.epam.com/service-account annotation, then the TriggerTemplate's declared param default. Only whole-value placeholders are rewritten, so charts that pin a concrete account (tekton-cd, tekton-security, or plain tekton before the hardening) keep it, and pre-hardening clusters are unaffected.

This covers every portal path that builds a run from a resourcetemplate: the branch Build and Security scan actions, "Run with params", and the tRPC start procedure behind `krci pipelinerun start` — where the placeholder previously degraded to an empty string and the run silently used Tekton's default account.

Branch actions now wait for the Pipeline lookup to settle before enabling; a missing Pipeline falls back to the TriggerTemplate default rather than blocking.

